### PR TITLE
docs: add wipeFilesystem and raw disk support for persistent disks

### DIFF
--- a/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
@@ -546,6 +546,7 @@ spec:
       sizeGiB: <cp_var_lib_etcd_size_gib>
       mountPath: /var/lib/etcd
       fsFormat: ext4
+      wipeFilesystem: true
   - hostname: "<cp_node_name_2>"
     datacenter: "<master_02_datacenter>"
     network:
@@ -568,6 +569,7 @@ spec:
       sizeGiB: <cp_var_lib_etcd_size_gib>
       mountPath: /var/lib/etcd
       fsFormat: ext4
+      wipeFilesystem: true
   - hostname: "<cp_node_name_3>"
     datacenter: "<master_03_datacenter>"
     network:
@@ -590,6 +592,7 @@ spec:
       sizeGiB: <cp_var_lib_etcd_size_gib>
       mountPath: /var/lib/etcd
       fsFormat: ext4
+      wipeFilesystem: true
 ```
 
 Create the worker static allocation pool.
@@ -727,7 +730,9 @@ spec:
           "apiVersion": "kubelet.config.k8s.io/v1beta1",
           "kind": "KubeletConfiguration",
           "protectKernelDefaults": true,
-          "streamingConnectionIdleTimeout": "5m"
+          "streamingConnectionIdleTimeout": "5m",
+          "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
+          "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key"
         }
     # Generate the encryption key with: head -c 32 /dev/urandom | base64
     - path: /etc/kubernetes/encryption-provider.conf
@@ -917,6 +922,7 @@ spec:
         kubeletExtraArgs:
           cloud-provider: external
           node-labels: kube-ovn/role=master
+          volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
         name: '{{ local_hostname }}'
       patches:
         directory: /etc/kubernetes/patches
@@ -967,12 +973,29 @@ metadata:
 spec:
   template:
     spec:
+      files:
+      - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+        owner: "root:root"
+        permissions: "0644"
+        content: |
+          {
+            "apiVersion": "kubelet.config.k8s.io/v1beta1",
+            "kind": "KubeletConfiguration",
+            "protectKernelDefaults": true,
+            "staticPodPath": null,
+            "streamingConnectionIdleTimeout": "5m",
+            "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
+            "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key"
+          }
       joinConfiguration:
         nodeRegistration:
           criSocket: /var/run/containerd/containerd.sock
           kubeletExtraArgs:
             cloud-provider: external
+            volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
           name: '{{ local_hostname }}'
+        patches:
+          directory: /etc/kubernetes/patches
       preKubeadmCommands:
       - hostnamectl set-hostname "{{ ds.meta_data.hostname }}"
       - echo "::1         ipv6-localhost ipv6-loopback localhost6 localhost6.localdomain6" >/etc/hosts

--- a/docs/en/create-cluster/vmware-vsphere/extension-scenarios.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/extension-scenarios.mdx
@@ -281,10 +281,13 @@ Before you enable multiple datacenters, also confirm the following prerequisites
 
 The baseline deployment includes the following required data disks:
 
-- **Control plane nodes**: `var-cpaas`, `var-lib-containerd`, and `var-lib-etcd` (3 disks per node). Do not remove any of these disks.
+- **Control plane nodes**: `var-cpaas`, `var-lib-containerd`, and `var-lib-etcd` (3 disks per node). Do not remove any of these disks. The `var-lib-etcd` disk must set `wipeFilesystem: true` to allow `kubeadm join` during rolling updates.
 - **Worker nodes**: `var-cpaas` and `var-lib-containerd` (2 disks per node). Do not remove any of these disks.
 
-If a node needs additional data disks beyond the required set, append more entries to the same `persistentDisks` list in the corresponding `VSphereResourcePool` node slot.
+If a node needs additional data disks beyond the required set, append more entries to the same `persistentDisks` list in the corresponding `VSphereResourcePool` node slot. The following optional fields are especially relevant here:
+
+- **`mountPath`**: If set, the disk is formatted and mounted at the specified path. If omitted, the disk is attached as a raw device with a symlink at `/dev/disk/by-capv/<name>`, allowing an external process to manage it at runtime.
+- **`wipeFilesystem`**: When `true`, disk content is wiped on the first boot of a new VM. Normal reboots and manual service restarts are not affected. Defaults to `false`.
 
 ## Scale out worker nodes
 
@@ -322,6 +325,17 @@ The following example adds a new worker slot:
     mountPath: /var/lib/containerd
     fsFormat: ext4
 ```
+
+To attach a raw disk without formatting or mounting (for example, when an application manages the disk itself), omit `mountPath` and `fsFormat`:
+
+```yaml
+  persistentDisks:
+  # ...required disks...
+  - name: app-data
+    sizeGiB: 50
+```
+
+The disk is accessible inside the guest OS at `/dev/disk/by-capv/app-data`. On rolling updates, the same VMDK is re-attached to the new VM and the symlink is recreated. The disk is never formatted or mounted automatically — the application is responsible for managing it at runtime.
 
 Then update the worker replicas:
 

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -233,22 +233,33 @@ The template should also meet the following requirements:
 
 ### Standard data disks
 
