### PR TITLE
[codex] update HCS provider documentation

### DIFF
--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -110,6 +110,8 @@ The `HCSMachineConfigPool` defines pre-configured hostnames and static IP addres
 The configuration pool must include at least as many entries as the number of control plane nodes you plan to deploy.
 :::
 
+Use `subnetName` in new manifests. The provider still accepts the deprecated `subenetName` field for existing manifests, but do not use both fields with different values.
+
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: HCSMachineConfigPool
@@ -134,9 +136,14 @@ spec:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `.spec.configs[].hostname` | string | Yes | VM hostname |
-| `.spec.configs[].networks[].subnetName` | string | Yes | Subnet name in HCS |
-| `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address |
+| `.spec.configs[]` | array | Yes | Non-empty list of machine configurations |
+| `.spec.configs[].hostname` | string | Yes | VM hostname. Use lowercase letters, numbers, hyphens (`-`), or dots (`.`); the value must start and end with a lowercase letter or number and must not exceed 253 characters |
+| `.spec.configs[].networks[]` | array | Yes | Non-empty list of network configurations for the VM |
+| `.spec.configs[].networks[].subnetName` | string | No* | Recommended subnet name field for new manifests |
+| `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
+| `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the VM |
+
+*Set either `subnetName` or `subnetId`. For new manifests, use `subnetName`.
 
 ### Configure Machine Template
 
@@ -199,6 +206,8 @@ spec:
 
 *Required when dataVolumes is specified.
 
+**Note:** Do not set runtime identity fields such as `providerID` or `serverId` in `HCSMachineTemplate` manifests. The provider assigns these values when it creates HCS instances.
+
 ### Configure KubeadmControlPlane
 
 The `KubeadmControlPlane` defines the Kubernetes control plane configuration.
@@ -213,6 +222,53 @@ spec:
   replicas: 3
   version: <kubernetes-version>
   kubeadmConfigSpec:
+    files:
+      - path: /etc/kubernetes/admission/psa-config.yaml
+        owner: root:root
+        permissions: "0644"
+        content: |
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: AdmissionConfiguration
+          plugins:
+          - name: PodSecurity
+            configuration:
+              apiVersion: pod-security.admission.config.k8s.io/v1
+              kind: PodSecurityConfiguration
+      - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+        owner: root:root
+        permissions: "0644"
+        content: |
+          {
+            "apiVersion": "kubelet.config.k8s.io/v1beta1",
+            "kind": "KubeletConfiguration",
+            "protectKernelDefaults": true,
+            "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
+            "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key",
+            "streamingConnectionIdleTimeout": "5m",
+            "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+          }
+      - path: /etc/kubernetes/encryption-provider.conf
+        owner: root:root
+        permissions: "0600"
+        content: |
+          apiVersion: apiserver.config.k8s.io/v1
+          kind: EncryptionConfiguration
+          resources:
+          - resources:
+            - secrets
+            providers:
+            - aescbc:
+                keys:
+                - name: key1
+                  secret: bootstrap-placeholder
+      - path: /etc/kubernetes/audit/policy.yaml
+        owner: root:root
+        permissions: "0644"
+        content: |
+          apiVersion: audit.k8s.io/v1
+          kind: Policy
+          rules:
+          - level: Metadata
     clusterConfiguration:
       imageRepository: <image-repository>
       dns:
@@ -220,12 +276,46 @@ spec:
       etcd:
         local:
           imageTag: <etcd-image-tag>
+      apiServer:
+        extraArgs:
+          audit-log-format: json
+          audit-log-mode: batch
+          audit-log-path: /etc/kubernetes/audit/audit.log
+          audit-policy-file: /etc/kubernetes/audit/policy.yaml
+          admission-control-config-file: /etc/kubernetes/admission/psa-config.yaml
+          encryption-provider-config: /etc/kubernetes/encryption-provider.conf
+          kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
+          profiling: "false"
+          tls-min-version: VersionTLS12
+        extraVolumes:
+          - name: vol-dir-0
+            hostPath: /etc/kubernetes
+            mountPath: /etc/kubernetes
+            pathType: Directory
+      controllerManager:
+        extraArgs:
+          bind-address: "::"
+          flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+          profiling: "false"
+          tls-min-version: VersionTLS12
+      scheduler:
+        extraArgs:
+          bind-address: "::"
+          profiling: "false"
+          tls-min-version: VersionTLS12
+    postKubeadmCommands:
+      - chmod 600 /var/lib/kubelet/config.yaml
     initConfiguration:
+      patches:
+        directory: /etc/kubernetes/patches
       nodeRegistration:
         kubeletExtraArgs:
           node-labels: "kube-ovn/role=master"
+          protect-kernel-defaults: "true"
           volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
     joinConfiguration:
+      patches:
+        directory: /etc/kubernetes/patches
       nodeRegistration:
         kubeletExtraArgs:
           node-labels: "kube-ovn/role=master"
@@ -238,6 +328,10 @@ spec:
       kind: HCSMachineTemplate
       name: <cluster-name>-control-plane
 ```
