### PR TITLE
docs: flesh out vSphere provider overview, API reference, and CRDs

### DIFF
--- a/docs/en/apis/providers/vmware-vsphere/index.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/index.mdx
@@ -1,19 +1,31 @@
 ---
 weight: 30
+title: vSphere Provider APIs
+author: dev@alauda.io
+category: api
+queries:
+  - vsphere api reference
+  - vmware vsphere crd
+  - vspherecluster api
 ---
 
 # VMware vSphere Provider APIs
 
 <Overview />
 
-## Status
+The VMware vSphere Infrastructure Provider defines custom resources for managing vSphere infrastructure through Cluster API.
 
-🚧 **In Development**
+## Custom Resources
 
-API documentation will be available when the provider is released.
+| Resource | Description | Documentation |
+|----------|-------------|---------------|
+| `VSphereCluster` | Represents a Kubernetes cluster infrastructure on vSphere | [VSphereCluster](./vspherecluster.mdx) |
+| `VSphereMachine` | Represents a virtual machine in vSphere | [VSphereMachine](./vspheremachine.mdx) |
+| `VSphereMachineTemplate` | Template for creating vSphere machines | [VSphereMachineTemplate](./vspheremachinetemplate.mdx) |
+| `VSphereMachineConfigPool` | Pool of pre-defined node slots with hostnames, static IPs, and persistent disks | [VSphereMachineConfigPool](./vspheremachineconfigpool.mdx) |
+| `VSphereFailureDomain` | Describes a datacenter, compute cluster, datastore, and network topology used as a failure domain | [VSphereFailureDomain](./vspherefailuredomain.mdx) |
+| `VSphereDeploymentZone` | Binds a `VSphereFailureDomain` to a vCenter server and placement constraints | [VSphereDeploymentZone](./vspheredeploymentzone.mdx) |
 
-## Planned Resources
+## API Group
 
-- `VSphereCluster`: Represents a Kubernetes cluster infrastructure on vSphere
-- `VSphereMachine`: Represents a virtual machine in vSphere
-- `VSphereMachineTemplate`: Template for creating vSphere machines
+All VMware vSphere resources belong to the API group `infrastructure.cluster.x-k8s.io/v1beta1`.

--- a/docs/en/apis/providers/vmware-vsphere/index.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/index.mdx
@@ -20,7 +20,9 @@ The VMware vSphere Infrastructure Provider defines custom resources for managing
 | Resource | Description | Documentation |
 |----------|-------------|---------------|
 | `VSphereCluster` | Represents a Kubernetes cluster infrastructure on vSphere | [VSphereCluster](./vspherecluster.mdx) |
+| `VSphereClusterIdentity` | Cluster-scoped vCenter credential shared across namespaces via selectors | [VSphereClusterIdentity](./vsphereclusteridentity.mdx) |
 | `VSphereMachine` | Represents a virtual machine in vSphere | [VSphereMachine](./vspheremachine.mdx) |
+| `VSphereVM` | Low-level provider resource for the backing vCenter VM, reconciled by the controller | [VSphereVM](./vspherevm.mdx) |
 | `VSphereMachineTemplate` | Template for creating vSphere machines | [VSphereMachineTemplate](./vspheremachinetemplate.mdx) |
 | `VSphereMachineConfigPool` | Pool of pre-defined node slots with hostnames, static IPs, and persistent disks | [VSphereMachineConfigPool](./vspheremachineconfigpool.mdx) |
 | `VSphereFailureDomain` | Describes a datacenter, compute cluster, datastore, and network topology used as a failure domain | [VSphereFailureDomain](./vspherefailuredomain.mdx) |
@@ -29,3 +31,7 @@ The VMware vSphere Infrastructure Provider defines custom resources for managing
 ## API Group
 
 All VMware vSphere resources belong to the API group `infrastructure.cluster.x-k8s.io/v1beta1`.
+
+## Not Covered
+
+The provider also ships `VSphereClusterTemplate`, which is consumed by Cluster API ClusterClass / managed-topology flows. This product provisions workload clusters from explicit `Cluster`, `VSphereCluster`, and `KubeadmControlPlane` manifests rather than through ClusterClass, so `VSphereClusterTemplate` is not documented here.

--- a/docs/en/apis/providers/vmware-vsphere/vspherecluster.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspherecluster.mdx
@@ -1,0 +1,14 @@
+---
+weight: 10
+author: dev@alauda.io
+category: api
+queries:
+  - vspherecluster crd
+  - vspherecluster spec
+  - vsphere infrastructure cluster
+---
+
+# VSphereCluster [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vsphereclusters.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vsphereclusteridentity.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vsphereclusteridentity.mdx
@@ -1,0 +1,18 @@
+---
+weight: 15
+author: dev@alauda.io
+category: api
+queries:
+  - vsphereclusteridentity crd
+  - vsphere identity ref
+  - vsphere credential sharing
+---
+
+# VSphereClusterIdentity [infrastructure.cluster.x-k8s.io/v1beta1]
+
+`VSphereClusterIdentity` is a cluster-scoped credential that lets multiple `VSphereCluster` objects across different namespaces share one set of vCenter credentials, gated by namespace selectors. It is an alternative to referencing a `Secret` directly from `VSphereCluster.spec.identityRef`.
+
+Workflows documented in this guide use `identityRef.kind: Secret` and provision credentials per workload cluster; this resource is shown here for completeness for operators who need to share credentials across clusters.
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vsphereclusteridentities.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vspheredeploymentzone.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspheredeploymentzone.mdx
@@ -1,0 +1,14 @@
+---
+weight: 60
+author: dev@alauda.io
+category: api
+queries:
+  - vspheredeploymentzone crd
+  - vsphere deployment zone
+  - vsphere placement constraint
+---
+
+# VSphereDeploymentZone [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vspheredeploymentzones.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vspherefailuredomain.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspherefailuredomain.mdx
@@ -1,0 +1,14 @@
+---
+weight: 50
+author: dev@alauda.io
+category: api
+queries:
+  - vspherefailuredomain crd
+  - vsphere failure domain
+  - vsphere datacenter zone
+---
+
+# VSphereFailureDomain [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vspherefailuredomains.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vspheremachine.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspheremachine.mdx
@@ -1,0 +1,14 @@
+---
+weight: 20
+author: dev@alauda.io
+category: api
+queries:
+  - vspheremachine crd
+  - vsphere machine spec
+  - vsphere virtual machine
+---
+
+# VSphereMachine [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vspheremachines.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vspheremachineconfigpool.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspheremachineconfigpool.mdx
@@ -1,0 +1,14 @@
+---
+weight: 40
+author: dev@alauda.io
+category: api
+queries:
+  - vspheremachineconfigpool crd
+  - vsphere config pool
+  - vsphere machine config pool
+---
+
+# VSphereMachineConfigPool [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vspheremachineconfigpools.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vspheremachinetemplate.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspheremachinetemplate.mdx
@@ -1,0 +1,14 @@
+---
+weight: 30
+author: dev@alauda.io
+category: api
+queries:
+  - vspheremachinetemplate crd
+  - vsphere machine template
+  - vsphere vm template
+---
+
+# VSphereMachineTemplate [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vspheremachinetemplates.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/vspherevm.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vspherevm.mdx
@@ -1,0 +1,16 @@
+---
+weight: 25
+author: dev@alauda.io
+category: api
+queries:
+  - vspherevm crd
+  - vsphere vm status
+  - vspherevm addresses
+---
+
+# VSphereVM [infrastructure.cluster.x-k8s.io/v1beta1]
+
+`VSphereVM` is the low-level provider resource that represents the in-vCenter virtual machine backing a `VSphereMachine`. It is created by the provider controller, not by end users. Operators inspect it directly when troubleshooting cloning, IP allocation, or power state.
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vspherevms.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -26,7 +26,7 @@ Use this checklist in the following scenarios:
 Before you begin, ensure the following conditions are met:
 
 - You can access the `global` cluster with `kubectl`.
-- You know which namespace will store the workload cluster objects.
+- You know which namespace will store the workload cluster objects. Currently only `cpaas-system` is supported.
 - You have access to the target vCenter inventory, networks, datastores, and templates.
 
 ## How to Use This Checklist
@@ -116,7 +116,7 @@ Use the following table to record the required values and validation results.
 | Parameter | Placeholder | Required | Validation or Notes | Example | Actual Value |
 |-----------|-------------|----------|---------------------|---------|--------------|
 | `global` cluster kubeconfig path | - | Yes | `kubectl get ns` succeeds with this kubeconfig. | `/path/to/kubeconfig` | - |
-| Workload object namespace | `<namespace>` | Yes | The namespace that stores workload cluster objects. | `cpaas-system` | - |
+| Workload object namespace | `<namespace>` | Yes | The namespace that stores workload cluster objects. Currently only `cpaas-system` is supported; using any other value may cause cluster creation to fail. | `cpaas-system` | - |
 | `cluster-api-provider-vsphere` is installed | - | Yes | `kubectl get minfo -l cpaas.io/module-name=cluster-api-provider-vsphere` returns a result. | `Yes` | - |
 | `cluster-api-provider-kubeadm` is installed | - | Yes | `kubectl get minfo -l cpaas.io/module-name=cluster-api-provider-kubeadm` returns a result. | `Yes` | - |
 | `ClusterResourceSet=true` is enabled | - | Yes | The `capi-controller-manager` arguments include `ClusterResourceSet=true`. | `Yes` | - |

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -26,7 +26,7 @@ Use this checklist in the following scenarios:
 Before you begin, ensure the following conditions are met:
 
 - You can access the `global` cluster with `kubectl`.
-- You know which namespace will store the workload cluster objects. Currently only `cpaas-system` is supported.
+- The workload cluster objects must be stored in the `cpaas-system` namespace.
 - You have access to the target vCenter inventory, networks, datastores, and templates.
 
 ## How to Use This Checklist
@@ -116,7 +116,7 @@ Use the following table to record the required values and validation results.
 | Parameter | Placeholder | Required | Validation or Notes | Example | Actual Value |
 |-----------|-------------|----------|---------------------|---------|--------------|
 | `global` cluster kubeconfig path | - | Yes | `kubectl get ns` succeeds with this kubeconfig. | `/path/to/kubeconfig` | - |
-| Workload object namespace | `<namespace>` | Yes | The namespace that stores workload cluster objects. Currently only `cpaas-system` is supported; using any other value may cause cluster creation to fail. | `cpaas-system` | - |
+| Workload object namespace | `<namespace>` | Yes | The namespace that stores workload cluster objects. Must be `cpaas-system`. | `cpaas-system` | - |
 | `cluster-api-provider-vsphere` is installed | - | Yes | `kubectl get minfo -l cpaas.io/module-name=cluster-api-provider-vsphere` returns a result. | `Yes` | - |
 | `cluster-api-provider-kubeadm` is installed | - | Yes | `kubectl get minfo -l cpaas.io/module-name=cluster-api-provider-kubeadm` returns a result. | `Yes` | - |
 | `ClusterResourceSet=true` is enabled | - | Yes | The `capi-controller-manager` arguments include `ClusterResourceSet=true`. | `Yes` | - |
@@ -140,8 +140,8 @@ Use the following table to record the required values and validation results.
 |-----------|-------------|----------|---------------------|---------|--------------|
 | VM template name | `<template_name>` | Yes | Used to clone control plane and worker nodes. | `microos-k8s-template` | - |
 | vCenter credential secret name | `<credentials_secret_name>` | Yes | Use a stable name such as `<cluster_name>-vsphere-credentials`. | `demo-cluster-vsphere-credentials` | - |
-| Clone mode | `<clone_mode>` | Yes | `linkedClone` is recommended when your environment supports it. | `linkedClone` | - |
-| Power-off mode | `<power_off_mode>` | Yes | Use the value expected by your CAPV environment. | `trySoft` | - |
+| Clone mode | `<clone_mode>` | Yes | Allowed values: `linkedClone`, `fullClone`. Default is `linkedClone`. `linkedClone` requires the VM template to have at least one snapshot; if none exists, CAPV falls back to `fullClone`. When `linkedClone` is used, `diskGiB` is ignored; the system disk stays at the template's size. Choose `fullClone` if you need `diskGiB` to take effect. | `linkedClone` | - |
+| Power-off mode | `<power_off_mode>` | Yes | Allowed values: `hard`, `soft`, `trySoft`. Default is `hard`. `soft` and `trySoft` require VMware Tools / `open-vm-tools` in the template for graceful shutdown; `trySoft` falls back to `hard` after the guest-soft-power-off timeout. | `trySoft` | - |
 | SSH public key | `<ssh_public_key>` | Yes | Injected into control plane and worker nodes. | `ssh-rsa AAAA...` | - |
 
 The template should also meet the following requirements:
@@ -233,11 +233,11 @@ The template should also meet the following requirements:
 | Control plane CPU | `<cp_num_cpus>` | Yes | CPU count per control plane node. | `4` | - |
 | Control plane memory MiB | `<cp_memory_mib>` | Yes | Memory per control plane node. | `8192` | - |
 | Control plane system datastore | `<cp_system_datastore>` | Yes | Datastore for the control plane system disk. | `datastore-cp` | - |
-| Control plane system disk size GiB | `<cp_system_disk_gib>` | Yes | Baseline example value is `300`. | `300` | - |
+| Control plane system disk size GiB | `<cp_system_disk_gib>` | Yes | Baseline example value is `300`. Ignored when `<clone_mode>` is `linkedClone`; the system disk then stays at the template's size. | `300` | - |
 | Worker CPU | `<worker_num_cpus>` | Yes | CPU count per worker node. | `2` | - |
 | Worker memory MiB | `<worker_memory_mib>` | Yes | Memory per worker node. | `4096` | - |
 | Worker system datastore | `<worker_system_datastore>` | Yes | Datastore for the worker system disk. | `datastore-worker` | - |
-| Worker system disk size GiB | `<worker_system_disk_gib>` | Yes | Baseline example value is `300`. | `300` | - |
+| Worker system disk size GiB | `<worker_system_disk_gib>` | Yes | Baseline example value is `300`. Ignored when `<clone_mode>` is `linkedClone`; the system disk then stays at the template's size. | `300` | - |
 
 ### Standard data disks
 

--- a/docs/en/overview/feature.mdx
+++ b/docs/en/overview/feature.mdx
@@ -29,10 +29,10 @@ Our platform offers end-to-end Kubernetes cluster lifecycle management with immu
 
 ## Supported Infrastructure Providers \{#supported-infrastructure-providers}
 
-Our platform follows a pluggable provider model aligned with Cluster API infrastructure providers. It is designed for multiple infrastructure platforms. Today, the DCS infrastructure provider is supported, with additional providers in progress.
+Our platform follows a pluggable provider model aligned with Cluster API infrastructure providers. It is designed for multiple infrastructure platforms. Today, the DCS and VMware vSphere infrastructure providers are supported, with additional providers in progress.
 
 - **Provider-Agnostic Design**: Core workflows are consistent across providers
-- **Current Support**: DCS infrastructure provider
+- **Current Support**: DCS infrastructure provider, VMware vSphere infrastructure provider
 - **Roadmap**: Additional providers are being added
 
 ## Compute Resource Management \{#compute-resource-management}

--- a/docs/en/overview/providers/index.mdx
+++ b/docs/en/overview/providers/index.mdx
@@ -21,7 +21,7 @@ Immutable Infrastructure supports multiple infrastructure platforms through plug
 |----------|-------------|--------|
 | [Huawei DCS](./huawei-dcs.mdx) | Huawei Datacenter Virtualization Solution | ✅ Available |
 | [Huawei Cloud Stack](./huawei-cloud-stack.mdx) | Huawei Cloud Stack | ✅ Available |
-| [VMware vSphere](./vmware-vsphere.mdx) | VMware vSphere virtualization platform | 🚧 In Development |
+| [VMware vSphere](./vmware-vsphere.mdx) | VMware vSphere virtualization platform | ✅ Available |
 | [Bare Metal](./bare-metal.mdx) | Bare-metal servers without virtualization | 📋 Planned |
 
 ## Fleet Essentials Plugin
@@ -40,7 +40,7 @@ Fleet Essentials works with Infrastructure Providers to deliver platform-specifi
 **Provider Extensions**:
 - **DCS Provider**: Alauda Container Platform DCS Infrastructure Provider `1.0.13` and later adds DCS-specific UI pages and workflows on Huawei DCS
 - **HCS Provider**: Enables UI-based cluster creation and management on Huawei Cloud Stack (coming soon)
-- **vSphere Provider**: Will enable UI-based cluster creation and management on VMware vSphere (in development)
+- **vSphere Provider**: The VMware vSphere infrastructure provider is generally available; its Fleet Essentials UI extension for cluster creation and management is coming soon
 
 ## Provider Architecture
 

--- a/docs/en/overview/providers/vmware-vsphere.mdx
+++ b/docs/en/overview/providers/vmware-vsphere.mdx
@@ -1,28 +1,49 @@
 ---
 weight: 30
+title: VMware vSphere Provider
+author: dev@alauda.io
+category: introduction
+queries:
+  - vmware vsphere provider
+  - capv cluster api
+  - vsphere infrastructure provider
 ---
 
 # VMware vSphere Provider
 
-The VMware vSphere Infrastructure Provider enables Immutable Infrastructure on VMware vSphere platform.
+<Overview />
+
+The VMware vSphere Infrastructure Provider enables Immutable Infrastructure on the VMware vSphere platform. This provider is built on top of Cluster API Provider vSphere (CAPV) and integrates with vCenter to provision and manage virtual machines, networks, and storage for Kubernetes clusters.
 
 ## Overview
 
-VMware vSphere is the industry-leading virtualization platform from VMware. The vSphere Provider integrates with vCenter to manage virtual machines, networks, and storage resources for Kubernetes clusters.
+VMware vSphere is the industry-leading virtualization platform from VMware. The vSphere Provider connects directly to vCenter to manage VM lifecycle, and extends CAPV with declarative node-slot allocation so that hostnames, static IP addresses, and persistent disks can be pre-defined before a cluster is provisioned.
 
-## Status
+## Key Features
 
