### PR TITLE
[codex] document x86-64-v2 baseline for MicroOS

### DIFF
--- a/docs/en/create-cluster/index.mdx
+++ b/docs/en/create-cluster/index.mdx
@@ -20,6 +20,7 @@ This section provides instructions for creating Kubernetes clusters on different
 Before creating a cluster, configure the required infrastructure resources:
 
 - **[Infrastructure Resources](../infrastructure/)** - Configure cloud credentials, IP pools, and machine templates
+- **CPU Baseline** - For x86_64 cluster nodes that use ACP-provided MicroOS images, the underlying CPUs must support the `x86-64-v2` ISA baseline. For details, see [OS Support Matrix](../overview/os-support-matrix.mdx).
 
 ## Platform-Specific Instructions
 

--- a/docs/en/overview/os-support-matrix.mdx
+++ b/docs/en/overview/os-support-matrix.mdx
@@ -7,6 +7,12 @@ title: OS Support Matrix
 
 This document lists the versions of Kubernetes components included in different MicroOS images.
 
+## CPU Baseline
+
+ACP-provided MicroOS images on x86_64 require CPUs that meet the `x86-64-v2` ISA baseline. x86_64 hardware that does not support `x86-64-v2` is outside the supported baseline for these images.
+
+This requirement applies when you create or upgrade cluster nodes with ACP-provided MicroOS images.
+
 ## Version Mapping
 
 | ACP Version | MicroOS Image Version | Kubernetes Version | coredns | etcd | pause |


### PR DESCRIPTION
## Summary
- document x86-64-v2 as the CPU baseline for ACP-provided MicroOS images on x86_64
- mark x86_64 hardware without x86-64-v2 support as outside the supported MicroOS baseline
- add a cluster creation entry-point reminder that links back to the OS Support Matrix

## Why
This repository documents ACP-provided immutable OS / MicroOS scenarios. Unlike user-provided OS documentation, this is a platform image baseline that ACP owns, so it can be stated as a hard requirement in the same way OpenShift/RHCOS documents its OS baseline.

Users should not need to determine which individual feature requires which CPU instruction set when they are using ACP-provided MicroOS images. The image baseline itself defines the supported hardware floor.

## Why not duplicate this per provider
The x86-64-v2 requirement is a MicroOS image baseline, not a Huawei DCS, Huawei Cloud Stack, VMware vSphere, or bare-metal provider feature. Keeping the authoritative requirement in the OS Support Matrix and linking to it from the cluster creation entry point avoids duplicated provider-specific wording that could drift over time.

## Validation
- `git diff --check`
- `yarn lint`