+
+The HCS controller also injects files while resolving cloud-init data. It writes `/etc/kubernetes/pki/kubelet.crt`, `/etc/kubernetes/pki/kubelet.key`, and `/etc/kubernetes/encryption-provider.conf` for control plane machines. For the first control plane machine, the controller generates the encryption provider configuration. After the control plane is initialized, it tries to reuse the existing `kube-apiserver` encryption provider configuration. If you include a bootstrap file at `/etc/kubernetes/encryption-provider.conf`, treat it as a placeholder because the controller-generated or synchronized file takes precedence.
+
+**Note:** Configure `apiServer.extraArgs` and `apiServer.extraVolumes` together. If the volume is not mounted, `kube-apiserver` cannot read the files written under `/etc/kubernetes`.
 
 For component versions (DNS image tag, etcd image tag), refer to the [OS Support Matrix](../overview/os-support-matrix.mdx).
 
@@ -287,7 +381,7 @@ spec:
 | `.spec.network.vpc.name` | string | Yes | VPC name |
 | `.spec.network.subnets[].name` | string | Yes | Subnet name list |
 | `.spec.network.securityGroup.name` | string | Yes | Security group name |
-| `.spec.identityRef.name` | string | Yes | Reference to credential Secret name |
+| `.spec.identityRef.name` | string | Yes | Non-empty credential Secret name referenced by `HCSCluster` |
 | `.spec.controlPlaneEndpoint.host` | string | No | API server host (VIP address or domain name) |
 | `.spec.controlPlaneEndpoint.port` | int | No | API server port (default: 6443) |
 | `.spec.controlPlaneLoadBalancer.vipAddress` | string | No* | Control plane VIP address |

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -234,6 +234,19 @@ spec:
             configuration:
               apiVersion: pod-security.admission.config.k8s.io/v1
               kind: PodSecurityConfiguration
+              defaults:
+                enforce: "privileged"
+                enforce-version: "latest"
+                audit: "baseline"
+                audit-version: "latest"
+                warn: "baseline"
+                warn-version: "latest"
+              exemptions:
+                usernames: []
+                runtimeClasses: []
+                namespaces:
+                - kube-system
+                - cpaas-system
       - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
         owner: root:root
         permissions: "0644"

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -112,7 +112,7 @@ The `HCSMachineConfigPool` defines pre-configured hostnames and static IP addres
 The configuration pool must include at least as many entries as the number of control plane nodes you plan to deploy.
 :::
 
-Use `subnetName` in new manifests. The provider still accepts the deprecated `subenetName` field for existing manifests, but do not use both fields with different values.
+Use one subnet selector per `networks[]` entry. For new manifests, set either `subnetName` or `subnetId`, but not both. Existing manifests may keep the deprecated `subenetName` field; if you also add `subnetName` while updating that manifest, its value must exactly match `subenetName`. Do not supply conflicting values across `subenetName`, `subnetName`, and `subnetId`.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -145,7 +145,9 @@ spec:
 | `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
 | `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the VM |
 