-🚧 **In Development**
+- **vCenter Integration**: Direct vCenter connectivity to clone VM templates, manage VM lifecycle, and place workloads on target datacenters, compute clusters, and datastores
+- **Machine Configuration Pools**: `VSphereMachineConfigPool` defines per-node slots with fixed hostnames, static IPs, and persistent-disk layouts, enabling predictable VM provisioning and slot-based scale-out
+- **Static IP Allocation**: Static IP, gateway, and DNS configuration per node slot for enterprise network environments where DHCP is not available
+- **Multi-NIC Support**: Primary and additional NICs per node, where the primary NIC drives the kubelet `node-ip` and additional NICs are attached in declared order for management, storage, or service networks
+- **Multiple Datacenters and Failure Domains**: Distribute control plane and worker nodes across multiple vCenter datacenters or compute clusters through `VSphereFailureDomain` and `VSphereDeploymentZone` for high availability
+- **Flexible Persistent Disks**: Declarative data disks with optional format/mount, `wipeFilesystem` control for etcd rolling updates, and raw-device mode exposed at `/dev/disk/by-capv/<name>` for application-managed disks
+- **Immutable-Template Rolling Updates**: Control plane and worker updates go through new `VSphereMachineTemplate` and `KubeadmConfigTemplate` resources, giving Cluster API a clean rollback path on failed upgrades
 
-This provider is currently under active development.
+## Supported Resources
 
-## Key Features (Planned)
-
-- **vCenter Integration**: Manage VMs through vCenter APIs
-- **Network Support**: Support for vSphere standard and distributed switches
-- **Storage Management**: Integration with vSphere datastores
-- **Static IP**: Static IP configuration for enterprise environments
+| Resource | Description |
+|----------|-------------|
+| `VSphereCluster` | Represents vSphere infrastructure including vCenter endpoint, control plane endpoint, and failure-domain selector |
+| `VSphereMachine` | Represents a virtual machine instance in vSphere |
+| `VSphereMachineTemplate` | Immutable template for creating vSphere machines with VM, CPU, memory, network, and disk specifications |
+| `VSphereMachineConfigPool` | Pool of pre-defined node slots with hostnames, static IPs, and persistent-disk layouts |
+| `VSphereFailureDomain` | Describes a datacenter, compute cluster, datastore, and network topology used as a failure domain |
+| `VSphereDeploymentZone` | Binds a `VSphereFailureDomain` to a vCenter server and placement constraints such as resource pool |
 
 ## Documentation
 
-Documentation will be available when the provider is released.
+- [Installation Guide](../../install/vmware-vsphere.mdx)
+- [Creating Clusters](../../create-cluster/vmware-vsphere/)
+- [Managing Nodes](../../manage-nodes/vmware-vsphere.mdx)
+- [Upgrading Clusters](../../upgrade-cluster/vmware-vsphere.mdx)
+- [Provider APIs](../../apis/providers/vmware-vsphere/)

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
@@ -1,0 +1,521 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vsphereclusteridentities.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereClusterIdentity
+    listKind: VSphereClusterIdentityList
+    plural: vsphereclusteridentities
+    singular: vsphereclusteridentity
+  scope: Cluster
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereClusterIdentity defines the account to be used for reconciling clusters
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowedNamespaces:
+                description: |-
+                  AllowedNamespaces is used to identify which namespaces are allowed to use this account.
+                  Namespaces can be selected with a label selector.
+                  If this object is nil, no namespaces will be allowed
+                properties:
+                  selector:
+                    description: Selector is a standard Kubernetes LabelSelector.
+                      A label query over a set of resources.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              secretName:
+                description: SecretName references a Secret inside the controller
+                  namespace with the credentials to use
+                minLength: 1
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereClusterIdentity defines the account to be used for reconciling clusters
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              allowedNamespaces:
+                description: |-
+                  AllowedNamespaces is used to identify which namespaces are allowed to use this account.
+                  Namespaces can be selected with a label selector.
+                  If this object is nil, no namespaces will be allowed
+                properties:
+                  selector:
+                    description: Selector is a standard Kubernetes LabelSelector.
+                      A label query over a set of resources.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              secretName:
+                description: SecretName references a Secret inside the controller
+                  namespace with the credentials to use
+                minLength: 1
+                type: string
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereClusterIdentity defines the account to be used for reconciling
+          clusters.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterIdentitySpec contains a secret reference and
+              a group of allowed namespaces.
+            properties:
+              allowedNamespaces:
+                description: |-
+                  AllowedNamespaces is used to identify which namespaces are allowed to use this account.
+                  Namespaces can be selected with a label selector.
+                  If this object is nil, no namespaces will be allowed
+                properties:
+                  selector:
+                    description: Selector is a standard Kubernetes LabelSelector.
+                      A label query over a set of resources.
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: |-
+                            A label selector requirement is a selector that contains values, a key, and an operator that
+                            relates the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: |-
+                                operator represents a key's relationship to a set of values.
+                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: |-
+                                values is an array of string values. If the operator is In or NotIn,
+                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced during a strategic
+                                merge patch.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                    x-kubernetes-map-type: atomic
+                type: object
+              secretName:
+                description: SecretName references a Secret inside the controller
+                  namespace with the credentials to use
+                minLength: 1
+                type: string
+            type: object
+          status:
+            description: VSphereClusterIdentityStatus contains the status of the VSphereClusterIdentity.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                type: boolean
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in VSphereClusterIdentity's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a VSphereClusterIdentity's current state.
+                      Known condition types are Available and Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclusteridentities.yaml
@@ -107,7 +107,7 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions defines current service state of the VSphereCluster.
+                description: Conditions defines current service state of the VSphereClusterIdentity.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.
@@ -249,7 +249,7 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions defines current service state of the VSphereCluster.
+                description: Conditions defines current service state of the VSphereClusterIdentity.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.
@@ -391,7 +391,7 @@ spec:
             description: VSphereClusterIdentityStatus contains the status of the VSphereClusterIdentity.
             properties:
               conditions:
-                description: Conditions defines current service state of the VSphereCluster.
+                description: Conditions defines current service state of the VSphereClusterIdentity.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclusters.yaml
@@ -1,0 +1,937 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vsphereclusters.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereCluster
+    listKind: VSphereClusterList
+    plural: vsphereclusters
+    singular: vspherecluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster infrastructure is ready for VSphereMachine
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Server is the address of the vSphere endpoint
+      jsonPath: .spec.server
+      name: Server
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint[0]
+      name: ControlPlaneEndpoint
+      priority: 1
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereCluster is the Schema for the vsphereclusters API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterSpec defines the desired state of VSphereCluster.
+            properties:
+              cloudProviderConfiguration:
+                description: |-
+                  CloudProviderConfiguration holds the cluster-wide configuration for the vSphere cloud provider.
+
+                  Deprecated: will be removed in v1alpha4.
+                properties:
+                  disk:
+                    description: Disk is the vSphere cloud provider's disk configuration.
+                    properties:
+                      scsiControllerType:
+                        description: SCSIControllerType defines SCSI controller to
+                          be used.
+                        type: string
+                    type: object
+                  global:
+                    description: Global is the vSphere cloud provider's global configuration.
+                    properties:
+                      apiBindPort:
+                        description: |-
+                          APIBindPort configures the vSphere cloud controller manager API port.
+                          Defaults to 43001.
+                        type: string
+                      apiDisable:
+                        description: |-
+                          APIDisable disables the vSphere cloud controller manager API.
+                          Defaults to true.
+                        type: boolean
+                      caFile:
+                        description: |-
+                          CAFile Specifies the path to a CA certificate in PEM format.
+                          If not configured, the system's CA certificates will be used.
+                        type: string
+                      datacenters:
+                        description: Datacenters is a CSV string of the datacenters
+                          in which VMs are located.
+                        type: string
+                      insecure:
+                        description: Insecure is a flag that disables TLS peer verification.
+                        type: boolean
+                      password:
+                        description: Password is the password used to access a vSphere
+                          endpoint.
+                        type: string
+                      port:
+                        description: |-
+                          Port is the port on which the vSphere endpoint is listening.
+                          Defaults to 443.
+                        type: string
+                      roundTripperCount:
+                        description: |-
+                          RoundTripperCount specifies the SOAP round tripper count
+                          (retries = RoundTripper - 1)
+                        format: int32
+                        type: integer
+                      secretName:
+                        description: |-
+                          SecretName is the name of the Kubernetes secret in which the vSphere
+                          credentials are located.
+                        type: string
+                      secretNamespace:
+                        description: SecretNamespace is the namespace for SecretName.
+                        type: string
+                      secretsDirectory:
+                        description: |-
+                          SecretsDirectory is a directory in which secrets may be found. This
+                          may used in the event that:
+                          1. It is not desirable to use the K8s API to watch changes to secrets
+                          2. The cloud controller manager is not running in a K8s environment,
+                             such as DC/OS. For example, the container storage interface (CSI) is
+                             container orcehstrator (CO) agnostic, and should support non-K8s COs.
+                          Defaults to /etc/cloud/credentials.
+                        type: string
+                      serviceAccount:
+                        description: |-
+                          ServiceAccount is the Kubernetes service account used to launch the cloud
+                          controller manager.
+                          Defaults to cloud-controller-manager.
+                        type: string
+                      thumbprint:
+                        description: |-
+                          Thumbprint is the cryptographic thumbprint of the vSphere endpoint's
+                          certificate.
+                        type: string
+                      username:
+                        description: Username is the username used to access a vSphere
+                          endpoint.
+                        type: string
+                    type: object
+                  labels:
+                    description: Labels is the vSphere cloud provider's zone and region
+                      configuration.
+                    properties:
+                      region:
+                        description: Region is the region in which VMs are created/located.
+                        type: string
+                      zone:
+                        description: Zone is the zone in which VMs are created/located.
+                        type: string
+                    type: object
+                  network:
+                    description: Network is the vSphere cloud provider's network configuration.
+                    properties:
+                      name:
+                        description: Name is the name of the network to which VMs
+                          are connected.
+                        type: string
+                    type: object
+                  providerConfig:
+                    description: |-
+                      CPIProviderConfig contains extra information used to configure the
+                      vSphere cloud provider.
+                    properties:
+                      cloud:
+                        properties:
+                          controllerImage:
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              ExtraArgs passes through extra arguments to the cloud provider.
+                              The arguments here are passed to the cloud provider daemonset specification
+                            type: object
+                        type: object
+                      storage:
+                        properties:
+                          attacherImage:
+                            type: string
+                          controllerImage:
+                            type: string
+                          livenessProbeImage:
+                            type: string
+                          metadataSyncerImage:
+                            type: string
+                          nodeDriverImage:
+                            type: string
+                          provisionerImage:
+                            type: string
+                          registrarImage:
+                            type: string
+                        type: object
+                    type: object
+                  virtualCenter:
+                    additionalProperties:
+                      description: CPIVCenterConfig is a vSphere cloud provider's
+                        vCenter configuration.
+                      properties:
+                        datacenters:
+                          description: Datacenters is a CSV string of the datacenters
+                            in which VMs are located.
+                          type: string
+                        password:
+                          description: Password is the password used to access a vSphere
+                            endpoint.
+                          type: string
+                        port:
+                          description: |-
+                            Port is the port on which the vSphere endpoint is listening.
+                            Defaults to 443.
+                          type: string
+                        roundTripperCount:
+                          description: |-
+                            RoundTripperCount specifies the SOAP round tripper count
+                            (retries = RoundTripper - 1)
+                          format: int32
+                          type: integer
+                        thumbprint:
+                          description: |-
+                            Thumbprint is the cryptographic thumbprint of the vSphere endpoint's
+                            certificate.
+                          type: string
+                        username:
+                          description: Username is the username used to access a vSphere
+                            endpoint.
+                          type: string
+                      type: object
+                    description: VCenter is a list of vCenter configurations.
+                    type: object
+                  workspace:
+                    description: Workspace is the vSphere cloud provider's workspace
+                      configuration.
+                    properties:
+                      datacenter:
+                        description: Datacenter is the datacenter in which VMs are
+                          created/located.
+                        type: string
+                      datastore:
+                        description: Datastore is the datastore in which VMs are created/located.
+                        type: string
+                      folder:
+                        description: Folder is the folder in which VMs are created/located.
+                        type: string
+                      resourcePool:
+                        description: ResourcePool is the resource pool in which VMs
+                          are created/located.
+                        type: string
+                      server:
+                        description: Server is the IP address or FQDN of the vSphere
+                          endpoint.
+                        type: string
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              identityRef:
+                description: |-
+                  IdentityRef is a reference to either a Secret or VSphereClusterIdentity that contains
+                  the identity to use when reconciling the cluster.
+                properties:
+                  kind:
+                    description: Kind of the identity. Can either be VSphereClusterIdentity
+                      or Secret
+                    enum:
+                    - VSphereClusterIdentity
+                    - Secret
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              insecure:
+                description: |-
+                  Insecure is a flag that controls whether to validate the
+                  vSphere server's certificate.
+
+                  Deprecated: will be removed in v1alpha4.
+                type: boolean
+              loadBalancerRef:
+                description: |-
+                  LoadBalancerRef may be used to enable a control plane load balancer
+                  for this cluster.
+                  When a LoadBalancerRef is provided, the VSphereCluster.Status.Ready field
+                  will not be true until the referenced resource is Status.Ready and has a
+                  non-empty Status.Address value.
+
+                  Deprecated: will be removed in v1alpha4.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When provided, Insecure should not be set to true
+                type: string
+            type: object
+          status:
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a list of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster infrastructure is ready for VSphereMachine
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Server is the address of the vSphere endpoint
+      jsonPath: .spec.server
+      name: Server
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint[0]
+      name: ControlPlaneEndpoint
+      priority: 1
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereCluster is the Schema for the vsphereclusters API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterSpec defines the desired state of VSphereCluster
+            properties:
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              identityRef:
+                description: |-
+                  IdentityRef is a reference to either a Secret or VSphereClusterIdentity that contains
+                  the identity to use when reconciling the cluster.
+                properties:
+                  kind:
+                    description: Kind of the identity. Can either be VSphereClusterIdentity
+                      or Secret
+                    enum:
+                    - VSphereClusterIdentity
+                    - Secret
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate
+                type: string
+            type: object
+          status:
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: Attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: ControlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a list of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster infrastructure is ready for VSphereMachine
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: Server is the address of the vSphere endpoint.
+      jsonPath: .spec.server
+      name: Server
+      type: string
+    - description: API Endpoint
+      jsonPath: .spec.controlPlaneEndpoint[0]
+      name: ControlPlaneEndpoint
+      priority: 1
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereCluster is the Schema for the vsphereclusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterSpec defines the desired state of VSphereCluster.
+            properties:
+              clusterModules:
+                description: |-
+                  ClusterModules hosts information regarding the anti-affinity vSphere constructs
+                  for each of the objects responsible for creation of VM objects belonging to the cluster.
+                items:
+                  description: |-
+                    ClusterModule holds the anti affinity construct `ClusterModule` identifier
+                    in use by the VMs owned by the object referred by the TargetObjectName field.
+                  properties:
+                    controlPlane:
+                      description: |-
+                        ControlPlane indicates whether the referred object is responsible for control plane nodes.
+                        Currently, only the KubeadmControlPlane objects have this flag set to true.
+                        Only a single object in the slice can have this value set to true.
+                      type: boolean
+                    moduleUUID:
+                      description: ModuleUUID is the unique identifier of the `ClusterModule`
+                        used by the object.
+                      type: string
+                    targetObjectName:
+                      description: |-
+                        TargetObjectName points to the object that uses the Cluster Module information to enforce
+                        anti-affinity amongst its descendant VM objects.
+                      type: string
+                  required:
+                  - controlPlane
+                  - moduleUUID
+                  - targetObjectName
+                  type: object
+                type: array
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              disableClusterModule:
+                description: |-
+                  DisableClusterModule is used to explicitly turn off the ClusterModule feature.
+                  This should work along side NodeAntiAffinity feature flag.
+                  If the NodeAntiAffinity feature flag is turned off, this will be disregarded.
+                type: boolean
+              failureDomainSelector:
+                description: |-
+                  FailureDomainSelector is the label selector to use for failure domain selection
+                  for the control plane nodes of the cluster.
+                  If not set (`nil`), selecting failure domains will be disabled.
+                  An empty value (`{}`) selects all existing failure domains.
+                  A valid selector will select all failure domains which match the selector.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              identityRef:
+                description: |-
+                  IdentityRef is a reference to either a Secret or VSphereClusterIdentity that contains
+                  the identity to use when reconciling the cluster.
+                properties:
+                  kind:
+                    description: Kind of the identity. Can either be VSphereClusterIdentity
+                      or Secret
+                    enum:
+                    - VSphereClusterIdentity
+                    - Secret
+                    type: string
+                  name:
+                    description: Name of the identity.
+                    minLength: 1
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+              thumbprint:
+                description: Thumbprint is the colon-separated SHA-1 checksum of the
+                  given vCenter server's host certificate
+                type: string
+            type: object
+          status:
+            description: VSphereClusterStatus defines the observed state of VSphereClusterSpec.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereCluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: FailureDomains is a list of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              ready:
+                type: boolean
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in VSphereCluster's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a VSphereCluster's current state.
+                      Known condition types are Ready, FailureDomainsReady, VCenterAvailable, ClusterModulesReady and Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+              vCenterVersion:
+                description: VCenterVersion defines the version of the vCenter server
+                  defined in the spec.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
@@ -1,0 +1,441 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vspheredeploymentzones.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereDeploymentZone
+    listKind: VSphereDeploymentZoneList
+    plural: vspheredeploymentzones
+    singular: vspheredeploymentzone
+  scope: Cluster
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereDeploymentZone is the Schema for the vspheredeploymentzones API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
+            properties:
+              controlPlane:
+                description: ControlPlane determines if this failure domain is suitable
+                  for use by control plane machines.
+                type: boolean
+              failureDomain:
+                description: failureDomain is the name of the VSphereFailureDomain
+                  used for this VSphereDeploymentZone
+                type: string
+              placementConstraint:
+                description: |-
+                  PlacementConstraint encapsulates the placement constraints
+                  used within this deployment zone.
+                properties:
+                  folder:
+                    description: |-
+                      Folder is the name or inventory path of the folder in which the
+                      virtual machine is created/located.
+                    type: string
+                  resourcePool:
+                    description: |-
+                      ResourcePool is the name or inventory path of the resource pool in which
+                      the virtual machine is created/located.
+                    type: string
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+            required:
+            - placementConstraint
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: |-
+                  Ready is true when the VSphereDeploymentZone resource is ready.
+                  If set to false, it will be ignored by VSphereClusters
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereDeploymentZone is the Schema for the vspheredeploymentzones API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone
+            properties:
+              controlPlane:
+                description: ControlPlane determines if this failure domain is suitable
+                  for use by control plane machines.
+                type: boolean
+              failureDomain:
+                description: FailureDomain is the name of the VSphereFailureDomain
+                  used for this VSphereDeploymentZone
+                type: string
+              placementConstraint:
+                description: |-
+                  PlacementConstraint encapsulates the placement constraints
+                  used within this deployment zone.
+                properties:
+                  folder:
+                    description: |-
+                      Folder is the name or inventory path of the folder in which the
+                      virtual machine is created/located.
+                    type: string
+                  resourcePool:
+                    description: |-
+                      ResourcePool is the name or inventory path of the resource pool in which
+                      the virtual machine is created/located.
+                    type: string
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+            required:
+            - placementConstraint
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: |-
+                  Ready is true when the VSphereDeploymentZone resource is ready.
+                  If set to false, it will be ignored by VSphereClusters
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereDeploymentZone is the Schema for the vspheredeploymentzones
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereDeploymentZoneSpec defines the desired state of VSphereDeploymentZone.
+            properties:
+              controlPlane:
+                description: ControlPlane determines if this failure domain is suitable
+                  for use by control plane machines.
+                type: boolean
+              failureDomain:
+                description: FailureDomain is the name of the VSphereFailureDomain
+                  used for this VSphereDeploymentZone
+                type: string
+              placementConstraint:
+                description: |-
+                  PlacementConstraint encapsulates the placement constraints
+                  used within this deployment zone.
+                properties:
+                  folder:
+                    description: |-
+                      Folder is the name or inventory path of the folder in which the
+                      virtual machine is created/located.
+                    type: string
+                  resourcePool:
+                    description: |-
+                      ResourcePool is the name or inventory path of the resource pool in which
+                      the virtual machine is created/located.
+                    type: string
+                type: object
+              server:
+                description: Server is the address of the vSphere endpoint.
+                type: string
+            required:
+            - placementConstraint
+            type: object
+          status:
+            description: VSphereDeploymentZoneStatus contains the status for a VSphereDeploymentZone.
+            properties:
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              ready:
+                description: |-
+                  Ready is true when the VSphereDeploymentZone resource is ready.
+                  If set to false, it will be ignored by VSphereClusters
+                type: boolean
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in VSphereDeploymentZone's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a VSphereDeploymentZone's current state.
+                      Known condition types are Ready, VCenterAvailable, PlacementConstraintReady, FailureDomainValidated and Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheredeploymentzones.yaml
@@ -78,7 +78,7 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions defines current service state of the VSphereMachine.
+                description: Conditions defines current service state of the VSphereDeploymentZone.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.
@@ -194,7 +194,7 @@ spec:
           status:
             properties:
               conditions:
-                description: Conditions defines current service state of the VSphereMachine.
+                description: Conditions defines current service state of the VSphereDeploymentZone.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.
@@ -308,7 +308,7 @@ spec:
             description: VSphereDeploymentZoneStatus contains the status for a VSphereDeploymentZone.
             properties:
               conditions:
-                description: Conditions defines current service state of the VSphereMachine.
+                description: Conditions defines current service state of the VSphereDeploymentZone.
                 items:
                   description: Condition defines an observation of a Cluster API resource
                     operational state.
@@ -323,7 +323,7 @@ spec:
                     message:
                       description: |-
                         message is a human readable message indicating details about the transition.
-                        This field may be empty.
+                        This field is optional, but if set it must not be empty.
                       maxLength: 10240
                       minLength: 1
                       type: string
@@ -331,7 +331,7 @@ spec:
                       description: |-
                         reason is the reason for the condition's last transition in CamelCase.
                         The specific API may choose whether or not this field is considered a guaranteed API.
-                        This field may be empty.
+                        This field is optional, but if set it must not be empty.
                       maxLength: 256
                       minLength: 1
                       type: string

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
@@ -455,8 +455,8 @@ spec:
                               type: boolean
                             useRoutes:
                               description: |-
-                                UseRoutes when `true`, the routes from the DHCP server will be installed
-                                in the routing table.
+                                UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                the routes from the DHCP server will be installed in the routing table.
                               type: string
                           type: object
                         dhcp6:
@@ -516,8 +516,8 @@ spec:
                               type: boolean
                             useRoutes:
                               description: |-
-                                UseRoutes when `true`, the routes from the DHCP server will be installed
-                                in the routing table.
+                                UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                the routes from the DHCP server will be installed in the routing table.
                               type: string
                           type: object
                         nameservers:

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherefailuredomains.yaml
@@ -1,0 +1,594 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vspherefailuredomains.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereFailureDomain
+    listKind: VSphereFailureDomainList
+    plural: vspherefailuredomains
+    singular: vspherefailuredomain
+  scope: Cluster
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereFailureDomain is the Schema for the vspherefailuredomains API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain
+            properties:
+              region:
+                description: Region defines the name and type of a region
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+              topology:
+                description: Topology is the what describes a given failure domain
+                  using vSphere constructs
+                properties:
+                  computeCluster:
+                    description: ComputeCluster as the failure domain
+                    type: string
+                  datacenter:
+                    description: |-
+                      The underlying infrastructure for this failure domain
+                      Datacenter as the failure domain
+                    type: string
+                  datastore:
+                    description: |-
+                      Datastore is the name or inventory path of the datastore in which the
+                      virtual machine is created/located.
+                    type: string
+                  hosts:
+                    description: Hosts has information required for placement of machines
+                      on VSphere hosts.
+                    properties:
+                      hostGroupName:
+                        description: HostGroupName is the name of the Host group
+                        type: string
+                      vmGroupName:
+                        description: VMGroupName is the name of the VM group
+                        type: string
+                    required:
+                    - hostGroupName
+                    - vmGroupName
+                    type: object
+                  networks:
+                    description: Networks is the list of networks within this failure
+                      domain
+                    items:
+                      type: string
+                    type: array
+                required:
+                - datacenter
+                type: object
+              zone:
+                description: Zone defines the name and type of a zone
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+            required:
+            - region
+            - topology
+            - zone
+            type: object
+        type: object
+    served: false
+    storage: false
+  - deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereFailureDomain is the Schema for the vspherefailuredomains API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain
+            properties:
+              region:
+                description: Region defines the name and type of a region
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+              topology:
+                description: Topology describes a given failure domain using vSphere
+                  constructs
+                properties:
+                  computeCluster:
+                    description: ComputeCluster as the failure domain
+                    type: string
+                  datacenter:
+                    description: |-
+                      The underlying infrastructure for this failure domain
+                      Datacenter as the failure domain
+                    type: string
+                  datastore:
+                    description: |-
+                      Datastore is the name or inventory path of the datastore in which the
+                      virtual machine is created/located.
+                    type: string
+                  hosts:
+                    description: Hosts has information required for placement of machines
+                      on VSphere hosts.
+                    properties:
+                      hostGroupName:
+                        description: HostGroupName is the name of the Host group
+                        type: string
+                      vmGroupName:
+                        description: VMGroupName is the name of the VM group
+                        type: string
+                    required:
+                    - hostGroupName
+                    - vmGroupName
+                    type: object
+                  networks:
+                    description: Networks is the list of networks within this failure
+                      domain
+                    items:
+                      type: string
+                    type: array
+                required:
+                - datacenter
+                type: object
+              zone:
+                description: Zone defines the name and type of a zone
+                properties:
+                  autoConfigure:
+                    description: AutoConfigure tags the Type which is specified in
+                      the Topology
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+            required:
+            - region
+            - topology
+            - zone
+            type: object
+        type: object
+    served: false
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereFailureDomain is the Schema for the vspherefailuredomains
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereFailureDomainSpec defines the desired state of VSphereFailureDomain.
+            properties:
+              region:
+                description: Region defines the name and type of a region
+                properties:
+                  autoConfigure:
+                    description: |-
+                      AutoConfigure tags the Type which is specified in the Topology
+
+                      Deprecated: This field is going to be removed in a future release.
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+              topology:
+                description: Topology describes a given failure domain using vSphere
+                  constructs
+                properties:
+                  computeCluster:
+                    description: ComputeCluster as the failure domain
+                    type: string
+                  datacenter:
+                    description: Datacenter as the failure domain.
+                    type: string
+                  datastore:
+                    description: |-
+                      Datastore is the name or inventory path of the datastore in which the
+                      virtual machine is created/located.
+                    type: string
+                  hosts:
+                    description: Hosts has information required for placement of machines
+                      on VSphere hosts.
+                    properties:
+                      hostGroupName:
+                        description: HostGroupName is the name of the Host group
+                        type: string
+                      vmGroupName:
+                        description: VMGroupName is the name of the VM group
+                        type: string
+                    required:
+                    - hostGroupName
+                    - vmGroupName
+                    type: object
+                  networkConfigurations:
+                    description: NetworkConfigurations is a list of network configurations
+                      within this failure domain.
+                    items:
+                      description: |-
+                        NetworkConfiguration defines a network configuration that should be used when consuming
+                        a failure domain.
+                      properties:
+                        addressesFromPools:
+                          description: |-
+                            AddressesFromPools is a list of IPAddressPools that should be assigned
+                            to IPAddressClaims. The machine's cloud-init metadata will be populated
+                            with IPAddresses fulfilled by an IPAM provider.
+                          items:
+                            description: |-
+                              TypedLocalObjectReference contains enough information to let you locate the
+                              typed referenced object inside the same namespace.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        dhcp4:
+                          description: DHCP4 is a flag that indicates whether or not
+                            to use DHCP for IPv4.
+                          type: boolean
+                        dhcp4Overrides:
+                          description: |-
+                            DHCP4Overrides allows for the control over several DHCP behaviors.
+                            Overrides will only be applied when the corresponding DHCP flag is set.
+                            Only configured values will be sent, omitted values will default to
+                            distribution defaults.
+                            Dependent on support in the network stack for your distribution.
+                            For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname is the name which will be sent to the DHCP server instead of
+                                the machine's hostname.
+                              type: string
+                            routeMetric:
+                              description: |-
+                                RouteMetric is used to prioritize routes for devices. A lower metric for
+                                an interface will have a higher priority.
+                              type: integer
+                            sendHostname:
+                              description: |-
+                                SendHostname when `true`, the hostname of the machine will be sent to the
+                                DHCP server.
+                              type: boolean
+                            useDNS:
+                              description: |-
+                                UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                take precedence.
+                              type: boolean
+                            useDomains:
+                              description: |-
+                                UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                the domain name from the DHCP server will be used as the DNS search
+                                domain for this device. When `route`, the domain name from the DHCP
+                                response will be used for routing DNS only, not for searching.
+                              type: string
+                            useHostname:
+                              description: |-
+                                UseHostname when `true`, the hostname from the DHCP server will be set
+                                as the transient hostname of the machine.
+                              type: boolean
+                            useMTU:
+                              description: |-
+                                UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                MTU of the device.
+                              type: boolean
+                            useNTP:
+                              description: |-
+                                UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                by systemd-timesyncd and take precedence.
+                              type: boolean
+                            useRoutes:
+                              description: |-
+                                UseRoutes when `true`, the routes from the DHCP server will be installed
+                                in the routing table.
+                              type: string
+                          type: object
+                        dhcp6:
+                          description: DHCP6 is a flag that indicates whether or not
+                            to use DHCP for IPv6.
+                          type: boolean
+                        dhcp6Overrides:
+                          description: |-
+                            DHCP6Overrides allows for the control over several DHCP behaviors.
+                            Overrides will only be applied when the corresponding DHCP flag is set.
+                            Only configured values will be sent, omitted values will default to
+                            distribution defaults.
+                            Dependent on support in the network stack for your distribution.
+                            For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname is the name which will be sent to the DHCP server instead of
+                                the machine's hostname.
+                              type: string
+                            routeMetric:
+                              description: |-
+                                RouteMetric is used to prioritize routes for devices. A lower metric for
+                                an interface will have a higher priority.
+                              type: integer
+                            sendHostname:
+                              description: |-
+                                SendHostname when `true`, the hostname of the machine will be sent to the
+                                DHCP server.
+                              type: boolean
+                            useDNS:
+                              description: |-
+                                UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                take precedence.
+                              type: boolean
+                            useDomains:
+                              description: |-
+                                UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                the domain name from the DHCP server will be used as the DNS search
+                                domain for this device. When `route`, the domain name from the DHCP
+                                response will be used for routing DNS only, not for searching.
+                              type: string
+                            useHostname:
+                              description: |-
+                                UseHostname when `true`, the hostname from the DHCP server will be set
+                                as the transient hostname of the machine.
+                              type: boolean
+                            useMTU:
+                              description: |-
+                                UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                MTU of the device.
+                              type: boolean
+                            useNTP:
+                              description: |-
+                                UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                by systemd-timesyncd and take precedence.
+                              type: boolean
+                            useRoutes:
+                              description: |-
+                                UseRoutes when `true`, the routes from the DHCP server will be installed
+                                in the routing table.
+                              type: string
+                          type: object
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: NetworkName is the network name for this machine's
+                            VM.
+                          type: string
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - networkName
+                    x-kubernetes-list-type: map
+                  networks:
+                    description: Networks is the list of networks within this failure
+                      domain
+                    items:
+                      type: string
+                    type: array
+                required:
+                - datacenter
+                type: object
+              zone:
+                description: Zone defines the name and type of a zone
+                properties:
+                  autoConfigure:
+                    description: |-
+                      AutoConfigure tags the Type which is specified in the Topology
+
+                      Deprecated: This field is going to be removed in a future release.
+                    type: boolean
+                  name:
+                    description: Name is the name of the tag that represents this
+                      failure domain
+                    type: string
+                  tagCategory:
+                    description: TagCategory is the category used for the tag
+                    type: string
+                  type:
+                    description: Type is the type of failure domain, the current values
+                      are "Datacenter", "ComputeCluster" and "HostGroup"
+                    enum:
+                    - Datacenter
+                    - ComputeCluster
+                    - HostGroup
+                    type: string
+                required:
+                - name
+                - tagCategory
+                - type
+                type: object
+            required:
+            - region
+            - topology
+            - zone
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachineconfigpools.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachineconfigpools.yaml
@@ -112,7 +112,7 @@ spec:
                         kubeadm nodeRegistration.name and the kubelet serving certificate DNS SAN.
                       maxLength: 253
                       minLength: 1
-                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
                     network:
                       description: Network describes the primary and additional network

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachineconfigpools.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachineconfigpools.yaml
@@ -1,0 +1,472 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vspheremachineconfigpools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereMachineConfigPool
+    listKind: VSphereMachineConfigPoolList
+    plural: vspheremachineconfigpools
+    singular: vspheremachineconfigpool
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachineConfigPool is the Schema for the vspheremachineconfigpools
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineConfigPoolSpec defines the desired state of
+              VSphereMachineConfigPool.
+            properties:
+              clusterRef:
+                description: |-
+                  ClusterRef references the CAPI Cluster (in the same namespace) whose
+                  VSphereCluster provides vCenter server, thumbprint, and credential
+                  chain (IdentityRef) for this pool's vCenter operations (e.g. disk
+                  reclaim). Required. Can only be changed when consumerRef is nil.
+                  The pool will not reconcile until the referenced Cluster and its
+                  VSphereCluster infrastructure are available.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              configs:
+                description: Configs is the list of pre-defined machine configuration
+                  slots.
+                items:
+                  description: MachineConfigSlot defines a single machine configuration
+                    slot in the pool.
+                  properties:
+                    datacenter:
+                      description: |-
+                        Datacenter is the vSphere datacenter for this slot.
+                        If set, it takes precedence over VSphereMachineConfigPool.spec.datacenter.
+                        If unset, the pool-level Datacenter acts as the default.
+                      type: string
+                    hostname:
+                      description: |-
+                        Hostname is the unique identifier for this slot and will be assigned to the VM.
+                        It must also be a valid Kubernetes node name because CAPV uses it for
+                        kubeadm nodeRegistration.name and the kubelet serving certificate DNS SAN.
+                      maxLength: 253
+                      minLength: 1
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    network:
+                      description: Network describes the primary and additional network
+                        configurations for this slot.
+                      properties:
+                        additional:
+                          description: Additional are the remaining network configurations
+                            attached after the primary device.
+                          items:
+                            description: NetworkConfig defines the network configuration
+                              for a slot device.
+                            properties:
+                              deviceName:
+                                description: DeviceName explicitly assigns a guest
+                                  OS interface name to the network device.
+                                type: string
+                              dns:
+                                description: DNS nameservers
+                                items:
+                                  type: string
+                                type: array
+                              gateway:
+                                type: string
+                              ip:
+                                description: IPv4 configuration
+                                type: string
+                              ipv6:
+                                description: IPv6 configuration
+                                type: string
+                              ipv6Gateway:
+                                type: string
+                              networkName:
+                                description: NetworkName is the name of the vSphere
+                                  network (PortGroup or DVPortGroup).
+                                type: string
+                            required:
+                            - networkName
+                            type: object
+                          type: array
+                        primary:
+                          description: Primary is the network configuration used for
+                            kubelet node IP registration.
+                          properties:
+                            deviceName:
+                              description: DeviceName explicitly assigns a guest OS
+                                interface name to the network device.
+                              type: string
+                            dns:
+                              description: DNS nameservers
+                              items:
+                                type: string
+                              type: array
+                            gateway:
+                              type: string
+                            ip:
+                              description: IPv4 configuration
+                              type: string
+                            ipv6:
+                              description: IPv6 configuration
+                              type: string
+                            ipv6Gateway:
+                              type: string
+                            networkName:
+                              description: NetworkName is the name of the vSphere
+                                network (PortGroup or DVPortGroup).
+                              type: string
+                          required:
+                          - networkName
+                          type: object
+                      required:
+                      - primary
+                      type: object
+                    persistentDisks:
+                      description: PersistentDisks that survive VM deletion.
+                      items:
+                        description: PersistentDisk defines a disk that survives VM
+                          deletion.
+                        properties:
+                          datastore:
+                            description: Datastore is the vSphere datastore name.
+                            type: string
+                          diskUUID:
+                            description: DiskUUID is backfilled by the controller.
+                            type: string
+                          fsFormat:
+                            description: FSFormat is the filesystem format (default
+                              "ext4").
+                            type: string
+                          mountOptions:
+                            description: MountOptions for the filesystem mount.
+                            items:
+                              type: string
+                            type: array
+                          mountPath:
+                            description: MountPath is the mount path inside the VM
+                              guest OS (e.g., "/var/lib/etcd").
+                            type: string
+                          name:
+                            description: Name is the disk name.
+                            type: string
+                          sizeGiB:
+                            description: SizeGiB is the disk size.
+                            format: int32
+                            type: integer
+                          storagePolicy:
+                            description: StoragePolicy is the vSphere storage policy
+                              name.
+                            type: string
+                          unitNumber:
+                            description: |-
+                              UnitNumber is the SCSI unit number for the disk (0-15, excluding 7).
+                              This ensures consistent disk ordering across VM recreations.
+                            format: int32
+                            type: integer
+                          volumePath:
+                            description: |-
+                              VolumePath is backfilled by the controller after the disk is created.
+                              For vSphere, this is usually the datastore path to the .vmdk file.
+                            type: string
+                          wipeFilesystem:
+                            description: |-
+                              WipeFilesystem controls whether to wipe the filesystem content when the
+                              slot is reused by a new VM. When true, the disk content is cleared on
+                              the first boot of a new VM (reboots and manual service restarts are not
+                              affected). Defaults to false (data is preserved across VM recreations).
+                            type: boolean
+                        required:
+                        - name
+                        - sizeGiB
+                        type: object
+                      type: array
+                  required:
+                  - hostname
+                  type: object
+                type: array
+              datacenter:
+                description: |-
+                  Datacenter is the default vSphere datacenter for slots in this pool.
+                  It is used when a slot does not define its own Datacenter.
+                type: string
+              releaseDelayHours:
+                description: |-
+                  ReleaseDelayHours is the time to wait before marking a released slot as "Available" for any machine.
+                  During this period, the slot can only be reused if specifically requested or via priority reuse.
+                  Default is 24.
+                type: integer
+            required:
+            - clusterRef
+            - configs
+            type: object
+          status:
+            description: VSphereMachineConfigPoolStatus defines the observed state
+              of VSphereMachineConfigPool.
+            properties:
+              conditions:
+                description: Conditions defines current state of the machine config
+                  pool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              configStatuses:
+                description: ConfigStatuses tracks the state of each slot.
+                items:
+                  description: MachineConfigSlotStatus tracks the state of a single
+                    slot.
+                  properties:
+                    hostname:
+                      description: Hostname matches the Hostname in the Spec.
+                      type: string
+                    lastReleasedTime:
+                      description: LastReleasedTime is the timestamp when the slot
+                        transitioned to Released.
+                      format: date-time
+                      type: string
+                    machineRef:
+                      description: MachineRef is the reference to the Machine currently
+                        using this slot.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          type: string
+                        resourceVersion:
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        uid:
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    reclaimStatus:
+                      description: ReclaimStatus tracks asynchronous reclaim progress
+                        for this slot.
+                      properties:
+                        lastError:
+                          description: LastError stores the latest reclaim task failure.
+                          type: string
+                        retryAfter:
+                          description: RetryAfter prevents tight retry loops after
+                            reclaim task failures.
+                          format: date-time
+                          type: string
+                        state:
+                          description: State tracks the lifecycle of the reclaim task.
+                          enum:
+                          - Running
+                          - Failed
+                          - Completed
+                          type: string
+                        taskRef:
+                          description: TaskRef tracks the in-flight vCenter reclaim
+                            task for this slot.
+                          type: string
+                        volumePath:
+                          description: VolumePath tracks the persistent disk currently
+                            being reclaimed.
+                          type: string
+                      type: object
+                    state:
+                      description: State is the allocation state of the slot.
+                      enum:
+                      - Available
+                      - InUse
+                      - Released
+                      type: string
+                  required:
+                  - hostname
+                  - state
+                  type: object
+                type: array
+              consumerRef:
+                description: |-
+                  ConsumerRef is the workload controller (KubeadmControlPlane or MachineDeployment)
+                  currently bound to this pool. Set automatically by the controller when a machine
+                  allocates a slot. Cleared when the pool becomes fully reusable.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1230,8 +1230,8 @@ spec:
                               type: boolean
                             useRoutes:
                               description: |-