-Each node role requires a set of dedicated data disks. The disks listed below are the minimum required set. You can append additional disks to the `persistentDisks` list if your workload requires them. Only the size of the required disks is configurable; the name, mount path, and file system format are fixed.
+Each node role requires a set of dedicated data disks. The disks listed below are the minimum required disks. You can append additional disks to the `persistentDisks` list if your workload requires them.
+
+#### Persistent disk fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `name` | Yes | — | Unique disk name within the slot. |
+| `sizeGiB` | Yes | — | Disk size in GiB. |
+| `mountPath` | No | (empty) | Mount path inside the guest OS. If empty, the disk is attached as a raw device with a symlink at `/dev/disk/by-capv/<name>` but is not formatted or mounted. This is useful when an external process manages the disk at runtime. |
+| `fsFormat` | No | `ext4` (when `mountPath` is set) | Filesystem format. Ignored when `mountPath` is empty. |
+| `wipeFilesystem` | No | `false` | When `true`, disk content is wiped on the first boot of a new VM. Reboots and manual service restarts are not affected. Use for etcd disks to prevent stale data from blocking `kubeadm join` during rolling updates. |
+| `datastore` | No | (pool default) | Override the datastore for this disk. |
 
 #### Control plane nodes (3 disks per node)
 
-| Disk Name | Mount Path | Purpose | Recommended Minimum Size | Placeholder |
-|-----------|------------|---------|--------------------------|-------------|
-| `var-cpaas` | `/var/cpaas` | Stores logs, audit data, and other platform data | 100 GiB | `<cp_var_cpaas_size_gib>` |
-| `var-lib-containerd` | `/var/lib/containerd` | Stores containerd runtime data (images, layers, snapshots) | 100 GiB | `<cp_var_lib_containerd_size_gib>` |
-| `var-lib-etcd` | `/var/lib/etcd` | Stores etcd data | 100 GiB | `<cp_var_lib_etcd_size_gib>` |
+| Disk Name | Mount Path | `wipeFilesystem` | Purpose | Recommended Minimum Size | Placeholder |
+|-----------|------------|-------------------|---------|--------------------------|-------------|
+| `var-cpaas` | `/var/cpaas` | `false` | Stores logs, audit data, and other platform data | 100 GiB | `<cp_var_cpaas_size_gib>` |
+| `var-lib-containerd` | `/var/lib/containerd` | `false` | Stores containerd runtime data (images, layers, snapshots) | 100 GiB | `<cp_var_lib_containerd_size_gib>` |
+| `var-lib-etcd` | `/var/lib/etcd` | **`true`** | Stores etcd data. Must set `wipeFilesystem: true` to allow `kubeadm join` during rolling updates. | 100 GiB | `<cp_var_lib_etcd_size_gib>` |
 
 #### Worker nodes (2 disks per node)
 
-| Disk Name | Mount Path | Purpose | Recommended Minimum Size | Placeholder |
-|-----------|------------|---------|--------------------------|-------------|
-| `var-cpaas` | `/var/cpaas` | Stores logs, audit data, and other platform data | 100 GiB | `<worker_var_cpaas_size_gib>` |
-| `var-lib-containerd` | `/var/lib/containerd` | Stores containerd runtime data (images, layers, snapshots) | 100 GiB | `<worker_var_lib_containerd_size_gib>` |
+| Disk Name | Mount Path | `wipeFilesystem` | Purpose | Recommended Minimum Size | Placeholder |
+|-----------|------------|-------------------|---------|--------------------------|-------------|
+| `var-cpaas` | `/var/cpaas` | `false` | Stores logs, audit data, and other platform data | 100 GiB | `<worker_var_cpaas_size_gib>` |
+| `var-lib-containerd` | `/var/lib/containerd` | `false` | Stores containerd runtime data (images, layers, snapshots) | 100 GiB | `<worker_var_lib_containerd_size_gib>` |
 
 #### Size parameters
 


### PR DESCRIPTION
- parameter-checklist: add persistent disk fields table with wipeFilesystem, mountPath, fsFormat descriptions; add wipeFilesystem column to CP/Worker disk tables
- create-cluster-in-global: add wipeFilesystem: true to etcd disk examples for all CP nodes
- extension-scenarios: document wipeFilesystem and empty mountPath behavior; add raw disk example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded vSphere persistent disk guidance and examples; added mountPath, fsFormat, wipeFilesystem, datastore fields and raw-disk attachment behavior
  * Clarified etcd disk must set wipeFilesystem: true for rolling updates and successful kubeadm join
  * Documented kubelet/kubeadm bootstrap changes: added tlsCertFile and tlsPrivateKeyFile, added volume-plugin-dir for control-plane and workers, and described worker-side kubelet patching via files and patches directory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->