-*Set either `subnetName` or `subnetId`. For new manifests, use `subnetName`.
+*For new manifests, set either `subnetName` or `subnetId`. Existing manifests may continue to use `subenetName`, and may add `subnetName` only if both fields use the same value. Do not provide conflicting subnet selector values.
+
+**Note:** The CRD schema lists `subnetName`, `subenetName`, and `subnetId` as optional fields and does not express their allowed combinations. Follow the provider-level rules above when writing manifests.
 
 ### Configure Machine Template
 

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -81,7 +81,7 @@ HCS authentication information is stored in a Secret resource.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <cluster-name>
+  name: <credential-secret-name>
   namespace: cpaas-system
 type: Opaque
 data:
@@ -99,6 +99,8 @@ data:
 | `.data.projectID` | HCS project ID (base64-encoded) |
 | `.data.region` | HCS region such as `cn-global-1` (base64-encoded) |
 | `.data.externalGlobalDomain` | HCS domain name (base64-encoded) |
+
+You can reuse an existing HCS credential Secret. Its name does not need to match the cluster name, but `HCSCluster.spec.identityRef.name` must reference this Secret.
 
 ### Configure Machine Configuration Pool
 
@@ -156,6 +158,7 @@ The following data disk mount points are recommended for control plane nodes:
 - `/var/lib/etcd` - etcd data (10GB+)
 - `/var/lib/kubelet` - kubelet data (100GB+)
 - `/var/lib/containerd` - container runtime data (100GB+)
+- `/var/cpaas` - platform data and logs (40GB+)
 :::
 
 ```yaml
@@ -187,6 +190,10 @@ spec:
         - size: 100
           type: SSD
           mountPath: /var/lib/containerd
+          format: xfs
+        - size: 40
+          type: SSD
+          mountPath: /var/cpaas
           format: xfs
 ```
 
@@ -221,6 +228,10 @@ metadata:
 spec:
   replicas: 3
   version: <kubernetes-version>
+  rolloutStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
   kubeadmConfigSpec:
     files:
       - path: /etc/kubernetes/admission/psa-config.yaml
@@ -346,11 +357,19 @@ The HCS controller also injects files while resolving cloud-init data. It writes
 
 **Note:** Configure `apiServer.extraArgs` and `apiServer.extraVolumes` together. If the volume is not mounted, `kube-apiserver` cannot read the files written under `/etc/kubernetes`.
 
+**Note:** For HCS control planes that use a fixed-size static IP pool, keep `rolloutStrategy.rollingUpdate.maxSurge: 0` so replacements happen in a scale-down-then-scale-up order. This default upgrade path usually does not require additional control plane IPs. If you plan to increase control plane replicas or set `maxSurge` greater than `0`, first extend the referenced `HCSMachineConfigPool` with additional hostname and static IP entries.
+
 For component versions (DNS image tag, etcd image tag), refer to the [OS Support Matrix](../overview/os-support-matrix.mdx).
 
 ### Configure HCSCluster
 
 The `HCSCluster` resource defines the HCS infrastructure configuration.
+
+The HCS provider creates an ELB on the HCS platform for the Kubernetes API server. This ELB must use mixed load balancing so cluster nodes can also reach the API server through the ELB address.
+
+If you want all ELB-related addresses to be fixed, provide `vipAddress`, `elbVirsubnetL4Ips`, and `elbVirsubnetL7Ips`. Each `elbVirsubnetL4Ips[].ips` and `elbVirsubnetL7Ips[].ips` entry must contain two IPs. If you omit the L4 or L7 virtual subnet IPs, HCS allocates them randomly.
+
+If you set `vipDomainName`, maintain DNS so that the domain resolves to `vipAddress`.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -360,19 +379,19 @@ metadata:
   namespace: cpaas-system
 spec:
   controlPlaneLoadBalancer:
-    vipAddress: <vip-address>
-    vipSubnetName: <elb-subnet-name>
-    vipDomainName: <vip-domain-name>
+    vipAddress: <control-plane-vip-address>
+    vipSubnetName: <vip-subnet-name>
+    vipDomainName: <control-plane-vip-domain-name>
     elbVirsubnetL4Ips:
       - subnetName: <subnet-name>
         ips:
-          - 192.168.15.101
-          - 192.168.15.102
+          - <l4-ip-1>
+          - <l4-ip-2>
     elbVirsubnetL7Ips:
       - subnetName: <subnet-name>
         ips:
-          - 192.168.15.103
-          - 192.168.15.104
+          - <l7-ip-1>
+          - <l7-ip-2>
   networkType: kube-ovn
   network:
     vpc:
@@ -382,10 +401,7 @@ spec:
     securityGroup:
       name: <security-group-name>
   identityRef:
-    name: <cluster-name>
-  controlPlaneEndpoint:
-    host: <vip-address>
-    port: 6443
+    name: <credential-secret-name>
 ```
 
 | Parameter | Type | Required | Description |
@@ -394,16 +410,21 @@ spec:
 | `.spec.network.vpc.name` | string | Yes | VPC name |
 | `.spec.network.subnets[].name` | string | Yes | Subnet name list |
 | `.spec.network.securityGroup.name` | string | Yes | Security group name |
-| `.spec.identityRef.name` | string | Yes | Non-empty credential Secret name referenced by `HCSCluster` |
-| `.spec.controlPlaneEndpoint.host` | string | No | API server host (VIP address or domain name) |
-| `.spec.controlPlaneEndpoint.port` | int | No | API server port (default: 6443) |
-| `.spec.controlPlaneLoadBalancer.vipAddress` | string | No* | Control plane VIP address |
-| `.spec.controlPlaneLoadBalancer.vipSubnetName` | string | No* | ELB subnet name |
-| `.spec.controlPlaneLoadBalancer.vipDomainName` | string | No | VIP domain name with DNS configured |
-| `.spec.controlPlaneLoadBalancer.elbVirsubnetL4Ips` | array | No | L4 load balancer IP configuration |
-| `.spec.controlPlaneLoadBalancer.elbVirsubnetL7Ips` | array | No | L7 load balancer IP configuration |
+| `.spec.identityRef.name` | string | Yes | Non-empty credential Secret name referenced by `HCSCluster`; this value does not need to match the cluster name |
+| `.spec.controlPlaneLoadBalancer` | object | Yes | ELB settings for exposing the control plane API server |
+| `.spec.controlPlaneLoadBalancer.vipAddress` | string | Yes | Fixed VIP for the control plane ELB |
+| `.spec.controlPlaneLoadBalancer.vipSubnetName` | string | Yes | Subnet name that contains the ELB VIP |
+| `.spec.controlPlaneLoadBalancer.vipDomainName` | string | No | Domain name for the VIP; you must maintain DNS so it resolves to `vipAddress` |
+| `.spec.controlPlaneLoadBalancer.elbVirsubnetL4Ips[]` | array | No* | L4 virtual subnet IP groups used by mixed load balancing |
+| `.spec.controlPlaneLoadBalancer.elbVirsubnetL4Ips[].subnetName` | string | Yes* | Subnet name for the L4 virtual subnet IPs |
+| `.spec.controlPlaneLoadBalancer.elbVirsubnetL4Ips[].ips[]` | string | Yes* | Two fixed L4 virtual subnet IPs |
+| `.spec.controlPlaneLoadBalancer.elbVirsubnetL7Ips[]` | array | No* | L7 virtual subnet IP groups used by mixed load balancing |
+| `.spec.controlPlaneLoadBalancer.elbVirsubnetL7Ips[].subnetName` | string | Yes* | Subnet name for the L7 virtual subnet IPs |
+| `.spec.controlPlaneLoadBalancer.elbVirsubnetL7Ips[].ips[]` | string | Yes* | Two fixed L7 virtual subnet IPs |
 
-*Required when configuring VIP address.
+*Required when you want to fix all ELB-related addresses. If you omit the L4 or L7 virtual subnet IPs, HCS allocates them randomly.
+
+Do not include `spec.controlPlaneEndpoint` in the create manifest. In the HCS create flow, the controller derives and populates this field from `spec.controlPlaneLoadBalancer` after the `HCSCluster` is created. Do not set `controlPlaneEndpoint` manually, and do not add an empty `controlPlaneEndpoint` object. If `controlPlaneEndpoint` is explicitly present in the manifest, it must include both `host` and `port`.
 
 ### Configure Cluster
 

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -83,7 +83,7 @@ spec:
 
 The `HCSMachineTemplate` defines the VM specifications for worker nodes.
 
-Configure worker nodes with a system volume and data volumes for `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas`. You may add more data volumes, but preserve these paths so node bootstrap and platform components can use stable storage.
+Configure worker nodes with a system volume and data volumes for `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas`. You may add more data volumes, but preserve these paths so node bootstrap and platform components can use the expected runtime directories. These paths do not imply that data volumes will be preserved when nodes are replaced.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -313,6 +313,8 @@ Scaling down removes nodes and their associated disks. Ensure:
 ### Upgrading Machine Infrastructure
 
 To upgrade worker machine specifications (CPU, memory, disk, VM image), follow these steps:
+
+**Note:** Worker infrastructure upgrades rely on Cluster API rolling replacement. The current HCS provider does not preserve or reattach data disks during node replacement. When a worker node is replaced, the old VM and its attached volumes may be deleted together. Move stateful data to external persistent storage, or complete backup and migration before starting the upgrade.
 
 1. **Create New Machine Template**
 

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -21,13 +21,7 @@ This document explains how to manage worker nodes using Cluster API `Machine` re
 - Ensure you have proper access to the HCS platform and required permissions.
 :::
 
-:::info
-**Configuration Guidelines**
-When working with the configurations in this document:
-- Only modify values enclosed in `<>` brackets
-- Replace placeholder values with your environment-specific settings
-- Preserve all other default configurations unless explicitly required
-:::
+When using the YAML examples in this document, replace only values enclosed in `<>` with environment-specific values. Preserve the remaining fields unless your cluster policy requires a different value.
 
 ## Overview
 
@@ -49,6 +43,8 @@ The `HCSMachineConfigPool` defines the network configuration for worker node VMs
 
 The pool must include at least as many entries as the number of worker nodes you plan to deploy. Insufficient entries will prevent node deployment.
 :::
+
+Use `subnetName` in new manifests. The provider still accepts the deprecated `subenetName` field for existing manifests, but do not use both fields with different values.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -74,25 +70,20 @@ spec:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `.spec.configs[].hostname` | string | Yes | VM hostname |
-| `.spec.configs[].networks[].subnetName` | string | Yes | Subnet name in HCS |
-| `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address |
+| `.spec.configs[]` | array | Yes | Non-empty list of worker node configurations |
+| `.spec.configs[].hostname` | string | Yes | VM hostname. Use lowercase letters, numbers, hyphens (`-`), or dots (`.`); the value must start and end with a lowercase letter or number and must not exceed 253 characters |
+| `.spec.configs[].networks[]` | array | Yes | Non-empty list of network configurations for the VM |
+| `.spec.configs[].networks[].subnetName` | string | No* | Recommended subnet name field for new manifests |
+| `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
+| `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the worker VM |
+
+*Set either `subnetName` or `subnetId`. For new manifests, use `subnetName`.
 
 ### Step 2: Configure Machine Template
 
 The `HCSMachineTemplate` defines the VM specifications for worker nodes.
 