-                                UseRoutes when `true`, the routes from the DHCP server will be installed
-                                in the routing table.
+                                UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                the routes from the DHCP server will be installed in the routing table.
                               type: string
                           type: object
                         dhcp6:
@@ -1293,8 +1293,8 @@ spec:
                               type: boolean
                             useRoutes:
                               description: |-
-                                UseRoutes when `true`, the routes from the DHCP server will be installed
-                                in the routing table.
+                                UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                the routes from the DHCP server will be installed in the routing table.
                               type: string
                           type: object
                         gateway4:

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -155,7 +155,7 @@ spec:
                           type: string
                         gateway6:
                           description: |-
-                            Gateway4 is the IPv4 gateway used by this device.
+                            Gateway6 is the IPv6 gateway used by this device.
                             Required when DHCP6 is false.
                           type: string
                         ipAddrs:
@@ -268,8 +268,7 @@ spec:
                 type: integer
               numCoresPerSocket:
                 description: |-
-                  NumCPUs is the number of cores among which to distribute CPUs in this
-                  virtual machine.
+                  NumCoresPerSocket is the number of cores per socket in a virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32
@@ -597,7 +596,7 @@ spec:
                           type: string
                         gateway6:
                           description: |-
-                            Gateway4 is the IPv4 gateway used by this device.
+                            Gateway6 is the IPv6 gateway used by this device.
                             Required when DHCP6 is false.
                           type: string
                         ipAddrs:
@@ -710,8 +709,7 @@ spec:
                 type: integer
               numCoresPerSocket:
                 description: |-
-                  NumCPUs is the number of cores among which to distribute CPUs in this
-                  virtual machine.
+                  NumCoresPerSocket is the number of cores per socket in a virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32
@@ -1303,7 +1301,7 @@ spec:
                             Required when DHCP4 is false.
                           type: string
                         gateway6:
-                          description: Gateway4 is the IPv4 gateway used by this device.
+                          description: Gateway6 is the IPv6 gateway used by this device.
                           type: string
                         ipAddrs:
                           description: |-
@@ -1423,8 +1421,7 @@ spec:
                 type: integer
               numCoresPerSocket:
                 description: |-
-                  NumCPUs is the number of cores among which to distribute CPUs in this
-                  virtual machine.
+                  NumCoresPerSocket is the number of cores per socket in a virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachines.yaml
@@ -1,0 +1,1771 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vspheremachines.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereMachine
+    listKind: VSphereMachineList
+    plural: vspheremachines
+    singular: vspheremachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster to which this VSphereMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: VSphereMachine instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns this VSphereMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      priority: 1
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereMachine is the Schema for the vspheremachines API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineSpec defines the desired state of VSphereMachine
+            properties:
+              cloneMode:
+                description: |-
+                  CloneMode specifies the type of clone operation.
+                  The LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone.
+                  When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                  not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                  of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                  Defaults to empty map
+                type: object
+              datacenter:
+                description: |-
+                  Datacenter is the name or inventory path of the datacenter in which the
+                  virtual machine is created/located.
+                type: string
+              datastore:
+                description: |-
+                  Datastore is the name or inventory path of the datastore in which the
+                  virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: |-
+                  DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              failureDomain:
+                description: |-
+                  FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+                  For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
+                type: string
+              folder:
+                description: |-
+                  Folder is the name or inventory path of the folder in which the
+                  virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: |-
+                  MemoryMiB is the size of a virtual machine's memory, in MiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: |
+                      Devices is the list of network devices used by the virtual machine.
+                    items:
+                      description: |-
+                        NetworkDeviceSpec defines the network configuration for a virtual machine's
+                        network device.
+                      properties:
+                        deviceName:
+                          description: |-
+                            DeviceName may be used to explicitly assign a name to the network device
+                            as it exists in the guest operating system.
+                          type: string
+                        dhcp4:
+                          description: |-
+                            DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                            on this device.
+                            If true then IPAddrs should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                            on this device.
+                            If true then IPAddrs should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: |-
+                            IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                            to this device. IP addresses must also specify the segment length in
+                            CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: |-
+                            MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow a MAC address
+                            to be generated.
+                            Please note that this value must use the VMware OUI to work with the
+                            in-tree vSphere cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: |-
+                            NetworkName is the name of the vSphere network to which the device
+                            will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: |-
+                      PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                      server endpoint on this machine
+                    type: string
+                  routes:
+                    description: |-
+                      Routes is a list of optional, static routes applied to the virtual
+                      machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: |-
+                  NumCPUs is the number of virtual processors in a virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: |-
+                  NumCPUs is the number of cores among which to distribute CPUs in this
+                  virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              providerID:
+                description: |-
+                  ProviderID is the virtual machine's BIOS UUID formated as
+                  vsphere://12345678-1234-1234-1234-123456789abc
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePool is the name or inventory path of the resource pool in which
+                  the virtual machine is created/located.
+                type: string
+              server:
+                description: |-
+                  Server is the IP address or FQDN of the vSphere server on which
+                  the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which to create a linked clone.
+                  This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: |-
+                  StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: |-
+                  Template is the name or inventory path of the template used to clone
+                  the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When this is set to empty, this VirtualMachine would be created
+                  without TLS certificate validation of the communication between Cluster API Provider vSphere
+                  and the VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereMachineStatus defines the observed state of VSphereMachine
+            properties:
+              addresses:
+                description: Addresses contains the VSphere instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              network:
+                description: |-
+                  Network returns the network status for each of the machine's configured
+                  network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: |-
+                        Connected is a flag that indicates whether this network is currently
+                        connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this VSphereMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: VSphereMachine instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns this VSphereMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      priority: 1
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereMachine is the Schema for the vspheremachines API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineSpec defines the desired state of VSphereMachine
+            properties:
+              cloneMode:
+                description: |-
+                  CloneMode specifies the type of clone operation.
+                  The LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone.
+                  When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                  not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                  of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                  Defaults to empty map
+                type: object
+              datacenter:
+                description: |-
+                  Datacenter is the name or inventory path of the datacenter in which the
+                  virtual machine is created/located.
+                type: string
+              datastore:
+                description: |-
+                  Datastore is the name or inventory path of the datastore in which the
+                  virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: |-
+                  DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              failureDomain:
+                description: |-
+                  FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+                  For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
+                type: string
+              folder:
+                description: |-
+                  Folder is the name or inventory path of the folder in which the
+                  virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: |-
+                  MemoryMiB is the size of a virtual machine's memory, in MiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: |
+                      Devices is the list of network devices used by the virtual machine.
+                    items:
+                      description: |-
+                        NetworkDeviceSpec defines the network configuration for a virtual machine's
+                        network device.
+                      properties:
+                        deviceName:
+                          description: |-
+                            DeviceName may be used to explicitly assign a name to the network device
+                            as it exists in the guest operating system.
+                          type: string
+                        dhcp4:
+                          description: |-
+                            DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                            on this device.
+                            If true then IPAddrs should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                            on this device.
+                            If true then IPAddrs should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: |-
+                            IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                            to this device. IP addresses must also specify the segment length in
+                            CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: |-
+                            MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow a MAC address
+                            to be generated.
+                            Please note that this value must use the VMware OUI to work with the
+                            in-tree vSphere cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: |-
+                            NetworkName is the name of the vSphere network to which the device
+                            will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: |-
+                      PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                      server endpoint on this machine
+                    type: string
+                  routes:
+                    description: |-
+                      Routes is a list of optional, static routes applied to the virtual
+                      machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: |-
+                  NumCPUs is the number of virtual processors in a virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: |-
+                  NumCPUs is the number of cores among which to distribute CPUs in this
+                  virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              providerID:
+                description: |-
+                  ProviderID is the virtual machine's BIOS UUID formated as
+                  vsphere://12345678-1234-1234-1234-123456789abc
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePool is the name or inventory path of the resource pool in which
+                  the virtual machine is created/located.
+                type: string
+              server:
+                description: |-
+                  Server is the IP address or FQDN of the vSphere server on which
+                  the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which to create a linked clone.
+                  This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: |-
+                  StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: |-
+                  Template is the name or inventory path of the template used to clone
+                  the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When this is set to empty, this VirtualMachine would be created
+                  without TLS certificate validation of the communication between Cluster API Provider vSphere
+                  and the VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereMachineStatus defines the observed state of VSphereMachine
+            properties:
+              addresses:
+                description: Addresses contains the VSphere instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              network:
+                description: |-
+                  Network returns the network status for each of the machine's configured
+                  network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: |-
+                        Connected is a flag that indicates whether this network is currently
+                        connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Cluster to which this VSphereMachine belongs
+      jsonPath: .metadata.labels.cluster\.x-k8s\.io/cluster-name
+      name: Cluster
+      type: string
+    - description: Machine ready status
+      jsonPath: .status.ready
+      name: Ready
+      type: string
+    - description: VSphereMachine instance ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine object which owns with this VSphereMachine
+      jsonPath: .metadata.ownerReferences[?(@.kind=="Machine")].name
+      name: Machine
+      priority: 1
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachine is the Schema for the vspheremachines API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineSpec defines the desired state of VSphereMachine.
+            properties:
+              additionalDisksGiB:
+                description: |-
+                  AdditionalDisksGiB holds the sizes of additional disks of the virtual machine, in GiB
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                items:
+                  format: int32
+                  type: integer
+                type: array
+              cloneMode:
+                description: |-
+                  CloneMode specifies the type of clone operation.
+                  The LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone.
+                  When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                  not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                  of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                  Defaults to empty map
+                type: object
+              dataDisks:
+                description: DataDisks are additional disks to add to the VM that
+                  are not part of the VM's OVA template.
+                items:
+                  description: VSphereDisk is an additional disk to add to the VM
+                    that is not part of the VM OVA template.
+                  properties:
+                    name:
+                      description: |-
+                        Name is used to identify the disk definition. Name is required and needs to be unique so that it can be used to
+                        clearly identify purpose of the disk.
+                      type: string
+                    provisioningMode:
+                      description: |-
+                        ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+                        If not set, the setting will be provided by the default storage policy.
+                      enum:
+                      - Thin
+                      - Thick
+                      - EagerlyZeroed
+                      type: string
+                    sizeGiB:
+                      description: SizeGiB is the size of the disk in GiB.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - sizeGiB
+                  type: object
+                maxItems: 29
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              datacenter:
+                description: |-
+                  Datacenter is the name, inventory path, managed object reference or the managed
+                  object ID of the datacenter in which the virtual machine is created/located.
+                  Defaults to * which selects the default datacenter.
+                type: string
+              datastore:
+                description: |-
+                  Datastore is the name, inventory path, managed object reference or the managed
+                  object ID of the datastore in which the virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: |-
+                  DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              failureDomain:
+                description: |-
+                  FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+                  For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
+                type: string
+              folder:
+                description: |-
+                  Folder is the name, inventory path, managed object reference or the managed
+                  object ID of the folder in which the virtual machine is created/located.
+                type: string
+              guestSoftPowerOffTimeout:
+                description: |-
+                  GuestSoftPowerOffTimeout sets the wait timeout for shutdown in the VM guest.
+                  The VM will be powered off forcibly after the timeout if the VM is still
+                  up and running when the PowerOffMode is set to trySoft.
+
+                  This parameter only applies when the PowerOffMode is set to trySoft.
+
+                  If omitted, the timeout defaults to 5 minutes.
+                type: string
+              hardwareVersion:
+                description: |-
+                  HardwareVersion is the hardware version of the virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                  Check the compatibility with the ESXi version before setting the value.
+                type: string
+              machineConfigPoolRef:
+                description: MachineConfigPoolRef is a reference to the VSphereMachineConfigPool
+                  to use for this machine.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              memoryMiB:
+                description: |-
+                  MemoryMiB is the size of a virtual machine's memory, in MiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int64
+                type: integer
+              namingStrategy:
+                description: NamingStrategy allows configuring the naming strategy
+                  used when calculating the name of the VSphereVM.
+                properties:
+                  template:
+                    description: |-
+                      Template defines the template to use for generating the name of the VSphereVM object.
+                      If not defined, it will fall back to `{{ .machine.name }}`.
+                      The templating has the following data available:
+                      * `.machine.name`: The name of the Machine object.
+                      The templating also has the following funcs available:
+                      * `trimSuffix`: same as strings.TrimSuffix
+                      * `trunc`: truncates a string, e.g. `trunc 2 "hello"` or `trunc -2 "hello"`
+                      Notes:
+                      * While the template offers some flexibility, we would like the name to link to the Machine name
+                        to ensure better user experience when troubleshooting
+                      * Generated names must be valid Kubernetes names as they are used to create a VSphereVM object
+                        and usually also as the name of the Node object.
+                      * Names are automatically truncated at 63 characters. Please note that this can lead to name conflicts,
+                        so we highly recommend to use a template which leads to a name shorter than 63 characters.
+                    type: string
+                type: object
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: |
+                      Devices is the list of network devices used by the virtual machine.
+                    items:
+                      description: |-
+                        NetworkDeviceSpec defines the network configuration for a virtual machine's
+                        network device.
+                      properties:
+                        addressesFromPools:
+                          description: |-
+                            AddressesFromPools is a list of IPAddressPools that should be assigned
+                            to IPAddressClaims. The machine's cloud-init metadata will be populated
+                            with IPAddresses fulfilled by an IPAM provider.
+                          items:
+                            description: |-
+                              TypedLocalObjectReference contains enough information to let you locate the
+                              typed referenced object inside the same namespace.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        deviceName:
+                          description: |-
+                            DeviceName may be used to explicitly assign a name to the network device
+                            as it exists in the guest operating system.
+                          type: string
+                        dhcp4:
+                          description: |-
+                            DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                            on this device.
+                            If true then IPAddrs should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp4Overrides:
+                          description: |-
+                            DHCP4Overrides allows for the control over several DHCP behaviors.
+                            Overrides will only be applied when the corresponding DHCP flag is set.
+                            Only configured values will be sent, omitted values will default to
+                            distribution defaults.
+                            Dependent on support in the network stack for your distribution.
+                            For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname is the name which will be sent to the DHCP server instead of
+                                the machine's hostname.
+                              type: string
+                            routeMetric:
+                              description: |-
+                                RouteMetric is used to prioritize routes for devices. A lower metric for
+                                an interface will have a higher priority.
+                              type: integer
+                            sendHostname:
+                              description: |-
+                                SendHostname when `true`, the hostname of the machine will be sent to the
+                                DHCP server.
+                              type: boolean
+                            useDNS:
+                              description: |-
+                                UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                take precedence.
+                              type: boolean
+                            useDomains:
+                              description: |-
+                                UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                the domain name from the DHCP server will be used as the DNS search
+                                domain for this device. When `route`, the domain name from the DHCP
+                                response will be used for routing DNS only, not for searching.
+                              type: string
+                            useHostname:
+                              description: |-
+                                UseHostname when `true`, the hostname from the DHCP server will be set
+                                as the transient hostname of the machine.
+                              type: boolean
+                            useMTU:
+                              description: |-
+                                UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                MTU of the device.
+                              type: boolean
+                            useNTP:
+                              description: |-
+                                UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                by systemd-timesyncd and take precedence.
+                              type: boolean
+                            useRoutes:
+                              description: |-
+                                UseRoutes when `true`, the routes from the DHCP server will be installed
+                                in the routing table.
+                              type: string
+                          type: object
+                        dhcp6:
+                          description: |-
+                            DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                            on this device.
+                            If true then IPAddrs should not contain any IPv6 addresses.
+                          type: boolean
+                        dhcp6Overrides:
+                          description: |-
+                            DHCP6Overrides allows for the control over several DHCP behaviors.
+                            Overrides will only be applied when the corresponding DHCP flag is set.
+                            Only configured values will be sent, omitted values will default to
+                            distribution defaults.
+                            Dependent on support in the network stack for your distribution.
+                            For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname is the name which will be sent to the DHCP server instead of
+                                the machine's hostname.
+                              type: string
+                            routeMetric:
+                              description: |-
+                                RouteMetric is used to prioritize routes for devices. A lower metric for
+                                an interface will have a higher priority.
+                              type: integer
+                            sendHostname:
+                              description: |-
+                                SendHostname when `true`, the hostname of the machine will be sent to the
+                                DHCP server.
+                              type: boolean
+                            useDNS:
+                              description: |-
+                                UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                take precedence.
+                              type: boolean
+                            useDomains:
+                              description: |-
+                                UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                the domain name from the DHCP server will be used as the DNS search
+                                domain for this device. When `route`, the domain name from the DHCP
+                                response will be used for routing DNS only, not for searching.
+                              type: string
+                            useHostname:
+                              description: |-
+                                UseHostname when `true`, the hostname from the DHCP server will be set
+                                as the transient hostname of the machine.
+                              type: boolean
+                            useMTU:
+                              description: |-
+                                UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                MTU of the device.
+                              type: boolean
+                            useNTP:
+                              description: |-
+                                UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                by systemd-timesyncd and take precedence.
+                              type: boolean
+                            useRoutes:
+                              description: |-
+                                UseRoutes when `true`, the routes from the DHCP server will be installed
+                                in the routing table.
+                              type: string
+                          type: object
+                        gateway4:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                          type: string
+                        ipAddrs:
+                          description: |-
+                            IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                            to this device. IP addresses must also specify the segment length in
+                            CIDR notation.
+                            Required when DHCP4, DHCP6 and SkipIPAllocation are false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: |-
+                            MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow a MAC address
+                            to be generated.
+                            Please note that this value must use the VMware OUI to work with the
+                            in-tree vSphere cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: |-
+                            NetworkName is the name, managed object reference or the managed
+                            object ID of the vSphere network to which the device will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                        skipIPAllocation:
+                          description: |-
+                            SkipIPAllocation allows the device to not have IP address or DHCP configured.
+                            This is suitable for devices for which IP allocation is handled externally, eg. using Multus CNI.
+                            If true, CAPV will not verify IP address allocation.
+                          type: boolean
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: |-
+                      PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                      server endpoint on this machine
+
+                      Deprecated: This field is going to be removed in a future release.
+                    type: string
+                  routes:
+                    description: |-
+                      Routes is a list of optional, static routes applied to the virtual
+                      machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: |-
+                  NumCPUs is the number of virtual processors in a virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: |-
+                  NumCPUs is the number of cores among which to distribute CPUs in this
+                  virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              os:
+                description: |-
+                  OS is the Operating System of the virtual machine
+                  Defaults to Linux
+                type: string
+              pciDevices:
+                description: PciDevices is the list of pci devices used by the virtual
+                  machine.
+                items:
+                  description: PCIDeviceSpec defines virtual machine's PCI configuration.
+                  properties:
+                    customLabel:
+                      description: |-
+                        CustomLabel is the hardware label of a virtual machine's PCI device.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                      type: string
+                    deviceId:
+                      description: |-
+                        DeviceID is the device ID of a virtual machine's PCI, in integer.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                        Mutually exclusive with VGPUProfile as VGPUProfile and DeviceID + VendorID
+                        are two independent ways to define PCI devices.
+                      format: int32
+                      type: integer
+                    vGPUProfile:
+                      description: |-
+                        VGPUProfile is the profile name of a virtual machine's vGPU, in string.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                        Mutually exclusive with DeviceID and VendorID as VGPUProfile and DeviceID + VendorID
+                        are two independent ways to define PCI devices.
+                      type: string
+                    vendorId:
+                      description: |-
+                        VendorId is the vendor ID of a virtual machine's PCI, in integer.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                        Mutually exclusive with VGPUProfile as VGPUProfile and DeviceID + VendorID
+                        are two independent ways to define PCI devices.
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
+              powerOffMode:
+                default: hard
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM.
+
+                  There are three, supported power off modes: hard, soft, and
+                  trySoft. The first mode, hard, is the equivalent of a physical
+                  system's power cord being ripped from the wall. The soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully shut down the VM. Its variant, trySoft, first attempts
+                  a graceful shutdown, and if that fails or the VM is not in a powered off
+                  state after reaching the GuestSoftPowerOffTimeout, the VM is halted.
+
+                  If omitted, the mode defaults to hard.
+                enum:
+                - hard
+                - soft
+                - trySoft
+                type: string
+              providerID:
+                description: |-
+                  ProviderID is the virtual machine's BIOS UUID formated as
+                  vsphere://12345678-1234-1234-1234-123456789abc
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePool is the name, inventory path, managed object reference or the managed
+                  object ID in which the virtual machine is created/located.
+                type: string
+              server:
+                description: |-
+                  Server is the IP address or FQDN of the vSphere server on which
+                  the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which to create a linked clone.
+                  This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: |-
+                  StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              tagIDs:
+                description: |-
+                  TagIDs is an optional set of tags to add to an instance. Specified tagIDs
+                  must use URN-notation instead of display names.
+                items:
+                  type: string
+                type: array
+              template:
+                description: |-
+                  Template is the name, inventory path, managed object reference or the managed
+                  object ID of the template used to clone the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When this is set to empty, this VirtualMachine would be created
+                  without TLS certificate validation of the communication between Cluster API Provider vSphere
+                  and the VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereMachineStatus defines the observed state of VSphereMachine.
+            properties:
+              addresses:
+                description: Addresses contains the VSphere instance associated addresses.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions defines current service state of the VSphereMachine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+                type: string
+              network:
+                description: |-
+                  Network returns the network status for each of the machine's configured
+                  network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: |-
+                        Connected is a flag that indicates whether this network is currently
+                        connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: Ready is true when the provider resource is ready.
+                type: boolean
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in VSphereMachine's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a VSphereMachine's current state.
+                      Known condition types are Ready, VirtualMachineProvisioned and Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -264,7 +264,7 @@ spec:
                                   type: string
                                 gateway6:
                                   description: |-
-                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Gateway6 is the IPv6 gateway used by this device.
                                     Required when DHCP6 is false.
                                   type: string
                                 ipAddrs:
@@ -379,8 +379,7 @@ spec:
                         type: integer
                       numCoresPerSocket:
                         description: |-
-                          NumCPUs is the number of cores among which to distribute CPUs in this
-                          virtual machine.
+                          NumCoresPerSocket is the number of cores per socket in a virtual machine.
                           Defaults to the eponymous property value in the template from which the
                           virtual machine is cloned.
                         format: int32
@@ -586,7 +585,7 @@ spec:
                                   type: string
                                 gateway6:
                                   description: |-
-                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Gateway6 is the IPv6 gateway used by this device.
                                     Required when DHCP6 is false.
                                   type: string
                                 ipAddrs:
@@ -701,8 +700,7 @@ spec:
                         type: integer
                       numCoresPerSocket:
                         description: |-
-                          NumCPUs is the number of cores among which to distribute CPUs in this
-                          virtual machine.
+                          NumCoresPerSocket is the number of cores per socket in a virtual machine.
                           Defaults to the eponymous property value in the template from which the
                           virtual machine is cloned.
                         format: int32
@@ -1175,7 +1173,7 @@ spec:
                                     Required when DHCP4 is false.
                                   type: string
                                 gateway6:
-                                  description: Gateway4 is the IPv4 gateway used by
+                                  description: Gateway6 is the IPv6 gateway used by
                                     this device.
                                   type: string
                                 ipAddrs:
@@ -1298,8 +1296,7 @@ spec:
                         type: integer
                       numCoresPerSocket:
                         description: |-
-                          NumCPUs is the number of cores among which to distribute CPUs in this
-                          virtual machine.
+                          NumCoresPerSocket is the number of cores per socket in a virtual machine.
                           Defaults to the eponymous property value in the template from which the
                           virtual machine is cloned.
                         format: int32

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -1102,8 +1102,8 @@ spec:
                                       type: boolean
                                     useRoutes:
                                       description: |-
-                                        UseRoutes when `true`, the routes from the DHCP server will be installed
-                                        in the routing table.
+                                        UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                        the routes from the DHCP server will be installed in the routing table.
                                       type: string
                                   type: object
                                 dhcp6:
@@ -1165,8 +1165,8 @@ spec:
                                       type: boolean
                                     useRoutes:
                                       description: |-