-:::warning
-**Required Disk Configurations**
-
-The following disk mount points are recommended for worker nodes:
-- System volume (`systemVolume: true`)
-- `/var/lib/kubelet` - Kubelet data directory
-- `/var/lib/containerd` - Container runtime data
-- `/var/cpaas` - Platform-specific data
-
-You may add additional disks, but these essential configurations must be preserved.
-:::
+Configure worker nodes with a system volume and data volumes for `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas`. You may add more data volumes, but preserve these paths so node bootstrap and platform components can use stable storage.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -112,15 +103,15 @@ spec:
       configPoolRef:
         name: <worker-pool-name>
       dataVolumes:
-        - size: 100
+        - size: 20
           type: SSD
           mountPath: /var/lib/kubelet
           format: xfs
-        - size: 100
+        - size: 20
           type: SSD
           mountPath: /var/lib/containerd
           format: xfs
-        - size: 100
+        - size: 10
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -142,6 +133,8 @@ spec:
 
 *Required when dataVolumes is specified.
 
+**Note:** Do not set runtime identity fields such as `providerID` or `serverId` in `HCSMachineTemplate` manifests. The provider assigns these values when it creates HCS instances.
+
 ### Step 3: Configure Bootstrap Template
 
 The `KubeadmConfigTemplate` defines the bootstrap configuration for worker nodes.