-                                        UseRoutes when `true`, the routes from the DHCP server will be installed
-                                        in the routing table.
+                                        UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                        the routes from the DHCP server will be installed in the routing table.
                                       type: string
                                   type: object
                                 gateway4:

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspheremachinetemplates.yaml
@@ -1,0 +1,1430 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vspheremachinetemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereMachineTemplate
+    listKind: VSphereMachineTemplateList
+    plural: vspheremachinetemplates
+    singular: vspheremachinetemplate
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereMachineTemplate is the Schema for the vspheremachinetemplates API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate
+            properties:
+              template:
+                description: VSphereMachineTemplateResource describes the data needed
+                  to create a VSphereMachine from a template
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      generateName:
+                        description: |-
+                          GenerateName is an optional prefix, used by the server, to generate a unique
+                          name ONLY IF the Name field has not been provided.
+                          If this field is used, the name returned to the client will be different
+                          than the name passed. This value will also be combined with a unique suffix.
+                          The provided value has the same validation rules as the Name field,
+                          and may be truncated by the length of the suffix required to make the value
+                          unique on the server.
+
+                          If this field is specified and the generated name exists, the server will
+                          NOT return a 409 - instead, it will either return 201 Created or 500 with Reason
+                          ServerTimeout indicating a unique name could not be found in the time allotted, and the client
+                          should retry (optionally after the time indicated in the Retry-After header).
+
+                          Applied only if Name is not specified.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                      name:
+                        description: |-
+                          Name must be unique within a namespace. Is required when creating resources, although
+                          some resources may allow a client to request the generation of an appropriate name
+                          automatically. Name is primarily intended for creation idempotence and configuration
+                          definition.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/identifiers#names
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace defines the space within each name must be unique. An empty namespace is
+                          equivalent to the "default" namespace, but "default" is the canonical representation.
+                          Not all objects are required to be scoped to a namespace - the value of this field for
+                          those objects will be empty.
+
+                          Must be a DNS_LABEL.
+                          Cannot be updated.
+                          More info: http://kubernetes.io/docs/user-guide/namespaces
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        type: string
+                      ownerReferences:
+                        description: |-
+                          List of objects depended by this object. If ALL objects in the list have
+                          been deleted, this object will be garbage collected. If this object is managed by a controller,
+                          then an entry in this list will point to this controller, with the controller field set to true.
+                          There cannot be more than one managing controller.
+
+                          Deprecated: This field has no function and is going to be removed in a next release.
+                        items:
+                          description: |-
+                            OwnerReference contains enough information to let you identify an owning
+                            object. An owning object must be in the same namespace as the dependent, or
+                            be cluster-scoped, so there is no namespace field.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            blockOwnerDeletion:
+                              description: |-
+                                If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                the owner cannot be deleted from the key-value store until this
+                                reference is removed.
+                                See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this field and enforces the foreground deletion.
+                                Defaults to false.
+                                To set this field, a user needs "delete" permission of the owner,
+                                otherwise 422 (Unprocessable Entity) will be returned.
+                              type: boolean
+                            controller:
+                              description: If true, this reference points to the managing
+                                controller.
+                              type: boolean
+                            kind:
+                              description: |-
+                                Kind of the referent.
+                                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                              type: string
+                            name:
+                              description: |-
+                                Name of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names
+                              type: string
+                            uid:
+                              description: |-
+                                UID of the referent.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                              type: string
+                          required:
+                          - apiVersion
+                          - kind
+                          - name
+                          - uid
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        type: array
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      cloneMode:
+                        description: |-
+                          CloneMode specifies the type of clone operation.
+                          The LinkedClone mode is only support for templates that have at least
+                          one snapshot. If the template has no snapshots, then CloneMode defaults
+                          to FullClone.
+                          When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                          not possible to expand disks of linked clones.
+                          Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                          of the clone operation has no snapshots.
+                        type: string
+                      customVMXKeys:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                          Defaults to empty map
+                        type: object
+                      datacenter:
+                        description: |-
+                          Datacenter is the name or inventory path of the datacenter in which the
+                          virtual machine is created/located.
+                        type: string
+                      datastore:
+                        description: |-
+                          Datastore is the name or inventory path of the datastore in which the
+                          virtual machine is created/located.
+                        type: string
+                      diskGiB:
+                        description: |-
+                          DiskGiB is the size of a virtual machine's disk, in GiB.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      failureDomain:
+                        description: |-
+                          FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+                          For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
+                        type: string
+                      folder:
+                        description: |-
+                          Folder is the name or inventory path of the folder in which the
+                          virtual machine is created/located.
+                        type: string
+                      memoryMiB:
+                        description: |-
+                          MemoryMiB is the size of a virtual machine's memory, in MiB.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int64
+                        type: integer
+                      network:
+                        description: Network is the network configuration for this
+                          machine's VM.
+                        properties:
+                          devices:
+                            description: |
+                              Devices is the list of network devices used by the virtual machine.
+                            items:
+                              description: |-
+                                NetworkDeviceSpec defines the network configuration for a virtual machine's
+                                network device.
+                              properties:
+                                deviceName:
+                                  description: |-
+                                    DeviceName may be used to explicitly assign a name to the network device
+                                    as it exists in the guest operating system.
+                                  type: string
+                                dhcp4:
+                                  description: |-
+                                    DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                                    on this device.
+                                    If true then IPAddrs should not contain any IPv4 addresses.
+                                  type: boolean
+                                dhcp6:
+                                  description: |-
+                                    DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                                    on this device.
+                                    If true then IPAddrs should not contain any IPv6 addresses.
+                                  type: boolean
+                                gateway4:
+                                  description: |-
+                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Required when DHCP4 is false.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Required when DHCP6 is false.
+                                  type: string
+                                ipAddrs:
+                                  description: |-
+                                    IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                                    to this device. IP addresses must also specify the segment length in
+                                    CIDR notation.
+                                    Required when DHCP4 and DHCP6 are both false.
+                                  items:
+                                    type: string
+                                  type: array
+                                macAddr:
+                                  description: |-
+                                    MACAddr is the MAC address used by this device.
+                                    It is generally a good idea to omit this field and allow a MAC address
+                                    to be generated.
+                                    Please note that this value must use the VMware OUI to work with the
+                                    in-tree vSphere cloud provider.
+                                  type: string
+                                mtu:
+                                  description: MTU is the device’s Maximum Transmission
+                                    Unit size in bytes.
+                                  format: int64
+                                  type: integer
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                                    nameservers.
+                                    Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                networkName:
+                                  description: |-
+                                    NetworkName is the name of the vSphere network to which the device
+                                    will be connected.
+                                  type: string
+                                routes:
+                                  description: Routes is a list of optional, static
+                                    routes applied to the device.
+                                  items:
+                                    description: NetworkRouteSpec defines a static
+                                      network route.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        type: integer
+                                      to:
+                                        description: To is an IPv4 or IPv6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IPv4 or IPv6 address.
+                                        type: string
+                                    required:
+                                    - metric
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of search domains used when resolving IP
+                                    addresses with DNS.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - networkName
+                              type: object
+                            type: array
+                          preferredAPIServerCidr:
+                            description: |-
+                              PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                              server endpoint on this machine
+                            type: string
+                          routes:
+                            description: |-
+                              Routes is a list of optional, static routes applied to the virtual
+                              machine.
+                            items:
+                              description: NetworkRouteSpec defines a static network
+                                route.
+                              properties:
+                                metric:
+                                  description: Metric is the weight/priority of the
+                                    route.
+                                  format: int32
+                                  type: integer
+                                to:
+                                  description: To is an IPv4 or IPv6 address.
+                                  type: string
+                                via:
+                                  description: Via is an IPv4 or IPv6 address.
+                                  type: string
+                              required:
+                              - metric
+                              - to
+                              - via
+                              type: object
+                            type: array
+                        required:
+                        - devices
+                        type: object
+                      numCPUs:
+                        description: |-
+                          NumCPUs is the number of virtual processors in a virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      numCoresPerSocket:
+                        description: |-
+                          NumCPUs is the number of cores among which to distribute CPUs in this
+                          virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      providerID:
+                        description: |-
+                          ProviderID is the virtual machine's BIOS UUID formated as
+                          vsphere://12345678-1234-1234-1234-123456789abc
+                        type: string
+                      resourcePool:
+                        description: |-
+                          ResourcePool is the name or inventory path of the resource pool in which
+                          the virtual machine is created/located.
+                        type: string
+                      server:
+                        description: |-
+                          Server is the IP address or FQDN of the vSphere server on which
+                          the virtual machine is created/located.
+                        type: string
+                      snapshot:
+                        description: |-
+                          Snapshot is the name of the snapshot from which to create a linked clone.
+                          This field is ignored if LinkedClone is not enabled.
+                          Defaults to the source's current snapshot.
+                        type: string
+                      storagePolicyName:
+                        description: |-
+                          StoragePolicyName of the storage policy to use with this
+                          Virtual Machine
+                        type: string
+                      template:
+                        description: |-
+                          Template is the name or inventory path of the template used to clone
+                          the virtual machine.
+                        minLength: 1
+                        type: string
+                      thumbprint:
+                        description: |-
+                          Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                          When this is set to empty, this VirtualMachine would be created
+                          without TLS certificate validation of the communication between Cluster API Provider vSphere
+                          and the VMware vCenter server.
+                        type: string
+                    required:
+                    - network
+                    - template
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+  - deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereMachineTemplate is the Schema for the vspheremachinetemplates API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate
+            properties:
+              template:
+                description: VSphereMachineTemplateResource describes the data needed
+                  to create a VSphereMachine from a template
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      cloneMode:
+                        description: |-
+                          CloneMode specifies the type of clone operation.
+                          The LinkedClone mode is only support for templates that have at least
+                          one snapshot. If the template has no snapshots, then CloneMode defaults
+                          to FullClone.
+                          When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                          not possible to expand disks of linked clones.
+                          Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                          of the clone operation has no snapshots.
+                        type: string
+                      customVMXKeys:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                          Defaults to empty map
+                        type: object
+                      datacenter:
+                        description: |-
+                          Datacenter is the name or inventory path of the datacenter in which the
+                          virtual machine is created/located.
+                        type: string
+                      datastore:
+                        description: |-
+                          Datastore is the name or inventory path of the datastore in which the
+                          virtual machine is created/located.
+                        type: string
+                      diskGiB:
+                        description: |-
+                          DiskGiB is the size of a virtual machine's disk, in GiB.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      failureDomain:
+                        description: |-
+                          FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+                          For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
+                        type: string
+                      folder:
+                        description: |-
+                          Folder is the name or inventory path of the folder in which the
+                          virtual machine is created/located.
+                        type: string
+                      memoryMiB:
+                        description: |-
+                          MemoryMiB is the size of a virtual machine's memory, in MiB.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int64
+                        type: integer
+                      network:
+                        description: Network is the network configuration for this
+                          machine's VM.
+                        properties:
+                          devices:
+                            description: |
+                              Devices is the list of network devices used by the virtual machine.
+                            items:
+                              description: |-
+                                NetworkDeviceSpec defines the network configuration for a virtual machine's
+                                network device.
+                              properties:
+                                deviceName:
+                                  description: |-
+                                    DeviceName may be used to explicitly assign a name to the network device
+                                    as it exists in the guest operating system.
+                                  type: string
+                                dhcp4:
+                                  description: |-
+                                    DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                                    on this device.
+                                    If true then IPAddrs should not contain any IPv4 addresses.
+                                  type: boolean
+                                dhcp6:
+                                  description: |-
+                                    DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                                    on this device.
+                                    If true then IPAddrs should not contain any IPv6 addresses.
+                                  type: boolean
+                                gateway4:
+                                  description: |-
+                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Required when DHCP4 is false.
+                                  type: string
+                                gateway6:
+                                  description: |-
+                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Required when DHCP6 is false.
+                                  type: string
+                                ipAddrs:
+                                  description: |-
+                                    IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                                    to this device. IP addresses must also specify the segment length in
+                                    CIDR notation.
+                                    Required when DHCP4 and DHCP6 are both false.
+                                  items:
+                                    type: string
+                                  type: array
+                                macAddr:
+                                  description: |-
+                                    MACAddr is the MAC address used by this device.
+                                    It is generally a good idea to omit this field and allow a MAC address
+                                    to be generated.
+                                    Please note that this value must use the VMware OUI to work with the
+                                    in-tree vSphere cloud provider.
+                                  type: string
+                                mtu:
+                                  description: MTU is the device’s Maximum Transmission
+                                    Unit size in bytes.
+                                  format: int64
+                                  type: integer
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                                    nameservers.
+                                    Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                networkName:
+                                  description: |-
+                                    NetworkName is the name of the vSphere network to which the device
+                                    will be connected.
+                                  type: string
+                                routes:
+                                  description: Routes is a list of optional, static
+                                    routes applied to the device.
+                                  items:
+                                    description: NetworkRouteSpec defines a static
+                                      network route.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        type: integer
+                                      to:
+                                        description: To is an IPv4 or IPv6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IPv4 or IPv6 address.
+                                        type: string
+                                    required:
+                                    - metric
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of search domains used when resolving IP
+                                    addresses with DNS.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - networkName
+                              type: object
+                            type: array
+                          preferredAPIServerCidr:
+                            description: |-
+                              PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                              server endpoint on this machine
+                            type: string
+                          routes:
+                            description: |-
+                              Routes is a list of optional, static routes applied to the virtual
+                              machine.
+                            items:
+                              description: NetworkRouteSpec defines a static network
+                                route.
+                              properties:
+                                metric:
+                                  description: Metric is the weight/priority of the
+                                    route.
+                                  format: int32
+                                  type: integer
+                                to:
+                                  description: To is an IPv4 or IPv6 address.
+                                  type: string
+                                via:
+                                  description: Via is an IPv4 or IPv6 address.
+                                  type: string
+                              required:
+                              - metric
+                              - to
+                              - via
+                              type: object
+                            type: array
+                        required:
+                        - devices
+                        type: object
+                      numCPUs:
+                        description: |-
+                          NumCPUs is the number of virtual processors in a virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      numCoresPerSocket:
+                        description: |-
+                          NumCPUs is the number of cores among which to distribute CPUs in this
+                          virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      providerID:
+                        description: |-
+                          ProviderID is the virtual machine's BIOS UUID formated as
+                          vsphere://12345678-1234-1234-1234-123456789abc
+                        type: string
+                      resourcePool:
+                        description: |-
+                          ResourcePool is the name or inventory path of the resource pool in which
+                          the virtual machine is created/located.
+                        type: string
+                      server:
+                        description: |-
+                          Server is the IP address or FQDN of the vSphere server on which
+                          the virtual machine is created/located.
+                        type: string
+                      snapshot:
+                        description: |-
+                          Snapshot is the name of the snapshot from which to create a linked clone.
+                          This field is ignored if LinkedClone is not enabled.
+                          Defaults to the source's current snapshot.
+                        type: string
+                      storagePolicyName:
+                        description: |-
+                          StoragePolicyName of the storage policy to use with this
+                          Virtual Machine
+                        type: string
+                      template:
+                        description: |-
+                          Template is the name or inventory path of the template used to clone
+                          the virtual machine.
+                        minLength: 1
+                        type: string
+                      thumbprint:
+                        description: |-
+                          Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                          When this is set to empty, this VirtualMachine would be created
+                          without TLS certificate validation of the communication between Cluster API Provider vSphere
+                          and the VMware vCenter server.
+                        type: string
+                    required:
+                    - network
+                    - template
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: false
+    storage: false
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereMachineTemplate is the Schema for the vspheremachinetemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereMachineTemplateSpec defines the desired state of VSphereMachineTemplate.
+            properties:
+              template:
+                description: VSphereMachineTemplateResource describes the data needed
+                  to create a VSphereMachine from a template.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: Spec is the specification of the desired behavior
+                      of the machine.
+                    properties:
+                      additionalDisksGiB:
+                        description: |-
+                          AdditionalDisksGiB holds the sizes of additional disks of the virtual machine, in GiB
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        items:
+                          format: int32
+                          type: integer
+                        type: array
+                      cloneMode:
+                        description: |-
+                          CloneMode specifies the type of clone operation.
+                          The LinkedClone mode is only support for templates that have at least
+                          one snapshot. If the template has no snapshots, then CloneMode defaults
+                          to FullClone.
+                          When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                          not possible to expand disks of linked clones.
+                          Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                          of the clone operation has no snapshots.
+                        type: string
+                      customVMXKeys:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                          Defaults to empty map
+                        type: object
+                      dataDisks:
+                        description: DataDisks are additional disks to add to the
+                          VM that are not part of the VM's OVA template.
+                        items:
+                          description: VSphereDisk is an additional disk to add to
+                            the VM that is not part of the VM OVA template.
+                          properties:
+                            name:
+                              description: |-
+                                Name is used to identify the disk definition. Name is required and needs to be unique so that it can be used to
+                                clearly identify purpose of the disk.
+                              type: string
+                            provisioningMode:
+                              description: |-
+                                ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+                                If not set, the setting will be provided by the default storage policy.
+                              enum:
+                              - Thin
+                              - Thick
+                              - EagerlyZeroed
+                              type: string
+                            sizeGiB:
+                              description: SizeGiB is the size of the disk in GiB.
+                              format: int32
+                              type: integer
+                          required:
+                          - name
+                          - sizeGiB
+                          type: object
+                        maxItems: 29
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      datacenter:
+                        description: |-
+                          Datacenter is the name, inventory path, managed object reference or the managed
+                          object ID of the datacenter in which the virtual machine is created/located.
+                          Defaults to * which selects the default datacenter.
+                        type: string
+                      datastore:
+                        description: |-
+                          Datastore is the name, inventory path, managed object reference or the managed
+                          object ID of the datastore in which the virtual machine is created/located.
+                        type: string
+                      diskGiB:
+                        description: |-
+                          DiskGiB is the size of a virtual machine's disk, in GiB.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      failureDomain:
+                        description: |-
+                          FailureDomain is the failure domain unique identifier this Machine should be attached to, as defined in Cluster API.
+                          For this infrastructure provider, the name is equivalent to the name of the VSphereDeploymentZone.
+                        type: string
+                      folder:
+                        description: |-
+                          Folder is the name, inventory path, managed object reference or the managed
+                          object ID of the folder in which the virtual machine is created/located.
+                        type: string
+                      guestSoftPowerOffTimeout:
+                        description: |-
+                          GuestSoftPowerOffTimeout sets the wait timeout for shutdown in the VM guest.
+                          The VM will be powered off forcibly after the timeout if the VM is still
+                          up and running when the PowerOffMode is set to trySoft.
+
+                          This parameter only applies when the PowerOffMode is set to trySoft.
+
+                          If omitted, the timeout defaults to 5 minutes.
+                        type: string
+                      hardwareVersion:
+                        description: |-
+                          HardwareVersion is the hardware version of the virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                          Check the compatibility with the ESXi version before setting the value.
+                        type: string
+                      machineConfigPoolRef:
+                        description: MachineConfigPoolRef is a reference to the VSphereMachineConfigPool
+                          to use for this machine.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      memoryMiB:
+                        description: |-
+                          MemoryMiB is the size of a virtual machine's memory, in MiB.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int64
+                        type: integer
+                      namingStrategy:
+                        description: NamingStrategy allows configuring the naming
+                          strategy used when calculating the name of the VSphereVM.
+                        properties:
+                          template:
+                            description: |-
+                              Template defines the template to use for generating the name of the VSphereVM object.
+                              If not defined, it will fall back to `{{ .machine.name }}`.
+                              The templating has the following data available:
+                              * `.machine.name`: The name of the Machine object.
+                              The templating also has the following funcs available:
+                              * `trimSuffix`: same as strings.TrimSuffix
+                              * `trunc`: truncates a string, e.g. `trunc 2 "hello"` or `trunc -2 "hello"`
+                              Notes:
+                              * While the template offers some flexibility, we would like the name to link to the Machine name
+                                to ensure better user experience when troubleshooting
+                              * Generated names must be valid Kubernetes names as they are used to create a VSphereVM object
+                                and usually also as the name of the Node object.
+                              * Names are automatically truncated at 63 characters. Please note that this can lead to name conflicts,
+                                so we highly recommend to use a template which leads to a name shorter than 63 characters.
+                            type: string
+                        type: object
+                      network:
+                        description: Network is the network configuration for this
+                          machine's VM.
+                        properties:
+                          devices:
+                            description: |
+                              Devices is the list of network devices used by the virtual machine.
+                            items:
+                              description: |-
+                                NetworkDeviceSpec defines the network configuration for a virtual machine's
+                                network device.
+                              properties:
+                                addressesFromPools:
+                                  description: |-
+                                    AddressesFromPools is a list of IPAddressPools that should be assigned
+                                    to IPAddressClaims. The machine's cloud-init metadata will be populated
+                                    with IPAddresses fulfilled by an IPAM provider.
+                                  items:
+                                    description: |-
+                                      TypedLocalObjectReference contains enough information to let you locate the
+                                      typed referenced object inside the same namespace.
+                                    properties:
+                                      apiGroup:
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource
+                                          being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource
+                                          being referenced
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                deviceName:
+                                  description: |-
+                                    DeviceName may be used to explicitly assign a name to the network device
+                                    as it exists in the guest operating system.
+                                  type: string
+                                dhcp4:
+                                  description: |-
+                                    DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                                    on this device.
+                                    If true then IPAddrs should not contain any IPv4 addresses.
+                                  type: boolean
+                                dhcp4Overrides:
+                                  description: |-
+                                    DHCP4Overrides allows for the control over several DHCP behaviors.
+                                    Overrides will only be applied when the corresponding DHCP flag is set.
+                                    Only configured values will be sent, omitted values will default to
+                                    distribution defaults.
+                                    Dependent on support in the network stack for your distribution.
+                                    For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the name which will be sent to the DHCP server instead of
+                                        the machine's hostname.
+                                      type: string
+                                    routeMetric:
+                                      description: |-
+                                        RouteMetric is used to prioritize routes for devices. A lower metric for
+                                        an interface will have a higher priority.
+                                      type: integer
+                                    sendHostname:
+                                      description: |-
+                                        SendHostname when `true`, the hostname of the machine will be sent to the
+                                        DHCP server.
+                                      type: boolean
+                                    useDNS:
+                                      description: |-
+                                        UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                        take precedence.
+                                      type: boolean
+                                    useDomains:
+                                      description: |-
+                                        UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                        the domain name from the DHCP server will be used as the DNS search
+                                        domain for this device. When `route`, the domain name from the DHCP
+                                        response will be used for routing DNS only, not for searching.
+                                      type: string
+                                    useHostname:
+                                      description: |-
+                                        UseHostname when `true`, the hostname from the DHCP server will be set
+                                        as the transient hostname of the machine.
+                                      type: boolean
+                                    useMTU:
+                                      description: |-
+                                        UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                        MTU of the device.
+                                      type: boolean
+                                    useNTP:
+                                      description: |-
+                                        UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                        by systemd-timesyncd and take precedence.
+                                      type: boolean
+                                    useRoutes:
+                                      description: |-
+                                        UseRoutes when `true`, the routes from the DHCP server will be installed
+                                        in the routing table.
+                                      type: string
+                                  type: object
+                                dhcp6:
+                                  description: |-
+                                    DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                                    on this device.
+                                    If true then IPAddrs should not contain any IPv6 addresses.
+                                  type: boolean
+                                dhcp6Overrides:
+                                  description: |-
+                                    DHCP6Overrides allows for the control over several DHCP behaviors.
+                                    Overrides will only be applied when the corresponding DHCP flag is set.
+                                    Only configured values will be sent, omitted values will default to
+                                    distribution defaults.
+                                    Dependent on support in the network stack for your distribution.
+                                    For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                                  properties:
+                                    hostname:
+                                      description: |-
+                                        Hostname is the name which will be sent to the DHCP server instead of
+                                        the machine's hostname.
+                                      type: string
+                                    routeMetric:
+                                      description: |-
+                                        RouteMetric is used to prioritize routes for devices. A lower metric for
+                                        an interface will have a higher priority.
+                                      type: integer
+                                    sendHostname:
+                                      description: |-
+                                        SendHostname when `true`, the hostname of the machine will be sent to the
+                                        DHCP server.
+                                      type: boolean
+                                    useDNS:
+                                      description: |-
+                                        UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                        take precedence.
+                                      type: boolean
+                                    useDomains:
+                                      description: |-
+                                        UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                        the domain name from the DHCP server will be used as the DNS search
+                                        domain for this device. When `route`, the domain name from the DHCP
+                                        response will be used for routing DNS only, not for searching.
+                                      type: string
+                                    useHostname:
+                                      description: |-
+                                        UseHostname when `true`, the hostname from the DHCP server will be set
+                                        as the transient hostname of the machine.
+                                      type: boolean
+                                    useMTU:
+                                      description: |-
+                                        UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                        MTU of the device.
+                                      type: boolean
+                                    useNTP:
+                                      description: |-
+                                        UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                        by systemd-timesyncd and take precedence.
+                                      type: boolean
+                                    useRoutes:
+                                      description: |-
+                                        UseRoutes when `true`, the routes from the DHCP server will be installed
+                                        in the routing table.
+                                      type: string
+                                  type: object
+                                gateway4:
+                                  description: |-
+                                    Gateway4 is the IPv4 gateway used by this device.
+                                    Required when DHCP4 is false.
+                                  type: string
+                                gateway6:
+                                  description: Gateway4 is the IPv4 gateway used by
+                                    this device.
+                                  type: string
+                                ipAddrs:
+                                  description: |-
+                                    IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                                    to this device. IP addresses must also specify the segment length in
+                                    CIDR notation.
+                                    Required when DHCP4, DHCP6 and SkipIPAllocation are false.
+                                  items:
+                                    type: string
+                                  type: array
+                                macAddr:
+                                  description: |-
+                                    MACAddr is the MAC address used by this device.
+                                    It is generally a good idea to omit this field and allow a MAC address
+                                    to be generated.
+                                    Please note that this value must use the VMware OUI to work with the
+                                    in-tree vSphere cloud provider.
+                                  type: string
+                                mtu:
+                                  description: MTU is the device’s Maximum Transmission
+                                    Unit size in bytes.
+                                  format: int64
+                                  type: integer
+                                nameservers:
+                                  description: |-
+                                    Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                                    nameservers.
+                                    Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                                  items:
+                                    type: string
+                                  type: array
+                                networkName:
+                                  description: |-
+                                    NetworkName is the name, managed object reference or the managed
+                                    object ID of the vSphere network to which the device will be connected.
+                                  type: string
+                                routes:
+                                  description: Routes is a list of optional, static
+                                    routes applied to the device.
+                                  items:
+                                    description: NetworkRouteSpec defines a static
+                                      network route.
+                                    properties:
+                                      metric:
+                                        description: Metric is the weight/priority
+                                          of the route.
+                                        format: int32
+                                        type: integer
+                                      to:
+                                        description: To is an IPv4 or IPv6 address.
+                                        type: string
+                                      via:
+                                        description: Via is an IPv4 or IPv6 address.
+                                        type: string
+                                    required:
+                                    - metric
+                                    - to
+                                    - via
+                                    type: object
+                                  type: array
+                                searchDomains:
+                                  description: |-
+                                    SearchDomains is a list of search domains used when resolving IP
+                                    addresses with DNS.
+                                  items:
+                                    type: string
+                                  type: array
+                                skipIPAllocation:
+                                  description: |-
+                                    SkipIPAllocation allows the device to not have IP address or DHCP configured.
+                                    This is suitable for devices for which IP allocation is handled externally, eg. using Multus CNI.
+                                    If true, CAPV will not verify IP address allocation.
+                                  type: boolean
+                              required:
+                              - networkName
+                              type: object
+                            type: array
+                          preferredAPIServerCidr:
+                            description: |-
+                              PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                              server endpoint on this machine
+
+                              Deprecated: This field is going to be removed in a future release.
+                            type: string
+                          routes:
+                            description: |-
+                              Routes is a list of optional, static routes applied to the virtual
+                              machine.
+                            items:
+                              description: NetworkRouteSpec defines a static network
+                                route.
+                              properties:
+                                metric:
+                                  description: Metric is the weight/priority of the
+                                    route.
+                                  format: int32
+                                  type: integer
+                                to:
+                                  description: To is an IPv4 or IPv6 address.
+                                  type: string
+                                via:
+                                  description: Via is an IPv4 or IPv6 address.
+                                  type: string
+                              required:
+                              - metric
+                              - to
+                              - via
+                              type: object
+                            type: array
+                        required:
+                        - devices
+                        type: object
+                      numCPUs:
+                        description: |-
+                          NumCPUs is the number of virtual processors in a virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      numCoresPerSocket:
+                        description: |-
+                          NumCPUs is the number of cores among which to distribute CPUs in this
+                          virtual machine.
+                          Defaults to the eponymous property value in the template from which the
+                          virtual machine is cloned.
+                        format: int32
+                        type: integer
+                      os:
+                        description: |-
+                          OS is the Operating System of the virtual machine
+                          Defaults to Linux
+                        type: string
+                      pciDevices:
+                        description: PciDevices is the list of pci devices used by
+                          the virtual machine.
+                        items:
+                          description: PCIDeviceSpec defines virtual machine's PCI
+                            configuration.
+                          properties:
+                            customLabel:
+                              description: |-
+                                CustomLabel is the hardware label of a virtual machine's PCI device.
+                                Defaults to the eponymous property value in the template from which the
+                                virtual machine is cloned.
+                              type: string
+                            deviceId:
+                              description: |-
+                                DeviceID is the device ID of a virtual machine's PCI, in integer.
+                                Defaults to the eponymous property value in the template from which the
+                                virtual machine is cloned.
+                                Mutually exclusive with VGPUProfile as VGPUProfile and DeviceID + VendorID
+                                are two independent ways to define PCI devices.
+                              format: int32
+                              type: integer
+                            vGPUProfile:
+                              description: |-
+                                VGPUProfile is the profile name of a virtual machine's vGPU, in string.
+                                Defaults to the eponymous property value in the template from which the
+                                virtual machine is cloned.
+                                Mutually exclusive with DeviceID and VendorID as VGPUProfile and DeviceID + VendorID
+                                are two independent ways to define PCI devices.
+                              type: string
+                            vendorId:
+                              description: |-
+                                VendorId is the vendor ID of a virtual machine's PCI, in integer.
+                                Defaults to the eponymous property value in the template from which the
+                                virtual machine is cloned.
+                                Mutually exclusive with VGPUProfile as VGPUProfile and DeviceID + VendorID
+                                are two independent ways to define PCI devices.
+                              format: int32
+                              type: integer
+                          type: object
+                        type: array
+                      powerOffMode:
+                        default: hard
+                        description: |-
+                          PowerOffMode describes the desired behavior when powering off a VM.
+
+                          There are three, supported power off modes: hard, soft, and
+                          trySoft. The first mode, hard, is the equivalent of a physical
+                          system's power cord being ripped from the wall. The soft mode
+                          requires the VM's guest to have VM Tools installed and attempts to
+                          gracefully shut down the VM. Its variant, trySoft, first attempts
+                          a graceful shutdown, and if that fails or the VM is not in a powered off
+                          state after reaching the GuestSoftPowerOffTimeout, the VM is halted.
+
+                          If omitted, the mode defaults to hard.
+                        enum:
+                        - hard
+                        - soft
+                        - trySoft
+                        type: string
+                      providerID:
+                        description: |-
+                          ProviderID is the virtual machine's BIOS UUID formated as
+                          vsphere://12345678-1234-1234-1234-123456789abc
+                        type: string
+                      resourcePool:
+                        description: |-
+                          ResourcePool is the name, inventory path, managed object reference or the managed
+                          object ID in which the virtual machine is created/located.
+                        type: string
+                      server:
+                        description: |-
+                          Server is the IP address or FQDN of the vSphere server on which
+                          the virtual machine is created/located.
+                        type: string
+                      snapshot:
+                        description: |-
+                          Snapshot is the name of the snapshot from which to create a linked clone.
+                          This field is ignored if LinkedClone is not enabled.
+                          Defaults to the source's current snapshot.
+                        type: string
+                      storagePolicyName:
+                        description: |-
+                          StoragePolicyName of the storage policy to use with this
+                          Virtual Machine
+                        type: string
+                      tagIDs:
+                        description: |-
+                          TagIDs is an optional set of tags to add to an instance. Specified tagIDs
+                          must use URN-notation instead of display names.
+                        items:
+                          type: string
+                        type: array
+                      template:
+                        description: |-
+                          Template is the name, inventory path, managed object reference or the managed
+                          object ID of the template used to clone the virtual machine.
+                        minLength: 1
+                        type: string
+                      thumbprint:
+                        description: |-
+                          Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                          When this is set to empty, this VirtualMachine would be created
+                          without TLS certificate validation of the communication between Cluster API Provider vSphere
+                          and the VMware vCenter server.
+                        type: string
+                    required:
+                    - network
+                    - template
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -1,0 +1,1803 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  name: vspherevms.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereVM
+    listKind: VSphereVMList
+    plural: vspherevms
+    singular: vspherevm
+  scope: Namespaced
+  versions:
+  - deprecated: true
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereVM is the Schema for the vspherevms API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereVMSpec defines the desired state of VSphereVM.
+            properties:
+              biosUUID:
+                description: |-
+                  BiosUUID is the VM's BIOS UUID that is assigned at runtime after
+                  the VM has been created.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                type: string
+              bootstrapRef:
+                description: |-
+                  BootstrapRef is a reference to a bootstrap provider-specific resource
+                  that holds configuration details.
+                  This field is optional in case no bootstrap data is required to create
+                  a VM.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              cloneMode:
+                description: |-
+                  CloneMode specifies the type of clone operation.
+                  The LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone.
+                  When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                  not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                  of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                  Defaults to empty map
+                type: object
+              datacenter:
+                description: |-
+                  Datacenter is the name or inventory path of the datacenter in which the
+                  virtual machine is created/located.
+                type: string
+              datastore:
+                description: |-
+                  Datastore is the name or inventory path of the datastore in which the
+                  virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: |-
+                  DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              folder:
+                description: |-
+                  Folder is the name or inventory path of the folder in which the
+                  virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: |-
+                  MemoryMiB is the size of a virtual machine's memory, in MiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: |
+                      Devices is the list of network devices used by the virtual machine.
+                    items:
+                      description: |-
+                        NetworkDeviceSpec defines the network configuration for a virtual machine's
+                        network device.
+                      properties:
+                        deviceName:
+                          description: |-
+                            DeviceName may be used to explicitly assign a name to the network device
+                            as it exists in the guest operating system.
+                          type: string
+                        dhcp4:
+                          description: |-
+                            DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                            on this device.
+                            If true then IPAddrs should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                            on this device.
+                            If true then IPAddrs should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: |-
+                            IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                            to this device. IP addresses must also specify the segment length in
+                            CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: |-
+                            MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow a MAC address
+                            to be generated.
+                            Please note that this value must use the VMware OUI to work with the
+                            in-tree vSphere cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: |-
+                            NetworkName is the name of the vSphere network to which the device
+                            will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: |-
+                      PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                      server endpoint on this machine
+                    type: string
+                  routes:
+                    description: |-
+                      Routes is a list of optional, static routes applied to the virtual
+                      machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: |-
+                  NumCPUs is the number of virtual processors in a virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: |-
+                  NumCPUs is the number of cores among which to distribute CPUs in this
+                  virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              resourcePool:
+                description: |-
+                  ResourcePool is the name or inventory path of the resource pool in which
+                  the virtual machine is created/located.
+                type: string
+              server:
+                description: |-
+                  Server is the IP address or FQDN of the vSphere server on which
+                  the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which to create a linked clone.
+                  This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: |-
+                  StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: |-
+                  Template is the name or inventory path of the template used to clone
+                  the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When this is set to empty, this VirtualMachine would be created
+                  without TLS certificate validation of the communication between Cluster API Provider vSphere
+                  and the VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereVMStatus defines the observed state of VSphereVM
+            properties:
+              addresses:
+                description: |-
+                  Addresses is a list of the VM's IP addresses.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                items:
+                  type: string
+                type: array
+              cloneMode:
+                description: |-
+                  CloneMode is the type of clone operation used to clone this VM. Since
+                  LinkedMode is the default but fails gracefully if the source of the
+                  clone has no snapshots, this field may be used to determine the actual
+                  type of clone operation used to create this VM.
+                type: string
+              conditions:
+                description: Conditions defines current service state of the VSphereVM.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the vspherevm and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the vm.
+
+                  Any transient errors that occur during the reconciliation of vspherevms
+                  can be added as events to the vspherevm object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the vspherevm and will contain a succinct value suitable
+                  for vm interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the vm.
+
+                  Any transient errors that occur during the reconciliation of vspherevms
+                  can be added as events to the vspherevm object and/or logged in the
+                  controller's output.
+                type: string
+              network:
+                description: |-
+                  Network returns the network status for each of the machine's configured
+                  network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: |-
+                        Connected is a flag that indicates whether this network is currently
+                        connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: |-
+                  Ready is true when the provider resource is ready.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                type: boolean
+              retryAfter:
+                description: RetryAfter tracks the time we can retry queueing a task
+                format: date-time
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which the VM was cloned if
+                  LinkedMode is enabled.
+                type: string
+              taskRef:
+                description: |-
+                  TaskRef is a managed object reference to a Task related to the machine.
+                  This value is set automatically at runtime and should not be set or
+                  modified by users.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - deprecated: true
+    name: v1alpha4
+    schema:
+      openAPIV3Schema:
+        description: |-
+          VSphereVM is the Schema for the vspherevms API
+
+          Deprecated: This type will be removed in one of the next releases.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereVMSpec defines the desired state of VSphereVM.
+            properties:
+              biosUUID:
+                description: |-
+                  BiosUUID is the VM's BIOS UUID that is assigned at runtime after
+                  the VM has been created.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                type: string
+              bootstrapRef:
+                description: |-
+                  BootstrapRef is a reference to a bootstrap provider-specific resource
+                  that holds configuration details.
+                  This field is optional in case no bootstrap data is required to create
+                  a VM.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              cloneMode:
+                description: |-
+                  CloneMode specifies the type of clone operation.
+                  The LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone.
+                  When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                  not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                  of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                  Defaults to empty map
+                type: object
+              datacenter:
+                description: |-
+                  Datacenter is the name or inventory path of the datacenter in which the
+                  virtual machine is created/located.
+                type: string
+              datastore:
+                description: |-
+                  Datastore is the name or inventory path of the datastore in which the
+                  virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: |-
+                  DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              folder:
+                description: |-
+                  Folder is the name or inventory path of the folder in which the
+                  virtual machine is created/located.
+                type: string
+              memoryMiB:
+                description: |-
+                  MemoryMiB is the size of a virtual machine's memory, in MiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: |
+                      Devices is the list of network devices used by the virtual machine.
+                    items:
+                      description: |-
+                        NetworkDeviceSpec defines the network configuration for a virtual machine's
+                        network device.
+                      properties:
+                        deviceName:
+                          description: |-
+                            DeviceName may be used to explicitly assign a name to the network device
+                            as it exists in the guest operating system.
+                          type: string
+                        dhcp4:
+                          description: |-
+                            DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                            on this device.
+                            If true then IPAddrs should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp6:
+                          description: |-
+                            DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                            on this device.
+                            If true then IPAddrs should not contain any IPv6 addresses.
+                          type: boolean
+                        gateway4:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP6 is false.
+                          type: string
+                        ipAddrs:
+                          description: |-
+                            IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                            to this device. IP addresses must also specify the segment length in
+                            CIDR notation.
+                            Required when DHCP4 and DHCP6 are both false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: |-
+                            MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow a MAC address
+                            to be generated.
+                            Please note that this value must use the VMware OUI to work with the
+                            in-tree vSphere cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: |-
+                            NetworkName is the name of the vSphere network to which the device
+                            will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: |-
+                      PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                      server endpoint on this machine
+                    type: string
+                  routes:
+                    description: |-
+                      Routes is a list of optional, static routes applied to the virtual
+                      machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: |-
+                  NumCPUs is the number of virtual processors in a virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: |-
+                  NumCPUs is the number of cores among which to distribute CPUs in this
+                  virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              resourcePool:
+                description: |-
+                  ResourcePool is the name or inventory path of the resource pool in which
+                  the virtual machine is created/located.
+                type: string
+              server:
+                description: |-
+                  Server is the IP address or FQDN of the vSphere server on which
+                  the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which to create a linked clone.
+                  This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: |-
+                  StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              template:
+                description: |-
+                  Template is the name or inventory path of the template used to clone
+                  the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When this is set to empty, this VirtualMachine would be created
+                  without TLS certificate validation of the communication between Cluster API Provider vSphere
+                  and the VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereVMStatus defines the observed state of VSphereVM
+            properties:
+              addresses:
+                description: |-
+                  Addresses is a list of the VM's IP addresses.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                items:
+                  type: string
+                type: array
+              cloneMode:
+                description: |-
+                  CloneMode is the type of clone operation used to clone this VM. Since
+                  LinkedMode is the default but fails gracefully if the source of the
+                  clone has no snapshots, this field may be used to determine the actual
+                  type of clone operation used to create this VM.
+                type: string
+              conditions:
+                description: Conditions defines current service state of the VSphereVM.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the vspherevm and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the vm.
+
+                  Any transient errors that occur during the reconciliation of vspherevms
+                  can be added as events to the vspherevm object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the vspherevm and will contain a succinct value suitable
+                  for vm interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the vm.
+
+                  Any transient errors that occur during the reconciliation of vspherevms
+                  can be added as events to the vspherevm object and/or logged in the
+                  controller's output.
+                type: string
+              network:
+                description: |-
+                  Network returns the network status for each of the machine's configured
+                  network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: |-
+                        Connected is a flag that indicates whether this network is currently
+                        connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: |-
+                  Ready is true when the provider resource is ready.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                type: boolean
+              retryAfter:
+                description: RetryAfter tracks the time we can retry queueing a task
+                format: date-time
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which the VM was cloned if
+                  LinkedMode is enabled.
+                type: string
+              taskRef:
+                description: |-
+                  TaskRef is a managed object reference to a Task related to the machine.
+                  This value is set automatically at runtime and should not be set or
+                  modified by users.
+                type: string
+            type: object
+        type: object
+    served: false
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereVM is the Schema for the vspherevms API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereVMSpec defines the desired state of VSphereVM.
+            properties:
+              additionalDisksGiB:
+                description: |-
+                  AdditionalDisksGiB holds the sizes of additional disks of the virtual machine, in GiB
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                items:
+                  format: int32
+                  type: integer
+                type: array
+              biosUUID:
+                description: |-
+                  BiosUUID is the VM's BIOS UUID that is assigned at runtime after
+                  the VM has been created.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                type: string
+              bootstrapRef:
+                description: |-
+                  BootstrapRef is a reference to a bootstrap provider-specific resource
+                  that holds configuration details.
+                  This field is optional in case no bootstrap data is required to create
+                  a VM.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              cloneMode:
+                description: |-
+                  CloneMode specifies the type of clone operation.
+                  The LinkedClone mode is only support for templates that have at least
+                  one snapshot. If the template has no snapshots, then CloneMode defaults
+                  to FullClone.
+                  When LinkedClone mode is enabled the DiskGiB field is ignored as it is
+                  not possible to expand disks of linked clones.
+                  Defaults to LinkedClone, but fails gracefully to FullClone if the source
+                  of the clone operation has no snapshots.
+                type: string
+              customVMXKeys:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CustomVMXKeys is a dictionary of advanced VMX options that can be set on VM
+                  Defaults to empty map
+                type: object
+              dataDisks:
+                description: DataDisks are additional disks to add to the VM that
+                  are not part of the VM's OVA template.
+                items:
+                  description: VSphereDisk is an additional disk to add to the VM
+                    that is not part of the VM OVA template.
+                  properties:
+                    name:
+                      description: |-
+                        Name is used to identify the disk definition. Name is required and needs to be unique so that it can be used to
+                        clearly identify purpose of the disk.
+                      type: string
+                    provisioningMode:
+                      description: |-
+                        ProvisioningMode specifies the provisioning type to be used by this vSphere data disk.
+                        If not set, the setting will be provided by the default storage policy.
+                      enum:
+                      - Thin
+                      - Thick
+                      - EagerlyZeroed
+                      type: string
+                    sizeGiB:
+                      description: SizeGiB is the size of the disk in GiB.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - sizeGiB
+                  type: object
+                maxItems: 29
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              datacenter:
+                description: |-
+                  Datacenter is the name, inventory path, managed object reference or the managed
+                  object ID of the datacenter in which the virtual machine is created/located.
+                  Defaults to * which selects the default datacenter.
+                type: string
+              datastore:
+                description: |-
+                  Datastore is the name, inventory path, managed object reference or the managed
+                  object ID of the datastore in which the virtual machine is created/located.
+                type: string
+              diskGiB:
+                description: |-
+                  DiskGiB is the size of a virtual machine's disk, in GiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              folder:
+                description: |-
+                  Folder is the name, inventory path, managed object reference or the managed
+                  object ID of the folder in which the virtual machine is created/located.
+                type: string
+              guestSoftPowerOffTimeout:
+                description: |-
+                  GuestSoftPowerOffTimeout sets the wait timeout for shutdown in the VM guest.
+                  The VM will be powered off forcibly after the timeout if the VM is still
+                  up and running when the PowerOffMode is set to trySoft.
+
+                  This parameter only applies when the PowerOffMode is set to trySoft.
+
+                  If omitted, the timeout defaults to 5 minutes.
+                type: string
+              hardwareVersion:
+                description: |-
+                  HardwareVersion is the hardware version of the virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                  Check the compatibility with the ESXi version before setting the value.
+                type: string
+              memoryMiB:
+                description: |-
+                  MemoryMiB is the size of a virtual machine's memory, in MiB.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int64
+                type: integer
+              network:
+                description: Network is the network configuration for this machine's
+                  VM.
+                properties:
+                  devices:
+                    description: |
+                      Devices is the list of network devices used by the virtual machine.
+                    items:
+                      description: |-
+                        NetworkDeviceSpec defines the network configuration for a virtual machine's
+                        network device.
+                      properties:
+                        addressesFromPools:
+                          description: |-
+                            AddressesFromPools is a list of IPAddressPools that should be assigned
+                            to IPAddressClaims. The machine's cloud-init metadata will be populated
+                            with IPAddresses fulfilled by an IPAM provider.
+                          items:
+                            description: |-
+                              TypedLocalObjectReference contains enough information to let you locate the
+                              typed referenced object inside the same namespace.
+                            properties:
+                              apiGroup:
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                            - kind
+                            - name
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        deviceName:
+                          description: |-
+                            DeviceName may be used to explicitly assign a name to the network device
+                            as it exists in the guest operating system.
+                          type: string
+                        dhcp4:
+                          description: |-
+                            DHCP4 is a flag that indicates whether or not to use DHCP for IPv4
+                            on this device.
+                            If true then IPAddrs should not contain any IPv4 addresses.
+                          type: boolean
+                        dhcp4Overrides:
+                          description: |-
+                            DHCP4Overrides allows for the control over several DHCP behaviors.
+                            Overrides will only be applied when the corresponding DHCP flag is set.
+                            Only configured values will be sent, omitted values will default to
+                            distribution defaults.
+                            Dependent on support in the network stack for your distribution.
+                            For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname is the name which will be sent to the DHCP server instead of
+                                the machine's hostname.
+                              type: string
+                            routeMetric:
+                              description: |-
+                                RouteMetric is used to prioritize routes for devices. A lower metric for
+                                an interface will have a higher priority.
+                              type: integer
+                            sendHostname:
+                              description: |-
+                                SendHostname when `true`, the hostname of the machine will be sent to the
+                                DHCP server.
+                              type: boolean
+                            useDNS:
+                              description: |-
+                                UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                take precedence.
+                              type: boolean
+                            useDomains:
+                              description: |-
+                                UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                the domain name from the DHCP server will be used as the DNS search
+                                domain for this device. When `route`, the domain name from the DHCP
+                                response will be used for routing DNS only, not for searching.
+                              type: string
+                            useHostname:
+                              description: |-
+                                UseHostname when `true`, the hostname from the DHCP server will be set
+                                as the transient hostname of the machine.
+                              type: boolean
+                            useMTU:
+                              description: |-
+                                UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                MTU of the device.
+                              type: boolean
+                            useNTP:
+                              description: |-
+                                UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                by systemd-timesyncd and take precedence.
+                              type: boolean
+                            useRoutes:
+                              description: |-
+                                UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                the routes from the DHCP server will be installed in the routing table.
+                              type: string
+                          type: object
+                        dhcp6:
+                          description: |-
+                            DHCP6 is a flag that indicates whether or not to use DHCP for IPv6
+                            on this device.
+                            If true then IPAddrs should not contain any IPv6 addresses.
+                          type: boolean
+                        dhcp6Overrides:
+                          description: |-
+                            DHCP6Overrides allows for the control over several DHCP behaviors.
+                            Overrides will only be applied when the corresponding DHCP flag is set.
+                            Only configured values will be sent, omitted values will default to
+                            distribution defaults.
+                            Dependent on support in the network stack for your distribution.
+                            For more information see the netplan reference (https://netplan.io/reference#dhcp-overrides)
+                          properties:
+                            hostname:
+                              description: |-
+                                Hostname is the name which will be sent to the DHCP server instead of
+                                the machine's hostname.
+                              type: string
+                            routeMetric:
+                              description: |-
+                                RouteMetric is used to prioritize routes for devices. A lower metric for
+                                an interface will have a higher priority.
+                              type: integer
+                            sendHostname:
+                              description: |-
+                                SendHostname when `true`, the hostname of the machine will be sent to the
+                                DHCP server.
+                              type: boolean
+                            useDNS:
+                              description: |-
+                                UseDNS when `true`, the DNS servers in the DHCP server will be used and
+                                take precedence.
+                              type: boolean
+                            useDomains:
+                              description: |-
+                                UseDomains can take the values `true`, `false`, or `route`. When `true`,
+                                the domain name from the DHCP server will be used as the DNS search
+                                domain for this device. When `route`, the domain name from the DHCP
+                                response will be used for routing DNS only, not for searching.
+                              type: string
+                            useHostname:
+                              description: |-
+                                UseHostname when `true`, the hostname from the DHCP server will be set
+                                as the transient hostname of the machine.
+                              type: boolean
+                            useMTU:
+                              description: |-
+                                UseMTU when `true`, the MTU from the DHCP server will be set as the
+                                MTU of the device.
+                              type: boolean
+                            useNTP:
+                              description: |-
+                                UseNTP when `true`, the NTP servers from the DHCP server will be used
+                                by systemd-timesyncd and take precedence.
+                              type: boolean
+                            useRoutes:
+                              description: |-
+                                UseRoutes can take the values `true`, `false`, or `route`. When `true`,
+                                the routes from the DHCP server will be installed in the routing table.
+                              type: string
+                          type: object
+                        gateway4:
+                          description: |-
+                            Gateway4 is the IPv4 gateway used by this device.
+                            Required when DHCP4 is false.
+                          type: string
+                        gateway6:
+                          description: Gateway4 is the IPv4 gateway used by this device.
+                          type: string
+                        ipAddrs:
+                          description: |-
+                            IPAddrs is a list of one or more IPv4 and/or IPv6 addresses to assign
+                            to this device. IP addresses must also specify the segment length in
+                            CIDR notation.
+                            Required when DHCP4, DHCP6 and SkipIPAllocation are false.
+                          items:
+                            type: string
+                          type: array
+                        macAddr:
+                          description: |-
+                            MACAddr is the MAC address used by this device.
+                            It is generally a good idea to omit this field and allow a MAC address
+                            to be generated.
+                            Please note that this value must use the VMware OUI to work with the
+                            in-tree vSphere cloud provider.
+                          type: string
+                        mtu:
+                          description: MTU is the device’s Maximum Transmission Unit
+                            size in bytes.
+                          format: int64
+                          type: integer
+                        nameservers:
+                          description: |-
+                            Nameservers is a list of IPv4 and/or IPv6 addresses used as DNS
+                            nameservers.
+                            Please note that Linux allows only three nameservers (https://linux.die.net/man/5/resolv.conf).
+                          items:
+                            type: string
+                          type: array
+                        networkName:
+                          description: |-
+                            NetworkName is the name, managed object reference or the managed
+                            object ID of the vSphere network to which the device will be connected.
+                          type: string
+                        routes:
+                          description: Routes is a list of optional, static routes
+                            applied to the device.
+                          items:
+                            description: NetworkRouteSpec defines a static network
+                              route.
+                            properties:
+                              metric:
+                                description: Metric is the weight/priority of the
+                                  route.
+                                format: int32
+                                type: integer
+                              to:
+                                description: To is an IPv4 or IPv6 address.
+                                type: string
+                              via:
+                                description: Via is an IPv4 or IPv6 address.
+                                type: string
+                            required:
+                            - metric
+                            - to
+                            - via
+                            type: object
+                          type: array
+                        searchDomains:
+                          description: |-
+                            SearchDomains is a list of search domains used when resolving IP
+                            addresses with DNS.
+                          items:
+                            type: string
+                          type: array
+                        skipIPAllocation:
+                          description: |-
+                            SkipIPAllocation allows the device to not have IP address or DHCP configured.
+                            This is suitable for devices for which IP allocation is handled externally, eg. using Multus CNI.
+                            If true, CAPV will not verify IP address allocation.
+                          type: boolean
+                      required:
+                      - networkName
+                      type: object
+                    type: array
+                  preferredAPIServerCidr:
+                    description: |-
+                      PreferredAPIServeCIDR is the preferred CIDR for the Kubernetes API
+                      server endpoint on this machine
+
+                      Deprecated: This field is going to be removed in a future release.
+                    type: string
+                  routes:
+                    description: |-
+                      Routes is a list of optional, static routes applied to the virtual
+                      machine.
+                    items:
+                      description: NetworkRouteSpec defines a static network route.
+                      properties:
+                        metric:
+                          description: Metric is the weight/priority of the route.
+                          format: int32
+                          type: integer
+                        to:
+                          description: To is an IPv4 or IPv6 address.
+                          type: string
+                        via:
+                          description: Via is an IPv4 or IPv6 address.
+                          type: string
+                      required:
+                      - metric
+                      - to
+                      - via
+                      type: object
+                    type: array
+                required:
+                - devices
+                type: object
+              numCPUs:
+                description: |-
+                  NumCPUs is the number of virtual processors in a virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              numCoresPerSocket:
+                description: |-
+                  NumCPUs is the number of cores among which to distribute CPUs in this
+                  virtual machine.
+                  Defaults to the eponymous property value in the template from which the
+                  virtual machine is cloned.
+                format: int32
+                type: integer
+              os:
+                description: |-
+                  OS is the Operating System of the virtual machine
+                  Defaults to Linux
+                type: string
+              pciDevices:
+                description: PciDevices is the list of pci devices used by the virtual
+                  machine.
+                items:
+                  description: PCIDeviceSpec defines virtual machine's PCI configuration.
+                  properties:
+                    customLabel:
+                      description: |-
+                        CustomLabel is the hardware label of a virtual machine's PCI device.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                      type: string
+                    deviceId:
+                      description: |-
+                        DeviceID is the device ID of a virtual machine's PCI, in integer.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                        Mutually exclusive with VGPUProfile as VGPUProfile and DeviceID + VendorID
+                        are two independent ways to define PCI devices.
+                      format: int32
+                      type: integer
+                    vGPUProfile:
+                      description: |-
+                        VGPUProfile is the profile name of a virtual machine's vGPU, in string.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                        Mutually exclusive with DeviceID and VendorID as VGPUProfile and DeviceID + VendorID
+                        are two independent ways to define PCI devices.
+                      type: string
+                    vendorId:
+                      description: |-
+                        VendorId is the vendor ID of a virtual machine's PCI, in integer.
+                        Defaults to the eponymous property value in the template from which the
+                        virtual machine is cloned.
+                        Mutually exclusive with VGPUProfile as VGPUProfile and DeviceID + VendorID
+                        are two independent ways to define PCI devices.
+                      format: int32
+                      type: integer
+                  type: object
+                type: array
+              powerOffMode:
+                default: hard
+                description: |-
+                  PowerOffMode describes the desired behavior when powering off a VM.
+
+                  There are three, supported power off modes: hard, soft, and
+                  trySoft. The first mode, hard, is the equivalent of a physical
+                  system's power cord being ripped from the wall. The soft mode
+                  requires the VM's guest to have VM Tools installed and attempts to
+                  gracefully shut down the VM. Its variant, trySoft, first attempts
+                  a graceful shutdown, and if that fails or the VM is not in a powered off
+                  state after reaching the GuestSoftPowerOffTimeout, the VM is halted.
+
+                  If omitted, the mode defaults to hard.
+                enum:
+                - hard
+                - soft
+                - trySoft
+                type: string
+              resourcePool:
+                description: |-
+                  ResourcePool is the name, inventory path, managed object reference or the managed
+                  object ID in which the virtual machine is created/located.
+                type: string
+              server:
+                description: |-
+                  Server is the IP address or FQDN of the vSphere server on which
+                  the virtual machine is created/located.
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which to create a linked clone.
+                  This field is ignored if LinkedClone is not enabled.
+                  Defaults to the source's current snapshot.
+                type: string
+              storagePolicyName:
+                description: |-
+                  StoragePolicyName of the storage policy to use with this
+                  Virtual Machine
+                type: string
+              tagIDs:
+                description: |-
+                  TagIDs is an optional set of tags to add to an instance. Specified tagIDs
+                  must use URN-notation instead of display names.
+                items:
+                  type: string
+                type: array
+              template:
+                description: |-
+                  Template is the name, inventory path, managed object reference or the managed
+                  object ID of the template used to clone the virtual machine.
+                minLength: 1
+                type: string
+              thumbprint:
+                description: |-
+                  Thumbprint is the colon-separated SHA-1 checksum of the given vCenter server's host certificate
+                  When this is set to empty, this VirtualMachine would be created
+                  without TLS certificate validation of the communication between Cluster API Provider vSphere
+                  and the VMware vCenter server.
+                type: string
+            required:
+            - network
+            - template
+            type: object
+          status:
+            description: VSphereVMStatus defines the observed state of VSphereVM.
+            properties:
+              addresses:
+                description: |-
+                  Addresses is a list of the VM's IP addresses.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                items:
+                  type: string
+                type: array
+              cloneMode:
+                description: |-
+                  CloneMode is the type of clone operation used to clone this VM. Since
+                  LinkedMode is the default but fails gracefully if the source of the
+                  clone has no snapshots, this field may be used to determine the actual
+                  type of clone operation used to create this VM.
+                type: string
+              conditions:
+                description: Conditions defines current service state of the VSphereVM.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  FailureMessage will be set in the event that there is a terminal problem
+                  reconciling the vspherevm and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the vm.
+
+                  Any transient errors that occur during the reconciliation of vspherevms
+                  can be added as events to the vspherevm object and/or logged in the
+                  controller's output.
+                type: string
+              failureReason:
+                description: |-
+                  FailureReason will be set in the event that there is a terminal problem
+                  reconciling the vspherevm and will contain a succinct value suitable
+                  for vm interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the vm.
+
+                  Any transient errors that occur during the reconciliation of vspherevms
+                  can be added as events to the vspherevm object and/or logged in the
+                  controller's output.
+                type: string
+              host:
+                description: |-
+                  Host describes the hostname or IP address of the infrastructure host
+                  that the VSphereVM is residing on.
+                type: string
+              moduleUUID:
+                description: |-
+                  ModuleUUID is the unique identifier for the vCenter cluster module construct
+                  which is used to configure anti-affinity. Objects with the same ModuleUUID
+                  will be anti-affined, meaning that the vCenter DRS will best effort schedule
+                  the VMs on separate hosts.
+                type: string
+              network:
+                description: |-
+                  Network returns the network status for each of the machine's configured
+                  network interfaces.
+                items:
+                  description: NetworkStatus provides information about one of a VM's
+                    networks.
+                  properties:
+                    connected:
+                      description: |-
+                        Connected is a flag that indicates whether this network is currently
+                        connected to the VM.
+                      type: boolean
+                    ipAddrs:
+                      description: IPAddrs is one or more IP addresses reported by
+                        vm-tools.
+                      items:
+                        type: string
+                      type: array
+                    macAddr:
+                      description: MACAddr is the MAC address of the network device.
+                      type: string
+                    networkName:
+                      description: NetworkName is the name of the network.
+                      type: string
+                  required:
+                  - macAddr
+                  type: object
+                type: array
+              ready:
+                description: |-
+                  Ready is true when the provider resource is ready.
+                  This field is required at runtime for other controllers that read
+                  this CRD as unstructured data.
+                type: boolean
+              retryAfter:
+                description: RetryAfter tracks the time we can retry queueing a task
+                format: date-time
+                type: string
+              snapshot:
+                description: |-
+                  Snapshot is the name of the snapshot from which the VM was cloned if
+                  LinkedMode is enabled.
+                type: string
+              taskRef:
+                description: |-
+                  TaskRef is a managed object reference to a Task related to the machine.
+                  This value is set automatically at runtime and should not be set or
+                  modified by users.
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in VSphereVM's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a VSphereVM's current state.
+                      Known condition types are Ready, VirtualMachineProvisioned, VCenterAvailable and IPAddressClaimsFulfilled,
+                      GuestSoftPowerOffSucceeded, PCIDevicesDetached and Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+              vmRef:
+                description: |-
+                  VMRef is the VM's Managed Object Reference on vSphere. It can be used by consumers
+                  to programatically get this VM representation on vSphere in case of the need to retrieve informations.
+                  This field is set once the machine is created and should not be changed
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherevms.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vspherevms.yaml
@@ -182,7 +182,7 @@ spec:
                           type: string
                         gateway6:
                           description: |-
-                            Gateway4 is the IPv4 gateway used by this device.
+                            Gateway6 is the IPv6 gateway used by this device.
                             Required when DHCP6 is false.
                           type: string
                         ipAddrs:
@@ -295,8 +295,7 @@ spec:
                 type: integer
               numCoresPerSocket:
                 description: |-
-                  NumCPUs is the number of cores among which to distribute CPUs in this
-                  virtual machine.
+                  NumCoresPerSocket is the number of cores per socket in a virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32
@@ -653,7 +652,7 @@ spec:
                           type: string
                         gateway6:
                           description: |-
-                            Gateway4 is the IPv4 gateway used by this device.
+                            Gateway6 is the IPv6 gateway used by this device.
                             Required when DHCP6 is false.
                           type: string
                         ipAddrs:
@@ -766,8 +765,7 @@ spec:
                 type: integer
               numCoresPerSocket:
                 description: |-
-                  NumCPUs is the number of cores among which to distribute CPUs in this
-                  virtual machine.
+                  NumCoresPerSocket is the number of cores per socket in a virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32
@@ -1322,7 +1320,7 @@ spec:
                             Required when DHCP4 is false.
                           type: string
                         gateway6:
-                          description: Gateway4 is the IPv4 gateway used by this device.
+                          description: Gateway6 is the IPv6 gateway used by this device.
                           type: string
                         ipAddrs:
                           description: |-
@@ -1442,8 +1440,7 @@ spec:
                 type: integer
               numCoresPerSocket:
                 description: |-
-                  NumCPUs is the number of cores among which to distribute CPUs in this
-                  virtual machine.
+                  NumCoresPerSocket is the number of cores per socket in a virtual machine.
                   Defaults to the eponymous property value in the template from which the
                   virtual machine is cloned.
                 format: int32


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API reference pages and CRD docs for VMware vSphere resources: VSphereCluster, VSphereMachine, VSphereMachineTemplate, VSphereMachineConfigPool, VSphereFailureDomain, VSphereDeploymentZone, VSphereVM, and VSphereClusterIdentity (infrastructure.cluster.x-k8s.io/v1beta1).
  * Updated Providers overview to mark VMware vSphere as "Available" and expanded key features.
  * Tightened cluster creation guidance: workload objects must be in the cpaas-system namespace; expanded VM template parameter guidance.
  * Added frontmatter/metadata and links across new docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->