@@ -155,11 +148,32 @@ metadata:
 spec:
   template:
     spec:
+      files:
+        - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+          owner: root:root
+          permissions: "0644"
+          content: |
+            {
+              "apiVersion": "kubelet.config.k8s.io/v1beta1",
+              "kind": "KubeletConfiguration",
+              "protectKernelDefaults": true,
+              "staticPodPath": null,
+              "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
+              "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key",
+              "streamingConnectionIdleTimeout": "5m",
+              "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+            }
+      postKubeadmCommands:
+        - chmod 600 /var/lib/kubelet/config.yaml
       joinConfiguration:
+        patches:
+          directory: /etc/kubernetes/patches
         nodeRegistration:
           kubeletExtraArgs:
             volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
 ```
+
+The HCS controller injects `/etc/kubernetes/pki/kubelet.crt` and `/etc/kubernetes/pki/kubelet.key` while resolving worker cloud-init data. The kubelet patch above configures kubelet to use those controller-provided certificate files.
 
 ### Step 4: Configure Machine Deployment
 
@@ -314,6 +328,7 @@ To upgrade worker machine specifications (CPU, memory, disk, VM image), follow t
 
    Then edit `new-template.yaml` before applying:
    - Change `metadata.name` to `<new-template>`
+   - Leave runtime identity fields unset, including `spec.template.spec.providerID` and `spec.template.spec.serverId`
    - Remove server-generated fields such as:
      - `metadata.resourceVersion`
      - `metadata.uid`
@@ -346,11 +361,7 @@ To upgrade worker machine specifications (CPU, memory, disk, VM image), follow t
 
 Kubernetes version upgrades require coordinated updates to both the `MachineDeployment` and the underlying VM template.
 
-:::warning
-**Version Compatibility**
-
-Ensure the VM template's Kubernetes version matches the version specified in the `MachineDeployment`. Mismatched versions will cause node join failures.
-:::
+**Note:** Ensure the VM template's Kubernetes version matches the version specified in the `MachineDeployment`. Mismatched versions will cause node join failures.
 
 **Procedure**:
 

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -44,7 +44,7 @@ The `HCSMachineConfigPool` defines the network configuration for worker node VMs
 The pool must include at least as many entries as the number of worker nodes you plan to deploy. Insufficient entries will prevent node deployment.
 :::
 
-Use `subnetName` in new manifests. The provider still accepts the deprecated `subenetName` field for existing manifests, but do not use both fields with different values.
+Use one subnet selector per `networks[]` entry. For new manifests, set either `subnetName` or `subnetId`, but not both. Existing manifests may keep the deprecated `subenetName` field; if you also add `subnetName` while updating that manifest, its value must exactly match `subenetName`. Do not supply conflicting values across `subenetName`, `subnetName`, and `subnetId`.
 
 ```yaml
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -77,7 +77,9 @@ spec:
 | `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
 | `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the worker VM |
 
-*Set either `subnetName` or `subnetId`. For new manifests, use `subnetName`.
+*For new manifests, set either `subnetName` or `subnetId`. Existing manifests may continue to use `subenetName`, and may add `subnetName` only if both fields use the same value. Do not provide conflicting subnet selector values.
+
+**Note:** The CRD schema lists `subnetName`, `subenetName`, and `subnetId` as optional fields and does not express their allowed combinations. Follow the provider-level rules above when writing manifests.
 
 ### Step 2: Configure Machine Template
 

--- a/docs/en/overview/providers/huawei-cloud-stack.mdx
+++ b/docs/en/overview/providers/huawei-cloud-stack.mdx
@@ -26,7 +26,7 @@ Huawei Cloud Stack is a hybrid cloud solution that extends public cloud capabili
 - **Static IP Configuration**: Static IP address allocation for enterprise network environments
 - **Machine Configuration Pools**: Pre-defined hostnames and IP address pools for predictable VM provisioning
 - **Control Plane Security Bootstrap**: Supports kube-apiserver audit, admission, encryption provider, and kubelet certificate configuration through kubeadm bootstrap data
-- **Multi-AZ Support**: Deployment across multiple availability zones for high availability
+- **Availability Zone Selection**: Supports specifying the target availability zone for HCS machines
 
 ## Supported Resources
 

--- a/docs/en/overview/providers/huawei-cloud-stack.mdx
+++ b/docs/en/overview/providers/huawei-cloud-stack.mdx
@@ -25,6 +25,7 @@ Huawei Cloud Stack is a hybrid cloud solution that extends public cloud capabili
 - **ELB Load Balancer**: Built-in elastic load balancer support for control plane high availability
 - **Static IP Configuration**: Static IP address allocation for enterprise network environments
 - **Machine Configuration Pools**: Pre-defined hostnames and IP address pools for predictable VM provisioning
+- **Control Plane Security Bootstrap**: Supports kube-apiserver audit, admission, encryption provider, and kubelet certificate configuration through kubeadm bootstrap data
 - **Multi-AZ Support**: Deployment across multiple availability zones for high availability
 
 ## Supported Resources

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -36,7 +36,7 @@ For initial deployment, see the [Create Cluster](../create-cluster/huawei-cloud-
 :::warning
 **Data Loss During Upgrades**
 
-Upgrades rely on Cluster API's rolling update mechanism. During a rolling update on HCS, data disks are detached from old VMs and reattached to new VMs. Ensure that no cluster functionality or workloads depend on data stored on the system disk.
+Upgrades rely on Cluster API's rolling replacement mechanism. The current HCS provider does not preserve or reattach data disks during node replacement. When a node is replaced, the old VM and its attached volumes may be deleted together. Do not treat node-local data on HCS data disks as preserved state. Move stateful data to external persistent storage, or complete backup and migration before starting the upgrade.
 :::
 
 ## Control Plane Upgrades

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -61,6 +61,8 @@ Upgrading the underlying machine images for control plane nodes provides securit
 
    Modify the new template:
    - Set `metadata.name` to `<new-template-name>`
+   - Remove server-generated metadata and status fields from the copied manifest.
+   - Leave runtime identity fields unset, including `spec.template.spec.providerID` and `spec.template.spec.serverId`. The HCS provider assigns these values when it creates instances.
    - Update as needed:
      - `spec.template.spec.imageName`
      - `spec.template.spec.flavorName`

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -43,6 +43,8 @@ Upgrades rely on Cluster API's rolling replacement mechanism. The current HCS pr
 
 Control plane upgrades update the Kubernetes API server, etcd, scheduler, and controller manager, along with the underlying VM infrastructure.
 
+For HCS control planes backed by a fixed-size `HCSMachineConfigPool`, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` during upgrades. This default scale-down-then-scale-up path usually does not require additional control plane IPs. Only prepare extra hostname and static IP entries in the control plane pool if you plan to increase control plane replicas or intentionally set `maxSurge` greater than `0`.
+
 ### Infrastructure Image Updates
 
 Upgrading the underlying machine images for control plane nodes provides security patches, performance improvements, and updated system components.
@@ -112,7 +114,7 @@ Upgrading the Kubernetes version involves updating both the control plane softwa
 
 2. **Update Control Plane Version**
 
-   Modify the `spec.version` field in the `KubeadmControlPlane` resource (required). Optionally adjust related fields as needed (for example, rollout strategy, drain/deletion timeouts, or the referenced infrastructure template) to align with the new version and upgrade policy
+   Modify the `spec.version` field in the `KubeadmControlPlane` resource (required). Keep `spec.rolloutStrategy.rollingUpdate.maxSurge: 0` for the default static IP control plane path. Only adjust rollout settings beyond this after you extend the control plane `HCSMachineConfigPool` with extra hostname and IP slots.
 
 3. **Verify Upgrade Progress**
 

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsclusters.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsclusters.yaml
@@ -165,16 +165,12 @@ spec:
                   the cluster.
                 properties:
                   name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    description: Name is the name of the identity secret to use.
+                    minLength: 1
                     type: string
+                required:
+                - name
                 type: object
-                x-kubernetes-map-type: atomic
               network:
                 description: Network is the network configuration of the cluster.
                 properties:

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachineconfigpools.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachineconfigpools.yaml
@@ -69,6 +69,8 @@ spec:
                   properties:
                     hostname:
                       description: Hostname is the hostname to assign to the machine.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-.a-z0-9]*[a-z0-9])?$
                       type: string
                     networks:
                       description: Networks is the list of network configurations
@@ -81,15 +83,27 @@ spec:
                             description: IpAddress is the static IP address to assign
                               to the machine.
                             type: string
-                          subnetName:
-                            description: SubnetName is the name of the subnet to use.
+                          subenetName:
+                            description: |-
+                              SubenetName is the deprecated legacy key kept for backward compatibility.
+                              Use subnetName instead.
                             type: string
                           subnetId:
                             description: SubnetId is the ID of the subnet to use.
                             type: string
+                          subnetName:
+                            description: SubnetName is the name of the subnet to use.
+                            type: string
+                        required:
+                        - ipAddress
                         type: object
+                      minItems: 1
                       type: array
+                  required:
+                  - hostname
+                  - networks
                   type: object
+                minItems: 1
                 type: array
             type: object
           status:


### PR DESCRIPTION
## What changed
- synced the HCS shared CRD reference docs with the `fix/subnetname-compatibility` provider branch for `HCSCluster` and `HCSMachineConfigPool`
- updated the HCS create-cluster and manage-nodes guides so the YAML examples reflect the current provider behavior for config pool validation, subnet field usage, worker bootstrap, and control plane bootstrap security settings
- clarified upgrade guidance so copied machine templates do not carry runtime identity fields such as `providerID` and `serverId`
- fixed the control plane PSA example so `/etc/kubernetes/admission/psa-config.yaml` is a complete `PodSecurityConfiguration`

## Why
The product docs were lagging behind the provider behavior in `fix/subnetname-compatibility`, especially around `HCSMachineConfigPool` validation and the control plane bootstrap configuration. The PSA example was also incomplete, which made the published YAML unsafe to copy directly.

## Impact
Users and AI coding agents can rely on the HCS docs to generate cluster and worker manifests that match the intended provider behavior. The API reference now exposes the current CRD constraints for the affected HCS resources.

## Root cause
The docs and shared CRD assets had not been fully synchronized with the provider branch that introduced subnet field compatibility, stricter validation, and additional bootstrap security configuration.

## Validation
- compared the updated docs and shared CRDs against `/Users/changjia/alauda/cluster-api-provider-hcs` on `origin/fix/subnetname-compatibility`
- performed document-level review of the HCS create/manage/upgrade content and YAML examples
- did not run Kubernetes runtime validation in this environment
- did not run `yarn build`; the user will validate with `yarn dev`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified credential usage: supply the credential Secret name in identityRef; controlPlaneEndpoint must not be included in create manifests.
  * Expanded networking guidance: subnetName vs subnetId selection rules; deprecated misspelled subnet key documented; hostname format/length and network requirements clarified.
  * Control plane examples: load balancer/vip guidance and rolloutStrategy (maxSurge: 0) documented; bootstrap files, kubelet patches, and recommended /var/cpaas data volume noted.
  * Upgrade/disk guidance: data disks are not preserved/reattached during replacements; leave runtime identity fields unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->