### PR TITLE
docs: backport standard API references to release-1.0

### DIFF
--- a/docs/en/apis/cluster_api/addons/clusterresourceset.mdx
+++ b/docs/en/apis/cluster_api/addons/clusterresourceset.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: ClusterResourceSet
+queries:
+  - clusterresourceset crd
+  - clusterresourceset api
+  - clusterresourcesets.addons.cluster.x-k8s.io reference
+---
+
+# ClusterResourceSet [addons.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="clusterresourcesets.addons.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/addons/clusterresourcesetbinding.mdx
+++ b/docs/en/apis/cluster_api/addons/clusterresourcesetbinding.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+title: ClusterResourceSetBinding
+queries:
+  - clusterresourcesetbinding crd
+  - clusterresourcesetbinding api
+  - clusterresourcesetbindings.addons.cluster.x-k8s.io reference
+---
+
+# ClusterResourceSetBinding [addons.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="clusterresourcesetbindings.addons.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/addons/index.mdx
+++ b/docs/en/apis/cluster_api/addons/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 20
+queries:
+  - cluster api add-on apis
+  - cluster api crd reference
+---
+
+# Cluster API Add-on APIs
+
+<Overview />

--- a/docs/en/apis/cluster_api/core/cluster.mdx
+++ b/docs/en/apis/cluster_api/core/cluster.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: Cluster
+queries:
+  - cluster crd
+  - cluster api
+  - clusters.cluster.x-k8s.io reference
+---
+
+# Cluster [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="clusters.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/clusterclass.mdx
+++ b/docs/en/apis/cluster_api/core/clusterclass.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+title: ClusterClass
+queries:
+  - clusterclass crd
+  - clusterclass api
+  - clusterclasses.cluster.x-k8s.io reference
+---
+
+# ClusterClass [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="clusterclasses.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/index.mdx
+++ b/docs/en/apis/cluster_api/core/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 10
+queries:
+  - cluster api core apis
+  - cluster api crd reference
+---
+
+# Cluster API Core APIs
+
+<Overview />

--- a/docs/en/apis/cluster_api/core/machine.mdx
+++ b/docs/en/apis/cluster_api/core/machine.mdx
@@ -1,0 +1,12 @@
+---
+weight: 30
+title: Machine
+queries:
+  - machine crd
+  - machine api
+  - machines.cluster.x-k8s.io reference
+---
+
+# Machine [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="machines.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/machinedeployment.mdx
+++ b/docs/en/apis/cluster_api/core/machinedeployment.mdx
@@ -1,0 +1,12 @@
+---
+weight: 50
+title: MachineDeployment
+queries:
+  - machinedeployment crd
+  - machinedeployment api
+  - machinedeployments.cluster.x-k8s.io reference
+---
+
+# MachineDeployment [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="machinedeployments.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/machinedrainrule.mdx
+++ b/docs/en/apis/cluster_api/core/machinedrainrule.mdx
@@ -1,0 +1,12 @@
+---
+weight: 80
+title: MachineDrainRule
+queries:
+  - machinedrainrule crd
+  - machinedrainrule api
+  - machinedrainrules.cluster.x-k8s.io reference
+---
+
+# MachineDrainRule [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="machinedrainrules.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/machinehealthcheck.mdx
+++ b/docs/en/apis/cluster_api/core/machinehealthcheck.mdx
@@ -1,0 +1,12 @@
+---
+weight: 70
+title: MachineHealthCheck
+queries:
+  - machinehealthcheck crd
+  - machinehealthcheck api
+  - machinehealthchecks.cluster.x-k8s.io reference
+---
+
+# MachineHealthCheck [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="machinehealthchecks.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/machinepool.mdx
+++ b/docs/en/apis/cluster_api/core/machinepool.mdx
@@ -1,0 +1,12 @@
+---
+weight: 60
+title: MachinePool
+queries:
+  - machinepool crd
+  - machinepool api
+  - machinepools.cluster.x-k8s.io reference
+---
+
+# MachinePool [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="machinepools.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/core/machineset.mdx
+++ b/docs/en/apis/cluster_api/core/machineset.mdx
@@ -1,0 +1,12 @@
+---
+weight: 40
+title: MachineSet
+queries:
+  - machineset crd
+  - machineset api
+  - machinesets.cluster.x-k8s.io reference
+---
+
+# MachineSet [cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="machinesets.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/hosted_control_plane/datastore.mdx
+++ b/docs/en/apis/cluster_api/hosted_control_plane/datastore.mdx
@@ -1,0 +1,13 @@
+---
+weight: 30
+title: DataStore
+queries:
+  - datastore crd
+  - datastore api
+  - datastores.kamaji.clastix.io reference
+---
+
+# DataStore [kamaji.clastix.io/v1alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="datastores.kamaji.clastix.io" />

--- a/docs/en/apis/cluster_api/hosted_control_plane/index.mdx
+++ b/docs/en/apis/cluster_api/hosted_control_plane/index.mdx
@@ -1,0 +1,13 @@
+---
+weight: 70
+queries:
+  - hosted control plane api
+  - kamaji control plane crd
+  - hcp api reference
+---
+
+# Hosted Control Plane APIs
+
+<Overview />
+
+Hosted Control Plane APIs define Kamaji-based control plane resources used with Cluster API.

--- a/docs/en/apis/cluster_api/hosted_control_plane/kamajicontrolplane.mdx
+++ b/docs/en/apis/cluster_api/hosted_control_plane/kamajicontrolplane.mdx
@@ -1,0 +1,13 @@
+---
+weight: 10
+title: KamajiControlPlane
+queries:
+  - kamajicontrolplane crd
+  - kamajicontrolplane api
+  - kamajicontrolplanes.controlplane.cluster.x-k8s.io reference
+---
+
+# KamajiControlPlane [controlplane.cluster.x-k8s.io/v1alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="kamajicontrolplanes.controlplane.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/hosted_control_plane/kamajicontrolplanetemplate.mdx
+++ b/docs/en/apis/cluster_api/hosted_control_plane/kamajicontrolplanetemplate.mdx
@@ -1,0 +1,13 @@
+---
+weight: 20
+title: KamajiControlPlaneTemplate
+queries:
+  - kamajicontrolplanetemplate crd
+  - kamajicontrolplanetemplate api
+  - kamajicontrolplanetemplates.controlplane.cluster.x-k8s.io reference
+---
+
+# KamajiControlPlaneTemplate [controlplane.cluster.x-k8s.io/v1alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="kamajicontrolplanetemplates.controlplane.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/hosted_control_plane/tenantcontrolplane.mdx
+++ b/docs/en/apis/cluster_api/hosted_control_plane/tenantcontrolplane.mdx
@@ -1,0 +1,13 @@
+---
+weight: 40
+title: TenantControlPlane
+queries:
+  - tenantcontrolplane crd
+  - tenantcontrolplane api
+  - tenantcontrolplanes.kamaji.clastix.io reference
+---
+
+# TenantControlPlane [kamaji.clastix.io/v1alpha1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="tenantcontrolplanes.kamaji.clastix.io" />

--- a/docs/en/apis/cluster_api/index.mdx
+++ b/docs/en/apis/cluster_api/index.mdx
@@ -1,0 +1,13 @@
+---
+weight: 20
+queries:
+  - cluster api reference
+  - cluster lifecycle api
+  - immutable infrastructure api
+---
+
+# Cluster API Reference
+
+<Overview />
+
+Cluster API defines the cluster lifecycle resources used by Immutable Infrastructure.

--- a/docs/en/apis/cluster_api/ipam/index.mdx
+++ b/docs/en/apis/cluster_api/ipam/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 30
+queries:
+  - cluster api ipam apis
+  - cluster api crd reference
+---
+
+# Cluster API IPAM APIs
+
+<Overview />

--- a/docs/en/apis/cluster_api/ipam/ipaddress.mdx
+++ b/docs/en/apis/cluster_api/ipam/ipaddress.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: IPAddress
+queries:
+  - ipaddress crd
+  - ipaddress api
+  - ipaddresses.ipam.cluster.x-k8s.io reference
+---
+
+# IPAddress [ipam.cluster.x-k8s.io/v1alpha1]
+
+<K8sCrd name="ipaddresses.ipam.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/ipam/ipaddressclaim.mdx
+++ b/docs/en/apis/cluster_api/ipam/ipaddressclaim.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+title: IPAddressClaim
+queries:
+  - ipaddressclaim crd
+  - ipaddressclaim api
+  - ipaddressclaims.ipam.cluster.x-k8s.io reference
+---
+
+# IPAddressClaim [ipam.cluster.x-k8s.io/v1alpha1]
+
+<K8sCrd name="ipaddressclaims.ipam.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/kubeadm_bootstrap/index.mdx
+++ b/docs/en/apis/cluster_api/kubeadm_bootstrap/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 50
+queries:
+  - kubeadm bootstrap apis
+  - cluster api crd reference
+---
+
+# Kubeadm Bootstrap APIs
+
+<Overview />

--- a/docs/en/apis/cluster_api/kubeadm_bootstrap/kubeadmconfig.mdx
+++ b/docs/en/apis/cluster_api/kubeadm_bootstrap/kubeadmconfig.mdx
@@ -1,0 +1,13 @@
+---
+weight: 10
+title: KubeadmConfig
+queries:
+  - kubeadmconfig crd
+  - kubeadmconfig api
+  - kubeadmconfigs.bootstrap.cluster.x-k8s.io reference
+---
+
+# KubeadmConfig [bootstrap.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="kubeadmconfigs.bootstrap.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/kubeadm_bootstrap/kubeadmconfigtemplate.mdx
+++ b/docs/en/apis/cluster_api/kubeadm_bootstrap/kubeadmconfigtemplate.mdx
@@ -1,0 +1,13 @@
+---
+weight: 20
+title: KubeadmConfigTemplate
+queries:
+  - kubeadmconfigtemplate crd
+  - kubeadmconfigtemplate api
+  - kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io reference
+---
+
+# KubeadmConfigTemplate [bootstrap.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/kubeadm_control_plane/index.mdx
+++ b/docs/en/apis/cluster_api/kubeadm_control_plane/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 60
+queries:
+  - kubeadm control plane apis
+  - cluster api crd reference
+---
+
+# Kubeadm Control Plane APIs
+
+<Overview />

--- a/docs/en/apis/cluster_api/kubeadm_control_plane/kubeadmcontrolplane.mdx
+++ b/docs/en/apis/cluster_api/kubeadm_control_plane/kubeadmcontrolplane.mdx
@@ -1,0 +1,13 @@
+---
+weight: 10
+title: KubeadmControlPlane
+queries:
+  - kubeadmcontrolplane crd
+  - kubeadmcontrolplane api
+  - kubeadmcontrolplanes.controlplane.cluster.x-k8s.io reference
+---
+
+# KubeadmControlPlane [controlplane.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="kubeadmcontrolplanes.controlplane.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/kubeadm_control_plane/kubeadmcontrolplanetemplate.mdx
+++ b/docs/en/apis/cluster_api/kubeadm_control_plane/kubeadmcontrolplanetemplate.mdx
@@ -1,0 +1,13 @@
+---
+weight: 20
+title: KubeadmControlPlaneTemplate
+queries:
+  - kubeadmcontrolplanetemplate crd
+  - kubeadmcontrolplanetemplate api
+  - kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io reference
+---
+
+# KubeadmControlPlaneTemplate [controlplane.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/runtime/extensionconfig.mdx
+++ b/docs/en/apis/cluster_api/runtime/extensionconfig.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: ExtensionConfig
+queries:
+  - extensionconfig crd
+  - extensionconfig api
+  - extensionconfigs.runtime.cluster.x-k8s.io reference
+---
+
+# ExtensionConfig [runtime.cluster.x-k8s.io/v1alpha1]
+
+<K8sCrd name="extensionconfigs.runtime.cluster.x-k8s.io" />

--- a/docs/en/apis/cluster_api/runtime/index.mdx
+++ b/docs/en/apis/cluster_api/runtime/index.mdx
@@ -1,0 +1,10 @@
+---
+weight: 40
+queries:
+  - cluster api runtime apis
+  - cluster api crd reference
+---
+
+# Cluster API Runtime APIs
+
+<Overview />

--- a/docs/en/apis/machine_configuration/index.mdx
+++ b/docs/en/apis/machine_configuration/index.mdx
@@ -1,0 +1,13 @@
+---
+weight: 40
+queries:
+  - machine configuration api
+  - machineconfig crd
+  - immutable infrastructure machine configuration
+---
+
+# Machine Configuration APIs
+
+<Overview />
+
+Machine Configuration APIs define node operating system configuration resources for Immutable Infrastructure.

--- a/docs/en/apis/machine_configuration/machineconfig.mdx
+++ b/docs/en/apis/machine_configuration/machineconfig.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: MachineConfig
+queries:
+  - machineconfig crd
+  - machineconfig api
+  - machineconfigs.machineconfiguration.alauda.io reference
+---
+
+# MachineConfig [machineconfiguration.alauda.io/v1alpha1]
+
+<K8sCrd name="machineconfigs.machineconfiguration.alauda.io" />

--- a/docs/en/apis/machine_configuration/machineconfigpool.mdx
+++ b/docs/en/apis/machine_configuration/machineconfigpool.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+title: MachineConfigPool
+queries:
+  - machineconfigpool crd
+  - machineconfigpool api
+  - machineconfigpools.machineconfiguration.alauda.io reference
+---
+
+# MachineConfigPool [machineconfiguration.alauda.io/v1alpha1]
+
+<K8sCrd name="machineconfigpools.machineconfiguration.alauda.io" />

--- a/docs/en/apis/machine_configuration/machineconfiguration.mdx
+++ b/docs/en/apis/machine_configuration/machineconfiguration.mdx
@@ -1,0 +1,12 @@
+---
+weight: 30
+title: MachineConfiguration
+queries:
+  - machineconfiguration crd
+  - machineconfiguration api
+  - machineconfigurations.machineconfiguration.alauda.io reference
+---
+
+# MachineConfiguration [machineconfiguration.alauda.io/v1alpha1]
+
+<K8sCrd name="machineconfigurations.machineconfiguration.alauda.io" />

--- a/docs/en/apis/providers/ssh/index.mdx
+++ b/docs/en/apis/providers/ssh/index.mdx
@@ -1,0 +1,12 @@
+---
+weight: 60
+queries:
+  - ssh provider apis
+  - ssh crd reference
+---
+
+# SSH Provider APIs
+
+<Overview />
+
+The SSH Infrastructure Provider defines custom resources for managing clusters on pre-provisioned hosts over SSH.

--- a/docs/en/apis/providers/ssh/sshcluster.mdx
+++ b/docs/en/apis/providers/ssh/sshcluster.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: SSHCluster
+queries:
+  - sshcluster crd
+  - sshcluster api
+  - sshclusters.infrastructure.cluster.x-k8s.io reference
+---
+
+# SSHCluster [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="sshclusters.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/ssh/sshhost.mdx
+++ b/docs/en/apis/providers/ssh/sshhost.mdx
@@ -1,0 +1,12 @@
+---
+weight: 40
+title: SSHHost
+queries:
+  - sshhost crd
+  - sshhost api
+  - sshhosts.infrastructure.cluster.x-k8s.io reference
+---
+
+# SSHHost [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="sshhosts.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/ssh/sshmachine.mdx
+++ b/docs/en/apis/providers/ssh/sshmachine.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+title: SSHMachine
+queries:
+  - sshmachine crd
+  - sshmachine api
+  - sshmachines.infrastructure.cluster.x-k8s.io reference
+---
+
+# SSHMachine [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="sshmachines.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/ssh/sshmachinetemplate.mdx
+++ b/docs/en/apis/providers/ssh/sshmachinetemplate.mdx
@@ -1,0 +1,12 @@
+---
+weight: 30
+title: SSHMachineTemplate
+queries:
+  - sshmachinetemplate crd
+  - sshmachinetemplate api
+  - sshmachinetemplates.infrastructure.cluster.x-k8s.io reference
+---
+
+# SSHMachineTemplate [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="sshmachinetemplates.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/user_provisioned/index.mdx
+++ b/docs/en/apis/providers/user_provisioned/index.mdx
@@ -1,0 +1,12 @@
+---
+weight: 50
+queries:
+  - user-provisioned infrastructure provider apis
+  - user-provisioned crd reference
+---
+
+# User-Provisioned Infrastructure Provider APIs
+
+<Overview />
+
+These APIs are the reference for creating and managing User-Provisioned Infrastructure clusters through Cluster API resources.

--- a/docs/en/apis/providers/user_provisioned/userprovisionedcluster.mdx
+++ b/docs/en/apis/providers/user_provisioned/userprovisionedcluster.mdx
@@ -1,0 +1,12 @@
+---
+weight: 10
+title: UserProvisionedCluster
+queries:
+  - userprovisionedcluster crd
+  - userprovisionedcluster api
+  - userprovisionedclusters.infrastructure.cluster.x-k8s.io reference
+---
+
+# UserProvisionedCluster [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="userprovisionedclusters.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/user_provisioned/userprovisionedmachine.mdx
+++ b/docs/en/apis/providers/user_provisioned/userprovisionedmachine.mdx
@@ -1,0 +1,12 @@
+---
+weight: 20
+title: UserProvisionedMachine
+queries:
+  - userprovisionedmachine crd
+  - userprovisionedmachine api
+  - userprovisionedmachines.infrastructure.cluster.x-k8s.io reference
+---
+
+# UserProvisionedMachine [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="userprovisionedmachines.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/user_provisioned/userprovisionedmachinepool.mdx
+++ b/docs/en/apis/providers/user_provisioned/userprovisionedmachinepool.mdx
@@ -1,0 +1,12 @@
+---
+weight: 30
+title: UserProvisionedMachinePool
+queries:
+  - userprovisionedmachinepool crd
+  - userprovisionedmachinepool api
+  - userprovisionedmachinepools.infrastructure.cluster.x-k8s.io reference
+---
+
+# UserProvisionedMachinePool [infrastructure.cluster.x-k8s.io/v1beta1]
+
+<K8sCrd name="userprovisionedmachinepools.infrastructure.cluster.x-k8s.io" />

--- a/docs/en/apis/providers/vmware-vsphere/index.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/index.mdx
@@ -27,11 +27,8 @@ The VMware vSphere Infrastructure Provider defines custom resources for managing
 | `VSphereMachineConfigPool` | Pool of pre-defined node slots with hostnames, static IPs, and persistent disks | [VSphereMachineConfigPool](./vspheremachineconfigpool.mdx) |
 | `VSphereFailureDomain` | Describes a datacenter, compute cluster, datastore, and network topology used as a failure domain | [VSphereFailureDomain](./vspherefailuredomain.mdx) |
 | `VSphereDeploymentZone` | Binds a `VSphereFailureDomain` to a vCenter server and placement constraints | [VSphereDeploymentZone](./vspheredeploymentzone.mdx) |
+| `VSphereClusterTemplate` | Template consumed by Cluster API ClusterClass and managed-topology flows | [VSphereClusterTemplate](./vsphereclustertemplate.mdx) |
 
 ## API Group
 
 All VMware vSphere resources belong to the API group `infrastructure.cluster.x-k8s.io/v1beta1`.
-
-## Not Covered
-
-The provider also ships `VSphereClusterTemplate`, which is consumed by Cluster API ClusterClass / managed-topology flows. This product provisions workload clusters from explicit `Cluster`, `VSphereCluster`, and `KubeadmControlPlane` manifests rather than through ClusterClass, so `VSphereClusterTemplate` is not documented here.

--- a/docs/en/apis/providers/vmware-vsphere/vsphereclustertemplate.mdx
+++ b/docs/en/apis/providers/vmware-vsphere/vsphereclustertemplate.mdx
@@ -1,0 +1,13 @@
+---
+weight: 25
+title: VSphereClusterTemplate
+queries:
+  - vsphereclustertemplate crd
+  - vsphere clusterclass template
+  - vsphere cluster template api
+---
+
+# VSphereClusterTemplate [infrastructure.cluster.x-k8s.io/v1beta1]
+
+{/* cspell:disable-next-line */}
+<K8sCrd name="vsphereclustertemplates.infrastructure.cluster.x-k8s.io" />

--- a/docs/shared/crds/cluster_api/addons/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
+++ b/docs/shared/crds/cluster_api/addons/addons.cluster.x-k8s.io_clusterresourcesetbindings.yaml
@@ -1,0 +1,123 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: clusterresourcesetbindings.addons.cluster.x-k8s.io
+spec:
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSetBinding
+    listKind: ClusterResourceSetBindingList
+    plural: clusterresourcesetbindings
+    singular: clusterresourcesetbinding
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSetBinding
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterResourceSetBinding lists all matching ClusterResourceSets
+          with the cluster it belongs to.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSetBinding.
+            properties:
+              bindings:
+                description: bindings is a list of ClusterResourceSets and their resources.
+                items:
+                  description: ResourceSetBinding keeps info on all of the resources
+                    in a ClusterResourceSet.
+                  properties:
+                    clusterResourceSetName:
+                      description: clusterResourceSetName is the name of the ClusterResourceSet
+                        that is applied to the owner cluster of the binding.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                    resources:
+                      description: resources is a list of resources that the ClusterResourceSet
+                        has.
+                      items:
+                        description: ResourceBinding shows the status of a resource
+                          that belongs to a ClusterResourceSet matched by the owner
+                          cluster of the ClusterResourceSetBinding object.
+                        properties:
+                          applied:
+                            description: applied is to track if a resource is applied
+                              to the cluster or not.
+                            type: boolean
+                          hash:
+                            description: |-
+                              hash is the hash of a resource's data. This can be used to decide if a resource is changed.
+                              For "ApplyOnce" ClusterResourceSet.spec.strategy, this is no-op as that strategy does not act on change.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          kind:
+                            description: 'kind of the resource. Supported kinds are:
+                              Secrets and ConfigMaps.'
+                            enum:
+                            - Secret
+                            - ConfigMap
+                            type: string
+                          lastAppliedTime:
+                            description: lastAppliedTime identifies when this resource
+                              was last applied to the cluster.
+                            format: date-time
+                            type: string
+                          name:
+                            description: name of the resource that is in the same
+                              namespace with ClusterResourceSet object.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                        required:
+                        - applied
+                        - kind
+                        - name
+                        type: object
+                      maxItems: 100
+                      type: array
+                  required:
+                  - clusterResourceSetName
+                  type: object
+                maxItems: 100
+                type: array
+              clusterName:
+                description: |-
+                  clusterName is the name of the Cluster this binding applies to.
+                  Note: this field mandatory in v1beta2.
+                maxLength: 63
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/addons/addons.cluster.x-k8s.io_clusterresourcesets.yaml
+++ b/docs/shared/crds/cluster_api/addons/addons.cluster.x-k8s.io_clusterresourcesets.yaml
@@ -1,0 +1,270 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: clusterresourcesets.addons.cluster.x-k8s.io
+spec:
+  group: addons.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterResourceSet
+    listKind: ClusterResourceSetList
+    plural: clusterresourcesets
+    singular: clusterresourceset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterResourceSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          ClusterResourceSet is the Schema for the clusterresourcesets API.
+          For advanced use cases an add-on provider should be used instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterResourceSet.
+            properties:
+              clusterSelector:
+                description: |-
+                  clusterSelector is the label selector for Clusters. The Clusters that are
+                  selected by this will be the ones affected by this ClusterResourceSet.
+                  It must match the Cluster labels. This field is immutable.
+                  Label selector cannot be empty.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              resources:
+                description: resources is a list of Secrets/ConfigMaps where each
+                  contains 1 or more resources to be applied to remote clusters.
+                items:
+                  description: ResourceRef specifies a resource.
+                  properties:
+                    kind:
+                      description: 'kind of the resource. Supported kinds are: Secrets
+                        and ConfigMaps.'
+                      enum:
+                      - Secret
+                      - ConfigMap
+                      type: string
+                    name:
+                      description: name of the resource that is in the same namespace
+                        with ClusterResourceSet object.
+                      maxLength: 253
+                      minLength: 1
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+              strategy:
+                description: strategy is the strategy to be used during applying resources.
+                  Defaults to ApplyOnce. This field is immutable.
+                enum:
+                - ApplyOnce
+                - Reconcile
+                type: string
+            required:
+            - clusterSelector
+            type: object
+          status:
+            description: status is the observed state of ClusterResourceSet.
+            properties:
+              conditions:
+                description: conditions defines current state of the ClusterResourceSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed ClusterResourceSet.
+                format: int64
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ClusterResourceSet's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ClusterResourceSet's current state.
+                      Known condition types are ResourceSetApplied, Deleting.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_clusterclasses.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_clusterclasses.yaml
@@ -1,0 +1,2420 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: clusterclasses.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ClusterClass
+    listKind: ClusterClassList
+    plural: clusterclasses
+    shortNames:
+    - cc
+    singular: clusterclass
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ClusterClass
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterClass is a template which can be used to create managed
+          topologies.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of ClusterClass.
+            properties:
+              availabilityGates:
+                description: |-
+                  availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                  NOTE: this field is considered only for computing v1beta2 conditions.
+                  NOTE: If a Cluster is using this ClusterClass, and this Cluster defines a custom list of availabilityGates,
+                  such list overrides availabilityGates defined in this field.
+                items:
+                  description: ClusterAvailabilityGate contains the type of a Cluster
+                    condition to be used as availability gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a condition with matching type in the Cluster's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this availabilityGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                      - Positive
+                      - Negative
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              controlPlane:
+                description: |-
+                  controlPlane is a reference to a local struct that holds the details
+                  for provisioning the Control Plane for the Cluster.
+                properties:
+                  machineHealthCheck:
+                    description: |-
+                      machineHealthCheck defines a MachineHealthCheck for this ControlPlaneClass.
+                      This field is supported if and only if the ControlPlane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      maxUnhealthy:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                          Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                          "selector" are not healthy.
+                        x-kubernetes-int-or-string: true
+                      nodeStartupTimeout:
+                        description: |-
+                          nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                          to consider a Machine unhealthy if a corresponding Node isn't associated
+                          through a `Spec.ProviderID` field.
+
+                          The duration set in this field is compared to the greatest of:
+                          - Cluster's infrastructure ready condition timestamp (if and when available)
+                          - Control Plane's initialized condition timestamp (if and when available)
+                          - Machine's infrastructure ready condition timestamp (if and when available)
+                          - Machine's metadata creation timestamp
+
+                          Defaults to 10 minutes.
+                          If you wish to disable this feature, set the value explicitly to 0.
+                        type: string
+                      remediationTemplate:
+                        description: |-
+                          remediationTemplate is a reference to a remediation template
+                          provided by an infrastructure provider.
+
+                          This field is completely optional, when filled, the MachineHealthCheck controller
+                          creates a new object from the template referenced and hands off remediation of the machine to
+                          a controller that lives outside of Cluster API.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      unhealthyConditions:
+                        description: |-
+                          unhealthyConditions contains a list of the conditions that determine
+                          whether a node is considered unhealthy. The conditions are combined in a
+                          logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                        items:
+                          description: |-
+                            UnhealthyCondition represents a Node condition type and value with a timeout
+                            specified as a duration.  When the named condition has been in the given
+                            status for at least the timeout value, a node is considered unhealthy.
+                          properties:
+                            status:
+                              description: status of the condition, one of True, False,
+                                Unknown.
+                              minLength: 1
+                              type: string
+                            timeout:
+                              description: |-
+                                timeout is the duration that a node must be in a given status for,
+                                after which the node is considered unhealthy.
+                                For example, with a value of "1h", the node must match the status
+                                for at least 1 hour before being considered unhealthy.
+                              type: string
+                            type:
+                              description: type of Node condition
+                              minLength: 1
+                              type: string
+                          required:
+                          - status
+                          - timeout
+                          - type
+                          type: object
+                        maxItems: 100
+                        type: array
+                      unhealthyRange:
+                        description: |-
+                          unhealthyRange specifies the range of unhealthy machines allowed.
+                          Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                          is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                          Eg. "[3-5]" - This means that remediation will be allowed only when:
+                          (a) there are at least 3 unhealthy machines (and)
+                          (b) there are at most 5 unhealthy machines
+                        maxLength: 32
+                        minLength: 1
+                        pattern: ^\[[0-9]+-[0-9]+\]$
+                        type: string
+                    type: object
+                  machineInfrastructure:
+                    description: |-
+                      machineInfrastructure defines the metadata and infrastructure information
+                      for control plane machines.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced above is Machine based and supports setting replicas.
+                    properties:
+                      ref:
+                        description: |-
+                          ref is a required reference to a custom resource
+                          offered by a provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - ref
+                    type: object
+                  metadata:
+                    description: |-
+                      metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                      if the ControlPlaneTemplate referenced is machine based. If not, it is applied only to the
+                      ControlPlane.
+                      At runtime this metadata is merged with the corresponding metadata from the topology.
+
+                      This field is supported if and only if the control plane provider template
+                      referenced is Machine based.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  namingStrategy:
+                    description: namingStrategy allows changing the naming pattern
+                      used when creating the control plane provider object.
+                    properties:
+                      template:
+                        description: |-
+                          template defines the template to use for generating the name of the ControlPlane object.
+                          If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`.
+                          If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                          get concatenated with a random suffix of length 5.
+                          The templating mechanism provides the following arguments:
+                          * `.cluster.name`: The name of the cluster object.
+                          * `.random`: A random alphanumeric string, without vowels, of length 5.
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      Defaults to 10 seconds.
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                      NOTE: This value can be overridden while defining a Cluster.Topology.
+                    type: string
+                  readinessGates:
+                    description: |-
+                      readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                      This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                      computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                      NOTE: This field is considered only for computing v1beta2 conditions.
+                      NOTE: If a Cluster defines a custom list of readinessGates for the control plane,
+                      such list overrides readinessGates defined in this field.
+                      NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
+                      e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+                    items:
+                      description: MachineReadinessGate contains the type of a Machine
+                        condition to be used as a readiness gate.
+                      properties:
+                        conditionType:
+                          description: |-
+                            conditionType refers to a condition with matching type in the Machine's condition list.
+                            If the conditions doesn't exist, it will be treated as unknown.
+                            Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                          maxLength: 316
+                          minLength: 1
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                        polarity:
+                          description: |-
+                            polarity of the conditionType specified in this readinessGate.
+                            Valid values are Positive, Negative and omitted.
+                            When omitted, the default behaviour will be Positive.
+                            A positive polarity means that the condition should report a true status under normal conditions.
+                            A negative polarity means that the condition should report a false status under normal conditions.
+                          enum:
+                          - Positive
+                          - Negative
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - conditionType
+                    x-kubernetes-list-type: map
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructure:
+                description: |-
+                  infrastructure is a reference to a provider-specific template that holds
+                  the details for provisioning infrastructure specific cluster
+                  for the underlying provider.
+                  The underlying provider is responsible for the implementation
+                  of the template to an infrastructure cluster.
+                properties:
+                  ref:
+                    description: |-
+                      ref is a required reference to a custom resource
+                      offered by a provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - ref
+                type: object
+              infrastructureNamingStrategy:
+                description: infrastructureNamingStrategy allows changing the naming
+                  pattern used when creating the infrastructure object.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the name of the Infrastructure object.
+                      If not defined, it will fallback to `{{ .cluster.name }}-{{ .random }}`.
+                      If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      The templating mechanism provides the following arguments:
+                      * `.cluster.name`: The name of the cluster object.
+                      * `.random`: A random alphanumeric string, without vowels, of length 5.
+                    maxLength: 1024
+                    minLength: 1
+                    type: string
+                type: object
+              patches:
+                description: |-
+                  patches defines the patches which are applied to customize
+                  referenced templates of a ClusterClass.
+                  Note: Patches will be applied in the order of the array.
+                items:
+                  description: ClusterClassPatch defines a patch which is applied
+                    to customize the referenced templates.
+                  properties:
+                    definitions:
+                      description: |-
+                        definitions define inline patches.
+                        Note: Patches will be applied in the order of the array.
+                        Note: Exactly one of Definitions or External must be set.
+                      items:
+                        description: PatchDefinition defines a patch which is applied
+                          to customize the referenced templates.
+                        properties:
+                          jsonPatches:
+                            description: |-
+                              jsonPatches defines the patches which should be applied on the templates
+                              matching the selector.
+                              Note: Patches will be applied in the order of the array.
+                            items:
+                              description: JSONPatch defines a JSON patch.
+                              properties:
+                                op:
+                                  description: |-
+                                    op defines the operation of the patch.
+                                    Note: Only `add`, `replace` and `remove` are supported.
+                                  enum:
+                                  - add
+                                  - replace
+                                  - remove
+                                  type: string
+                                path:
+                                  description: |-
+                                    path defines the path of the patch.
+                                    Note: Only the spec of a template can be patched, thus the path has to start with /spec/.
+                                    Note: For now the only allowed array modifications are `append` and `prepend`, i.e.:
+                                    * for op: `add`: only index 0 (prepend) and - (append) are allowed
+                                    * for op: `replace` or `remove`: no indexes are allowed
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: |-
+                                    value defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for add and replace
+                                    operations. Only one of them is allowed to be set at the same time.
+                                    Note: We have to use apiextensionsv1.JSON instead of our JSON type,
+                                    because controller-tools has a hard-coded schema for apiextensionsv1.JSON
+                                    which cannot be produced by another type (unset type field).
+                                    Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                  x-kubernetes-preserve-unknown-fields: true
+                                valueFrom:
+                                  description: |-
+                                    valueFrom defines the value of the patch.
+                                    Note: Either Value or ValueFrom is required for add and replace
+                                    operations. Only one of them is allowed to be set at the same time.
+                                  properties:
+                                    template:
+                                      description: |-
+                                        template is the Go template to be used to calculate the value.
+                                        A template can reference variables defined in .spec.variables and builtin variables.
+                                        Note: The template must evaluate to a valid YAML or JSON value.
+                                      maxLength: 10240
+                                      minLength: 1
+                                      type: string
+                                    variable:
+                                      description: |-
+                                        variable is the variable to be used as value.
+                                        Variable can be one of the variables defined in .spec.variables or a builtin variable.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                  type: object
+                              required:
+                              - op
+                              - path
+                              type: object
+                            maxItems: 100
+                            type: array
+                          selector:
+                            description: selector defines on which templates the patch
+                              should be applied.
+                            properties:
+                              apiVersion:
+                                description: apiVersion filters templates by apiVersion.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: kind filters templates by kind.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              matchResources:
+                                description: matchResources selects templates based
+                                  on where they are referenced.
+                                properties:
+                                  controlPlane:
+                                    description: |-
+                                      controlPlane selects templates referenced in .spec.ControlPlane.
+                                      Note: this will match the controlPlane and also the controlPlane
+                                      machineInfrastructure (depending on the kind and apiVersion).
+                                    type: boolean
+                                  infrastructureCluster:
+                                    description: infrastructureCluster selects templates
+                                      referenced in .spec.infrastructure.
+                                    type: boolean
+                                  machineDeploymentClass:
+                                    description: |-
+                                      machineDeploymentClass selects templates referenced in specific MachineDeploymentClasses in
+                                      .spec.workers.machineDeployments.
+                                    properties:
+                                      names:
+                                        description: names selects templates by class
+                                          names.
+                                        items:
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                    type: object
+                                  machinePoolClass:
+                                    description: |-
+                                      machinePoolClass selects templates referenced in specific MachinePoolClasses in
+                                      .spec.workers.machinePools.
+                                    properties:
+                                      names:
+                                        description: names selects templates by class
+                                          names.
+                                        items:
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                    type: object
+                                type: object
+                            required:
+                            - apiVersion
+                            - kind
+                            - matchResources
+                            type: object
+                        required:
+                        - jsonPatches
+                        - selector
+                        type: object
+                      maxItems: 100
+                      type: array
+                    description:
+                      description: description is a human-readable description of
+                        this patch.
+                      maxLength: 1024
+                      minLength: 1
+                      type: string
+                    enabledIf:
+                      description: |-
+                        enabledIf is a Go template to be used to calculate if a patch should be enabled.
+                        It can reference variables defined in .spec.variables and builtin variables.
+                        The patch will be enabled if the template evaluates to `true`, otherwise it will
+                        be disabled.
+                        If EnabledIf is not set, the patch will be enabled per default.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    external:
+                      description: |-
+                        external defines an external patch.
+                        Note: Exactly one of Definitions or External must be set.
+                      properties:
+                        discoverVariablesExtension:
+                          description: discoverVariablesExtension references an extension
+                            which is called to discover variables.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        generateExtension:
+                          description: generateExtension references an extension which
+                            is called to generate patches.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        settings:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            settings defines key value pairs to be passed to the extensions.
+                            Values defined here take precedence over the values defined in the
+                            corresponding ExtensionConfig.
+                          type: object
+                        validateExtension:
+                          description: validateExtension references an extension which
+                            is called to validate the topology.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                      type: object
+                    name:
+                      description: name of the patch.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 1000
+                type: array
+              variables:
+                description: |-
+                  variables defines the variables which can be configured
+                  in the Cluster topology and are then used in patches.
+                items:
+                  description: |-
+                    ClusterClassVariable defines a variable which can
+                    be configured in the Cluster topology and used in patches.
+                  properties:
+                    metadata:
+                      description: |-
+                        metadata is the metadata of a variable.
+                        It can be used to add additional data for higher level tools to
+                        a ClusterClassVariable.
+
+                        Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please use XMetadata in JSONSchemaProps instead.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            annotations is an unstructured key value map that can be used to store and
+                            retrieve arbitrary metadata.
+                            They are not queryable.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            labels is a map of string keys and values that can be used to organize and categorize
+                            (scope and select) variables.
+                          type: object
+                      type: object
+                    name:
+                      description: name of the variable.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    required:
+                      description: |-
+                        required specifies if the variable is required.
+                        Note: this applies to the variable as a whole and thus the
+                        top-level object defined in the schema. If nested fields are
+                        required, this will be specified inside the schema.
+                      type: boolean
+                    schema:
+                      description: schema defines the schema of the variable.
+                      properties:
+                        openAPIV3Schema:
+                          description: |-
+                            openAPIV3Schema defines the schema of a variable via OpenAPI v3
+                            schema. The schema is a subset of the schema used in
+                            Kubernetes CRDs.
+                          properties:
+                            additionalProperties:
+                              description: |-
+                                additionalProperties specifies the schema of values in a map (keys are always strings).
+                                NOTE: Can only be set if type is object.
+                                NOTE: AdditionalProperties is mutually exclusive with Properties.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            allOf:
+                              description: |-
+                                allOf specifies that the variable must validate against all of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            anyOf:
+                              description: |-
+                                anyOf specifies that the variable must validate against one or more of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            default:
+                              description: |-
+                                default is the default value of the variable.
+                                NOTE: Can be set for all types.
+                              x-kubernetes-preserve-unknown-fields: true
+                            description:
+                              description: description is a human-readable description
+                                of this variable.
+                              maxLength: 4096
+                              minLength: 1
+                              type: string
+                            enum:
+                              description: |-
+                                enum is the list of valid values of the variable.
+                                NOTE: Can be set for all types.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              maxItems: 100
+                              type: array
+                            example:
+                              description: example is an example for this variable.
+                              x-kubernetes-preserve-unknown-fields: true
+                            exclusiveMaximum:
+                              description: |-
+                                exclusiveMaximum specifies if the Maximum is exclusive.
+                                NOTE: Can only be set if type is integer or number.
+                              type: boolean
+                            exclusiveMinimum:
+                              description: |-
+                                exclusiveMinimum specifies if the Minimum is exclusive.
+                                NOTE: Can only be set if type is integer or number.
+                              type: boolean
+                            format:
+                              description: |-
+                                format is an OpenAPI v3 format string. Unknown formats are ignored.
+                                For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
+                                https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                NOTE: Can only be set if type is string.
+                              maxLength: 32
+                              minLength: 1
+                              type: string
+                            items:
+                              description: |-
+                                items specifies fields of an array.
+                                NOTE: Can only be set if type is array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            maxItems:
+                              description: |-
+                                maxItems is the max length of an array variable.
+                                NOTE: Can only be set if type is array.
+                              format: int64
+                              type: integer
+                            maxLength:
+                              description: |-
+                                maxLength is the max length of a string variable.
+                                NOTE: Can only be set if type is string.
+                              format: int64
+                              type: integer
+                            maxProperties:
+                              description: |-
+                                maxProperties is the maximum amount of entries in a map or properties in an object.
+                                NOTE: Can only be set if type is object.
+                              format: int64
+                              type: integer
+                            maximum:
+                              description: |-
+                                maximum is the maximum of an integer or number variable.
+                                If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
+                                If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
+                                NOTE: Can only be set if type is integer or number.
+                              format: int64
+                              type: integer
+                            minItems:
+                              description: |-
+                                minItems is the min length of an array variable.
+                                NOTE: Can only be set if type is array.
+                              format: int64
+                              type: integer
+                            minLength:
+                              description: |-
+                                minLength is the min length of a string variable.
+                                NOTE: Can only be set if type is string.
+                              format: int64
+                              type: integer
+                            minProperties:
+                              description: |-
+                                minProperties is the minimum amount of entries in a map or properties in an object.
+                                NOTE: Can only be set if type is object.
+                              format: int64
+                              type: integer
+                            minimum:
+                              description: |-
+                                minimum is the minimum of an integer or number variable.
+                                If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
+                                If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
+                                NOTE: Can only be set if type is integer or number.
+                              format: int64
+                              type: integer
+                            not:
+                              description: |-
+                                not specifies that the variable must not validate against the subschema.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            oneOf:
+                              description: |-
+                                oneOf specifies that the variable must validate against exactly one of the subschemas in the array.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            pattern:
+                              description: |-
+                                pattern is the regex which a string variable must match.
+                                NOTE: Can only be set if type is string.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            properties:
+                              description: |-
+                                properties specifies fields of an object.
+                                NOTE: Can only be set if type is object.
+                                NOTE: Properties is mutually exclusive with AdditionalProperties.
+                                NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                because recursive validation is not possible.
+                              x-kubernetes-preserve-unknown-fields: true
+                            required:
+                              description: |-
+                                required specifies which fields of an object are required.
+                                NOTE: Can only be set if type is object.
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 1000
+                              type: array
+                            type:
+                              description: |-
+                                type is the type of the variable.
+                                Valid values are: object, array, string, integer, number or boolean.
+                              enum:
+                              - object
+                              - array
+                              - string
+                              - integer
+                              - number
+                              - boolean
+                              type: string
+                            uniqueItems:
+                              description: |-
+                                uniqueItems specifies if items in an array must be unique.
+                                NOTE: Can only be set if type is array.
+                              type: boolean
+                            x-kubernetes-int-or-string:
+                              description: |-
+                                x-kubernetes-int-or-string specifies that this value is
+                                either an integer or a string. If this is true, an empty
+                                type is allowed and type as child of anyOf is permitted
+                                if following one of the following patterns:
+
+                                1) anyOf:
+                                   - type: integer
+                                   - type: string
+                                2) allOf:
+                                   - anyOf:
+                                     - type: integer
+                                     - type: string
+                                   - ... zero or more
+                              type: boolean
+                            x-kubernetes-preserve-unknown-fields:
+                              description: |-
+                                x-kubernetes-preserve-unknown-fields allows setting fields in a variable object
+                                which are not defined in the variable schema. This affects fields recursively,
+                                except if nested properties or additionalProperties are specified in the schema.
+                              type: boolean
+                            x-kubernetes-validations:
+                              description: x-kubernetes-validations describes a list
+                                of validation rules written in the CEL expression
+                                language.
+                              items:
+                                description: ValidationRule describes a validation
+                                  rule written in the CEL expression language.
+                                properties:
+                                  fieldPath:
+                                    description: |-
+                                      fieldPath represents the field path returned when the validation fails.
+                                      It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field.
+                                      e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo`
+                                      If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList`
+                                      It does not support list numeric index.
+                                      It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info.
+                                      Numeric index of array is not supported.
+                                      For field name which contains special characters, use `['specialName']` to refer the field name.
+                                      e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  message:
+                                    description: |-
+                                      message represents the message displayed when validation fails. The message is required if the Rule contains
+                                      line breaks. The message must not contain line breaks.
+                                      If unset, the message is "failed rule: {Rule}".
+                                      e.g. "must be a URL with the host matching spec.host"
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  messageExpression:
+                                    description: |-
+                                      messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+                                      Since messageExpression is used as a failure message, it must evaluate to a string.
+                                      If both message and messageExpression are present on a rule, then messageExpression will be used if validation
+                                      fails. If messageExpression results in a runtime error, the validation failure message is produced
+                                      as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string
+                                      that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset.
+                                      messageExpression has access to all the same variables as the rule; the only difference is the return type.
+                                      Example:
+                                      "x must be less than max ("+string(self.max)+")"
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                  reason:
+                                    default: FieldValueInvalid
+                                    description: |-
+                                      reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule.
+                                      The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate".
+                                      If not set, default to use "FieldValueInvalid".
+                                      All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+                                    enum:
+                                    - FieldValueInvalid
+                                    - FieldValueForbidden
+                                    - FieldValueRequired
+                                    - FieldValueDuplicate
+                                    type: string
+                                  rule:
+                                    description: "rule represents the expression which
+                                      will be evaluated by CEL.\nref: https://github.com/google/cel-spec\nThe
+                                      Rule is scoped to the location of the x-kubernetes-validations
+                                      extension in the schema.\nThe `self` variable
+                                      in the CEL expression is bound to the scoped
+                                      value.\nIf the Rule is scoped to an object with
+                                      properties, the accessible properties of the
+                                      object are field selectable\nvia `self.field`
+                                      and field presence can be checked via `has(self.field)`.\nIf
+                                      the Rule is scoped to an object with additionalProperties
+                                      (i.e. a map) the value of the map\nare accessible
+                                      via `self[mapKey]`, map containment can be checked
+                                      via `mapKey in self` and all entries of the
+                                      map\nare accessible via CEL macros and functions
+                                      such as `self.all(...)`.\nIf the Rule is scoped
+                                      to an array, the elements of the array are accessible
+                                      via `self[i]` and also by macros and\nfunctions.\nIf
+                                      the Rule is scoped to a scalar, `self` is bound
+                                      to the scalar value.\nExamples:\n- Rule scoped
+                                      to a map of objects: {\"rule\": \"self.components['Widget'].priority
+                                      < 10\"}\n- Rule scoped to a list of integers:
+                                      {\"rule\": \"self.values.all(value, value >=
+                                      0 && value < 100)\"}\n- Rule scoped to a string
+                                      value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown
+                                      data preserved in custom resources via x-kubernetes-preserve-unknown-fields
+                                      is not accessible in CEL\nexpressions. This
+                                      includes:\n- Unknown field values that are preserved
+                                      by object schemas with x-kubernetes-preserve-unknown-fields.\n-
+                                      Object properties where the property schema
+                                      is of an \"unknown type\". An \"unknown type\"
+                                      is recursively defined as:\n  - A schema with
+                                      no type and x-kubernetes-preserve-unknown-fields
+                                      set to true\n  - An array where the items schema
+                                      is of an \"unknown type\"\n  - An object where
+                                      the additionalProperties schema is of an \"unknown
+                                      type\"\n\nOnly property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`
+                                      are accessible.\nAccessible property names are
+                                      escaped according to the following rules when
+                                      accessed in the expression:\n- '__' escapes
+                                      to '__underscores__'\n- '.' escapes to '__dot__'\n-
+                                      '-' escapes to '__dash__'\n- '/' escapes to
+                                      '__slash__'\n- Property names that exactly match
+                                      a CEL RESERVED keyword escape to '__{keyword}__'.
+                                      The keywords are:\n\t  \"true\", \"false\",
+                                      \"null\", \"in\", \"as\", \"break\", \"const\",
+                                      \"continue\", \"else\", \"for\", \"function\",
+                                      \"if\",\n\t  \"import\", \"let\", \"loop\",
+                                      \"package\", \"namespace\", \"return\".\nExamples:\n
+                                      \ - Rule accessing a property named \"namespace\":
+                                      {\"rule\": \"self.__namespace__ > 0\"}\n  -
+                                      Rule accessing a property named \"x-prop\":
+                                      {\"rule\": \"self.x__dash__prop > 0\"}\n  -
+                                      Rule accessing a property named \"redact__d\":
+                                      {\"rule\": \"self.redact__underscores__d > 0\"}\n\nIf
+                                      `rule` makes use of the `oldSelf` variable it
+                                      is implicitly a\n`transition rule`.\n\nBy default,
+                                      the `oldSelf` variable is the same type as `self`.\n\nTransition
+                                      rules by default are applied only on UPDATE
+                                      requests and are\nskipped if an old value could
+                                      not be found."
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - rule
+                                type: object
+                              maxItems: 100
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - rule
+                              x-kubernetes-list-type: map
+                            x-metadata:
+                              description: |-
+                                x-metadata is the metadata of a variable or a nested field within a variable.
+                                It can be used to add additional data for higher level tools.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map that can be used to store and
+                                    retrieve arbitrary metadata.
+                                    They are not queryable.
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) variables.
+                                  type: object
+                              type: object
+                          type: object
+                      required:
+                      - openAPIV3Schema
+                      type: object
+                  required:
+                  - name
+                  - required
+                  - schema
+                  type: object
+                maxItems: 1000
+                type: array
+              workers:
+                description: |-
+                  workers describes the worker nodes for the cluster.
+                  It is a collection of node types which can be used to create
+                  the worker nodes of the cluster.
+                properties:
+                  machineDeployments:
+                    description: |-
+                      machineDeployments is a list of machine deployment classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachineDeploymentClass serves as a template to define a set of worker nodes of the cluster
+                        provisioned using the `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of worker node present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachineDeployment.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        failureDomain:
+                          description: |-
+                            failureDomain is the failure domain the machines will be created in.
+                            Must match a key in the FailureDomains map stored on the cluster object.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        machineHealthCheck:
+                          description: machineHealthCheck defines a MachineHealthCheck
+                            for this MachineDeploymentClass.
+                          properties:
+                            maxUnhealthy:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                                "selector" are not healthy.
+                              x-kubernetes-int-or-string: true
+                            nodeStartupTimeout:
+                              description: |-
+                                nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                to consider a Machine unhealthy if a corresponding Node isn't associated
+                                through a `Spec.ProviderID` field.
+
+                                The duration set in this field is compared to the greatest of:
+                                - Cluster's infrastructure ready condition timestamp (if and when available)
+                                - Control Plane's initialized condition timestamp (if and when available)
+                                - Machine's infrastructure ready condition timestamp (if and when available)
+                                - Machine's metadata creation timestamp
+
+                                Defaults to 10 minutes.
+                                If you wish to disable this feature, set the value explicitly to 0.
+                              type: string
+                            remediationTemplate:
+                              description: |-
+                                remediationTemplate is a reference to a remediation template
+                                provided by an infrastructure provider.
+
+                                This field is completely optional, when filled, the MachineHealthCheck controller
+                                creates a new object from the template referenced and hands off remediation of the machine to
+                                a controller that lives outside of Cluster API.
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                fieldPath:
+                                  description: |-
+                                    If referring to a piece of an object instead of an entire object, this string
+                                    should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                    For example, if the object reference is to a container within a pod, this would take on a value like:
+                                    "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                    the event) or if no container name is specified "spec.containers[2]" (container with
+                                    index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                    referencing a part of an object.
+                                  type: string
+                                kind:
+                                  description: |-
+                                    Kind of the referent.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                  type: string
+                                name:
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                namespace:
+                                  description: |-
+                                    Namespace of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                  type: string
+                                resourceVersion:
+                                  description: |-
+                                    Specific resourceVersion to which this reference is made, if any.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                  type: string
+                                uid:
+                                  description: |-
+                                    UID of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            unhealthyConditions:
+                              description: |-
+                                unhealthyConditions contains a list of the conditions that determine
+                                whether a node is considered unhealthy. The conditions are combined in a
+                                logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                              items:
+                                description: |-
+                                  UnhealthyCondition represents a Node condition type and value with a timeout
+                                  specified as a duration.  When the named condition has been in the given
+                                  status for at least the timeout value, a node is considered unhealthy.
+                                properties:
+                                  status:
+                                    description: status of the condition, one of True,
+                                      False, Unknown.
+                                    minLength: 1
+                                    type: string
+                                  timeout:
+                                    description: |-
+                                      timeout is the duration that a node must be in a given status for,
+                                      after which the node is considered unhealthy.
+                                      For example, with a value of "1h", the node must match the status
+                                      for at least 1 hour before being considered unhealthy.
+                                    type: string
+                                  type:
+                                    description: type of Node condition
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - status
+                                - timeout
+                                - type
+                                type: object
+                              maxItems: 100
+                              type: array
+                            unhealthyRange:
+                              description: |-
+                                unhealthyRange specifies the range of unhealthy machines allowed.
+                                Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                                Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                (a) there are at least 3 unhealthy machines (and)
+                                (b) there are at most 5 unhealthy machines
+                              maxLength: 32
+                              minLength: 1
+                              pattern: ^\[[0-9]+-[0-9]+\]$
+                              type: string
+                          type: object
+                        minReadySeconds:
+                          description: |-
+                            minReadySeconds is the minimum number of seconds for which a newly created machine should
+                            be ready.
+                            Defaults to 0 (machine will be considered available as soon as it
+                            is ready)
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          format: int32
+                          type: integer
+                        namingStrategy:
+                          description: namingStrategy allows changing the naming pattern
+                            used when creating the MachineDeployment.
+                          properties:
+                            template:
+                              description: |-
+                                template defines the template to use for generating the name of the MachineDeployment object.
+                                If not defined, it will fallback to `{{ .cluster.name }}-{{ .machineDeployment.topologyName }}-{{ .random }}`.
+                                If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                                get concatenated with a random suffix of length 5.
+                                The templating mechanism provides the following arguments:
+                                * `.cluster.name`: The name of the cluster object.
+                                * `.random`: A random alphanumeric string, without vowels, of length 5.
+                                * `.machineDeployment.topologyName`: The name of the MachineDeployment topology (Cluster.spec.topology.workers.machineDeployments[].name).
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          type: object
+                        nodeDeletionTimeout:
+                          description: |-
+                            nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                            hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                            Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        nodeDrainTimeout:
+                          description: |-
+                            nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                            The default value is 0, meaning that the node can be drained without any time limitations.
+                            NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: |-
+                            nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                            to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          type: string
+                        readinessGates:
+                          description: |-
+                            readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                            This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                            computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                            NOTE: This field is considered only for computing v1beta2 conditions.
+                            NOTE: If a Cluster defines a custom list of readinessGates for a MachineDeployment using this MachineDeploymentClass,
+                            such list overrides readinessGates defined in this field.
+                          items:
+                            description: MachineReadinessGate contains the type of
+                              a Machine condition to be used as a readiness gate.
+                            properties:
+                              conditionType:
+                                description: |-
+                                  conditionType refers to a condition with matching type in the Machine's condition list.
+                                  If the conditions doesn't exist, it will be treated as unknown.
+                                  Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                                maxLength: 316
+                                minLength: 1
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                              polarity:
+                                description: |-
+                                  polarity of the conditionType specified in this readinessGate.
+                                  Valid values are Positive, Negative and omitted.
+                                  When omitted, the default behaviour will be Positive.
+                                  A positive polarity means that the condition should report a true status under normal conditions.
+                                  A negative polarity means that the condition should report a false status under normal conditions.
+                                enum:
+                                - Positive
+                                - Negative
+                                type: string
+                            required:
+                            - conditionType
+                            type: object
+                          maxItems: 32
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - conditionType
+                          x-kubernetes-list-type: map
+                        strategy:
+                          description: |-
+                            strategy is the deployment strategy to use to replace existing machines with
+                            new ones.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachineDeploymentClass.
+                          properties:
+                            remediation:
+                              description: |-
+                                remediation controls the strategy of remediating unhealthy machines
+                                and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                              properties:
+                                maxInFlight:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                    Remediation only happens on the MachineSet with the most current revision, while
+                                    older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                    Note: In general (independent of remediations), unhealthy machines are always
+                                    prioritized during scale down operations over healthy ones.
+
+                                    MaxInFlight can be set to a fixed number or a percentage.
+                                    Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                    the desired replicas.
+
+                                    If not set, remediation is limited to all machines (bounded by replicas)
+                                    under the active MachineSet's management.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            rollingUpdate:
+                              description: |-
+                                rollingUpdate is the rolling update config params. Present only if
+                                MachineDeploymentStrategyType = RollingUpdate.
+                              properties:
+                                deletePolicy:
+                                  description: |-
+                                    deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                    Valid values are "Random", "Newest", "Oldest"
+                                    When no value is supplied, the default DeletePolicy of MachineSet is used
+                                  enum:
+                                  - Random
+                                  - Newest
+                                  - Oldest
+                                  type: string
+                                maxSurge:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxSurge is the maximum number of machines that can be scheduled above the
+                                    desired number of machines.
+                                    Value can be an absolute number (ex: 5) or a percentage of
+                                    desired machines (ex: 10%).
+                                    This can not be 0 if MaxUnavailable is 0.
+                                    Absolute number is calculated from percentage by rounding up.
+                                    Defaults to 1.
+                                    Example: when this is set to 30%, the new MachineSet can be scaled
+                                    up immediately when the rolling update starts, such that the total
+                                    number of old and new machines do not exceed 130% of desired
+                                    machines. Once old machines have been killed, new MachineSet can
+                                    be scaled up further, ensuring that total number of machines running
+                                    at any time during the update is at most 130% of desired machines.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired
+                                    machines (ex: 10%).
+                                    Absolute number is calculated from percentage by rounding down.
+                                    This can not be 0 if MaxSurge is 0.
+                                    Defaults to 0.
+                                    Example: when this is set to 30%, the old MachineSet can be scaled
+                                    down to 70% of desired machines immediately when the rolling update
+                                    starts. Once new machines are ready, old MachineSet can be scaled
+                                    down further, followed by scaling up the new MachineSet, ensuring
+                                    that the total number of machines available at all times
+                                    during the update is at least 70% of desired machines.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: |-
+                                type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                The default is RollingUpdate.
+                              enum:
+                              - RollingUpdate
+                              - OnDelete
+                              type: string
+                          type: object
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachineDeployment objects representing a set of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of worker Machines.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    maxItems: 100
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - class
+                    x-kubernetes-list-type: map
+                  machinePools:
+                    description: |-
+                      machinePools is a list of machine pool classes that can be used to create
+                      a set of worker nodes.
+                    items:
+                      description: |-
+                        MachinePoolClass serves as a template to define a pool of worker nodes of the cluster
+                        provisioned using `ClusterClass`.
+                      properties:
+                        class:
+                          description: |-
+                            class denotes a type of machine pool present in the cluster,
+                            this name MUST be unique within a ClusterClass and can be referenced
+                            in the Cluster to create a managed MachinePool.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        failureDomains:
+                          description: |-
+                            failureDomains is the list of failure domains the MachinePool should be attached to.
+                            Must match a key in the FailureDomains map stored on the cluster object.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          items:
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          maxItems: 100
+                          type: array
+                        minReadySeconds:
+                          description: |-
+                            minReadySeconds is the minimum number of seconds for which a newly created machine pool should
+                            be ready.
+                            Defaults to 0 (machine will be considered available as soon as it
+                            is ready)
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          format: int32
+                          type: integer
+                        namingStrategy:
+                          description: namingStrategy allows changing the naming pattern
+                            used when creating the MachinePool.
+                          properties:
+                            template:
+                              description: |-
+                                template defines the template to use for generating the name of the MachinePool object.
+                                If not defined, it will fallback to `{{ .cluster.name }}-{{ .machinePool.topologyName }}-{{ .random }}`.
+                                If the templated string exceeds 63 characters, it will be trimmed to 58 characters and will
+                                get concatenated with a random suffix of length 5.
+                                The templating mechanism provides the following arguments:
+                                * `.cluster.name`: The name of the cluster object.
+                                * `.random`: A random alphanumeric string, without vowels, of length 5.
+                                * `.machinePool.topologyName`: The name of the MachinePool topology (Cluster.spec.topology.workers.machinePools[].name).
+                              maxLength: 1024
+                              minLength: 1
+                              type: string
+                          type: object
+                        nodeDeletionTimeout:
+                          description: |-
+                            nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                            hosts after the Machine Pool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                            Defaults to 10 seconds.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        nodeDrainTimeout:
+                          description: |-
+                            nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                            The default value is 0, meaning that the node can be drained without any time limitations.
+                            NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        nodeVolumeDetachTimeout:
+                          description: |-
+                            nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                            to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            NOTE: This value can be overridden while defining a Cluster.Topology using this MachinePoolClass.
+                          type: string
+                        template:
+                          description: |-
+                            template is a local struct containing a collection of templates for creation of
+                            MachinePools objects representing a pool of worker nodes.
+                          properties:
+                            bootstrap:
+                              description: |-
+                                bootstrap contains the bootstrap template reference to be used
+                                for the creation of the Machines in the MachinePool.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            infrastructure:
+                              description: |-
+                                infrastructure contains the infrastructure template reference to be used
+                                for the creation of the MachinePool.
+                              properties:
+                                ref:
+                                  description: |-
+                                    ref is a required reference to a custom resource
+                                    offered by a provider.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - ref
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachinePool.
+                                At runtime this metadata is merged with the corresponding metadata from the topology.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                          required:
+                          - bootstrap
+                          - infrastructure
+                          type: object
+                      required:
+                      - class
+                      - template
+                      type: object
+                    maxItems: 100
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - class
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+          status:
+            description: status is the observed state of ClusterClass.
+            properties:
+              conditions:
+                description: conditions defines current observed state of the ClusterClass.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ClusterClass's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ClusterClass's current state.
+                      Known condition types are VariablesReady, RefVersionsUpToDate, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+              variables:
+                description: variables is a list of ClusterClassStatusVariable that
+                  are defined for the ClusterClass.
+                items:
+                  description: ClusterClassStatusVariable defines a variable which
+                    appears in the status of a ClusterClass.
+                  properties:
+                    definitions:
+                      description: definitions is a list of definitions for a variable.
+                      items:
+                        description: ClusterClassStatusVariableDefinition defines
+                          a variable which appears in the status of a ClusterClass.
+                        properties:
+                          from:
+                            description: |-
+                              from specifies the origin of the variable definition.
+                              This will be `inline` for variables defined in the ClusterClass or the name of a patch defined in the ClusterClass
+                              for variables discovered from a DiscoverVariables runtime extensions.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          metadata:
+                            description: |-
+                              metadata is the metadata of a variable.
+                              It can be used to add additional data for higher level tools to
+                              a ClusterClassVariable.
+
+                              Deprecated: This field is deprecated and is going to be removed in the next apiVersion.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map that can be used to store and
+                                  retrieve arbitrary metadata.
+                                  They are not queryable.
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  labels is a map of string keys and values that can be used to organize and categorize
+                                  (scope and select) variables.
+                                type: object
+                            type: object
+                          required:
+                            description: |-
+                              required specifies if the variable is required.
+                              Note: this applies to the variable as a whole and thus the
+                              top-level object defined in the schema. If nested fields are
+                              required, this will be specified inside the schema.
+                            type: boolean
+                          schema:
+                            description: schema defines the schema of the variable.
+                            properties:
+                              openAPIV3Schema:
+                                description: |-
+                                  openAPIV3Schema defines the schema of a variable via OpenAPI v3
+                                  schema. The schema is a subset of the schema used in
+                                  Kubernetes CRDs.
+                                properties:
+                                  additionalProperties:
+                                    description: |-
+                                      additionalProperties specifies the schema of values in a map (keys are always strings).
+                                      NOTE: Can only be set if type is object.
+                                      NOTE: AdditionalProperties is mutually exclusive with Properties.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  allOf:
+                                    description: |-
+                                      allOf specifies that the variable must validate against all of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  anyOf:
+                                    description: |-
+                                      anyOf specifies that the variable must validate against one or more of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  default:
+                                    description: |-
+                                      default is the default value of the variable.
+                                      NOTE: Can be set for all types.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  description:
+                                    description: description is a human-readable description
+                                      of this variable.
+                                    maxLength: 4096
+                                    minLength: 1
+                                    type: string
+                                  enum:
+                                    description: |-
+                                      enum is the list of valid values of the variable.
+                                      NOTE: Can be set for all types.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    maxItems: 100
+                                    type: array
+                                  example:
+                                    description: example is an example for this variable.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  exclusiveMaximum:
+                                    description: |-
+                                      exclusiveMaximum specifies if the Maximum is exclusive.
+                                      NOTE: Can only be set if type is integer or number.
+                                    type: boolean
+                                  exclusiveMinimum:
+                                    description: |-
+                                      exclusiveMinimum specifies if the Minimum is exclusive.
+                                      NOTE: Can only be set if type is integer or number.
+                                    type: boolean
+                                  format:
+                                    description: |-
+                                      format is an OpenAPI v3 format string. Unknown formats are ignored.
+                                      For a list of supported formats please see: (of the k8s.io/apiextensions-apiserver version we're currently using)
+                                      https://github.com/kubernetes/apiextensions-apiserver/blob/master/pkg/apiserver/validation/formats.go
+                                      NOTE: Can only be set if type is string.
+                                    maxLength: 32
+                                    minLength: 1
+                                    type: string
+                                  items:
+                                    description: |-
+                                      items specifies fields of an array.
+                                      NOTE: Can only be set if type is array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  maxItems:
+                                    description: |-
+                                      maxItems is the max length of an array variable.
+                                      NOTE: Can only be set if type is array.
+                                    format: int64
+                                    type: integer
+                                  maxLength:
+                                    description: |-
+                                      maxLength is the max length of a string variable.
+                                      NOTE: Can only be set if type is string.
+                                    format: int64
+                                    type: integer
+                                  maxProperties:
+                                    description: |-
+                                      maxProperties is the maximum amount of entries in a map or properties in an object.
+                                      NOTE: Can only be set if type is object.
+                                    format: int64
+                                    type: integer
+                                  maximum:
+                                    description: |-
+                                      maximum is the maximum of an integer or number variable.
+                                      If ExclusiveMaximum is false, the variable is valid if it is lower than, or equal to, the value of Maximum.
+                                      If ExclusiveMaximum is true, the variable is valid if it is strictly lower than the value of Maximum.
+                                      NOTE: Can only be set if type is integer or number.
+                                    format: int64
+                                    type: integer
+                                  minItems:
+                                    description: |-
+                                      minItems is the min length of an array variable.
+                                      NOTE: Can only be set if type is array.
+                                    format: int64
+                                    type: integer
+                                  minLength:
+                                    description: |-
+                                      minLength is the min length of a string variable.
+                                      NOTE: Can only be set if type is string.
+                                    format: int64
+                                    type: integer
+                                  minProperties:
+                                    description: |-
+                                      minProperties is the minimum amount of entries in a map or properties in an object.
+                                      NOTE: Can only be set if type is object.
+                                    format: int64
+                                    type: integer
+                                  minimum:
+                                    description: |-
+                                      minimum is the minimum of an integer or number variable.
+                                      If ExclusiveMinimum is false, the variable is valid if it is greater than, or equal to, the value of Minimum.
+                                      If ExclusiveMinimum is true, the variable is valid if it is strictly greater than the value of Minimum.
+                                      NOTE: Can only be set if type is integer or number.
+                                    format: int64
+                                    type: integer
+                                  not:
+                                    description: |-
+                                      not specifies that the variable must not validate against the subschema.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  oneOf:
+                                    description: |-
+                                      oneOf specifies that the variable must validate against exactly one of the subschemas in the array.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  pattern:
+                                    description: |-
+                                      pattern is the regex which a string variable must match.
+                                      NOTE: Can only be set if type is string.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  properties:
+                                    description: |-
+                                      properties specifies fields of an object.
+                                      NOTE: Can only be set if type is object.
+                                      NOTE: Properties is mutually exclusive with AdditionalProperties.
+                                      NOTE: This field uses PreserveUnknownFields and Schemaless,
+                                      because recursive validation is not possible.
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  required:
+                                    description: |-
+                                      required specifies which fields of an object are required.
+                                      NOTE: Can only be set if type is object.
+                                    items:
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 1000
+                                    type: array
+                                  type:
+                                    description: |-
+                                      type is the type of the variable.
+                                      Valid values are: object, array, string, integer, number or boolean.
+                                    enum:
+                                    - object
+                                    - array
+                                    - string
+                                    - integer
+                                    - number
+                                    - boolean
+                                    type: string
+                                  uniqueItems:
+                                    description: |-
+                                      uniqueItems specifies if items in an array must be unique.
+                                      NOTE: Can only be set if type is array.
+                                    type: boolean
+                                  x-kubernetes-int-or-string:
+                                    description: |-
+                                      x-kubernetes-int-or-string specifies that this value is
+                                      either an integer or a string. If this is true, an empty
+                                      type is allowed and type as child of anyOf is permitted
+                                      if following one of the following patterns:
+
+                                      1) anyOf:
+                                         - type: integer
+                                         - type: string
+                                      2) allOf:
+                                         - anyOf:
+                                           - type: integer
+                                           - type: string
+                                         - ... zero or more
+                                    type: boolean
+                                  x-kubernetes-preserve-unknown-fields:
+                                    description: |-
+                                      x-kubernetes-preserve-unknown-fields allows setting fields in a variable object
+                                      which are not defined in the variable schema. This affects fields recursively,
+                                      except if nested properties or additionalProperties are specified in the schema.
+                                    type: boolean
+                                  x-kubernetes-validations:
+                                    description: x-kubernetes-validations describes
+                                      a list of validation rules written in the CEL
+                                      expression language.
+                                    items:
+                                      description: ValidationRule describes a validation
+                                        rule written in the CEL expression language.
+                                      properties:
+                                        fieldPath:
+                                          description: |-
+                                            fieldPath represents the field path returned when the validation fails.
+                                            It must be a relative JSON path (i.e. with array notation) scoped to the location of this x-kubernetes-validations extension in the schema and refer to an existing field.
+                                            e.g. when validation checks if a specific attribute `foo` under a map `testMap`, the fieldPath could be set to `.testMap.foo`
+                                            If the validation checks two lists must have unique attributes, the fieldPath could be set to either of the list: e.g. `.testList`
+                                            It does not support list numeric index.
+                                            It supports child operation to refer to an existing field currently. Refer to [JSONPath support in Kubernetes](https://kubernetes.io/docs/reference/kubectl/jsonpath/) for more info.
+                                            Numeric index of array is not supported.
+                                            For field name which contains special characters, use `['specialName']` to refer the field name.
+                                            e.g. for attribute `foo.34$` appears in a list `testList`, the fieldPath could be set to `.testList['foo.34$']`
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        message:
+                                          description: |-
+                                            message represents the message displayed when validation fails. The message is required if the Rule contains
+                                            line breaks. The message must not contain line breaks.
+                                            If unset, the message is "failed rule: {Rule}".
+                                            e.g. "must be a URL with the host matching spec.host"
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        messageExpression:
+                                          description: |-
+                                            messageExpression declares a CEL expression that evaluates to the validation failure message that is returned when this rule fails.
+                                            Since messageExpression is used as a failure message, it must evaluate to a string.
+                                            If both message and messageExpression are present on a rule, then messageExpression will be used if validation
+                                            fails. If messageExpression results in a runtime error, the validation failure message is produced
+                                            as if the messageExpression field were unset. If messageExpression evaluates to an empty string, a string with only spaces, or a string
+                                            that contains line breaks, then the validation failure message will also be produced as if the messageExpression field were unset.
+                                            messageExpression has access to all the same variables as the rule; the only difference is the return type.
+                                            Example:
+                                            "x must be less than max ("+string(self.max)+")"
+                                          maxLength: 1024
+                                          minLength: 1
+                                          type: string
+                                        reason:
+                                          default: FieldValueInvalid
+                                          description: |-
+                                            reason provides a machine-readable validation failure reason that is returned to the caller when a request fails this validation rule.
+                                            The currently supported reasons are: "FieldValueInvalid", "FieldValueForbidden", "FieldValueRequired", "FieldValueDuplicate".
+                                            If not set, default to use "FieldValueInvalid".
+                                            All future added reasons must be accepted by clients when reading this value and unknown reasons should be treated as FieldValueInvalid.
+                                          enum:
+                                          - FieldValueInvalid
+                                          - FieldValueForbidden
+                                          - FieldValueRequired
+                                          - FieldValueDuplicate
+                                          type: string
+                                        rule:
+                                          description: "rule represents the expression
+                                            which will be evaluated by CEL.\nref:
+                                            https://github.com/google/cel-spec\nThe
+                                            Rule is scoped to the location of the
+                                            x-kubernetes-validations extension in
+                                            the schema.\nThe `self` variable in the
+                                            CEL expression is bound to the scoped
+                                            value.\nIf the Rule is scoped to an object
+                                            with properties, the accessible properties
+                                            of the object are field selectable\nvia
+                                            `self.field` and field presence can be
+                                            checked via `has(self.field)`.\nIf the
+                                            Rule is scoped to an object with additionalProperties
+                                            (i.e. a map) the value of the map\nare
+                                            accessible via `self[mapKey]`, map containment
+                                            can be checked via `mapKey in self` and
+                                            all entries of the map\nare accessible
+                                            via CEL macros and functions such as `self.all(...)`.\nIf
+                                            the Rule is scoped to an array, the elements
+                                            of the array are accessible via `self[i]`
+                                            and also by macros and\nfunctions.\nIf
+                                            the Rule is scoped to a scalar, `self`
+                                            is bound to the scalar value.\nExamples:\n-
+                                            Rule scoped to a map of objects: {\"rule\":
+                                            \"self.components['Widget'].priority <
+                                            10\"}\n- Rule scoped to a list of integers:
+                                            {\"rule\": \"self.values.all(value, value
+                                            >= 0 && value < 100)\"}\n- Rule scoped
+                                            to a string value: {\"rule\": \"self.startsWith('kube')\"}\n\nUnknown
+                                            data preserved in custom resources via
+                                            x-kubernetes-preserve-unknown-fields is
+                                            not accessible in CEL\nexpressions. This
+                                            includes:\n- Unknown field values that
+                                            are preserved by object schemas with x-kubernetes-preserve-unknown-fields.\n-
+                                            Object properties where the property schema
+                                            is of an \"unknown type\". An \"unknown
+                                            type\" is recursively defined as:\n  -
+                                            A schema with no type and x-kubernetes-preserve-unknown-fields
+                                            set to true\n  - An array where the items
+                                            schema is of an \"unknown type\"\n  -
+                                            An object where the additionalProperties
+                                            schema is of an \"unknown type\"\n\nOnly
+                                            property names of the form `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*`
+                                            are accessible.\nAccessible property names
+                                            are escaped according to the following
+                                            rules when accessed in the expression:\n-
+                                            '__' escapes to '__underscores__'\n- '.'
+                                            escapes to '__dot__'\n- '-' escapes to
+                                            '__dash__'\n- '/' escapes to '__slash__'\n-
+                                            Property names that exactly match a CEL
+                                            RESERVED keyword escape to '__{keyword}__'.
+                                            The keywords are:\n\t  \"true\", \"false\",
+                                            \"null\", \"in\", \"as\", \"break\", \"const\",
+                                            \"continue\", \"else\", \"for\", \"function\",
+                                            \"if\",\n\t  \"import\", \"let\", \"loop\",
+                                            \"package\", \"namespace\", \"return\".\nExamples:\n
+                                            \ - Rule accessing a property named \"namespace\":
+                                            {\"rule\": \"self.__namespace__ > 0\"}\n
+                                            \ - Rule accessing a property named \"x-prop\":
+                                            {\"rule\": \"self.x__dash__prop > 0\"}\n
+                                            \ - Rule accessing a property named \"redact__d\":
+                                            {\"rule\": \"self.redact__underscores__d
+                                            > 0\"}\n\nIf `rule` makes use of the `oldSelf`
+                                            variable it is implicitly a\n`transition
+                                            rule`.\n\nBy default, the `oldSelf` variable
+                                            is the same type as `self`.\n\nTransition
+                                            rules by default are applied only on UPDATE
+                                            requests and are\nskipped if an old value
+                                            could not be found."
+                                          maxLength: 4096
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - rule
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - rule
+                                    x-kubernetes-list-type: map
+                                  x-metadata:
+                                    description: |-
+                                      x-metadata is the metadata of a variable or a nested field within a variable.
+                                      It can be used to add additional data for higher level tools.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          annotations is an unstructured key value map that can be used to store and
+                                          retrieve arbitrary metadata.
+                                          They are not queryable.
+                                        type: object
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          labels is a map of string keys and values that can be used to organize and categorize
+                                          (scope and select) variables.
+                                        type: object
+                                    type: object
+                                type: object
+                            required:
+                            - openAPIV3Schema
+                            type: object
+                        required:
+                        - from
+                        - required
+                        - schema
+                        type: object
+                      maxItems: 100
+                      type: array
+                    definitionsConflict:
+                      description: definitionsConflict specifies whether or not there
+                        are conflicting definitions for a single variable name.
+                      type: boolean
+                    name:
+                      description: name is the name of the variable.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - definitions
+                  - name
+                  type: object
+                maxItems: 1000
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_clusters.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_clusters.yaml
@@ -1,0 +1,1451 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: clusters.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Cluster
+    listKind: ClusterList
+    plural: clusters
+    shortNames:
+    - cl
+    singular: cluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: ClusterClass of this Cluster, empty if the Cluster is not using
+        a ClusterClass
+      jsonPath: .spec.topology.class
+      name: ClusterClass
+      type: string
+    - description: Cluster status such as Pending/Provisioning/Provisioned/Deleting/Failed
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Cluster
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Cluster
+      jsonPath: .spec.topology.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Cluster is the Schema for the clusters API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Cluster.
+            properties:
+              availabilityGates:
+                description: |-
+                  availabilityGates specifies additional conditions to include when evaluating Cluster Available condition.
+
+                  If this field is not defined and the Cluster implements a managed topology, availabilityGates
+                  from the corresponding ClusterClass will be used, if any.
+
+                  NOTE: this field is considered only for computing v1beta2 conditions.
+                items:
+                  description: ClusterAvailabilityGate contains the type of a Cluster
+                    condition to be used as availability gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a condition with matching type in the Cluster's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as availability gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this availabilityGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                      - Positive
+                      - Negative
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              clusterNetwork:
+                description: clusterNetwork represents the cluster network configuration.
+                properties:
+                  apiServerPort:
+                    description: |-
+                      apiServerPort specifies the port the API Server should bind to.
+                      Defaults to 6443.
+                    format: int32
+                    type: integer
+                  pods:
+                    description: pods is the network ranges from which Pod networks
+                      are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          maxLength: 43
+                          minLength: 1
+                          type: string
+                        maxItems: 100
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                  serviceDomain:
+                    description: serviceDomain is the domain name for services.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  services:
+                    description: services is the network ranges from which service
+                      VIPs are allocated.
+                    properties:
+                      cidrBlocks:
+                        description: cidrBlocks is a list of CIDR blocks.
+                        items:
+                          maxLength: 43
+                          minLength: 1
+                          type: string
+                        maxItems: 100
+                        type: array
+                    required:
+                    - cidrBlocks
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: controlPlaneEndpoint represents the endpoint used to
+                  communicate with the control plane.
+                properties:
+                  host:
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
+                    type: string
+                  port:
+                    description: port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controlPlaneRef:
+                description: |-
+                  controlPlaneRef is an optional reference to a provider-specific resource that holds
+                  the details for provisioning the Control Plane for a Cluster.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a reference to a provider-specific resource that holds the details
+                  for provisioning infrastructure for a cluster in said provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: paused can be used to prevent controllers from processing
+                  the Cluster and all its associated objects.
+                type: boolean
+              topology:
+                description: |-
+                  topology encapsulates the topology for the cluster.
+                  NOTE: It is required to enable the ClusterTopology
+                  feature gate flag to activate managed topologies support;
+                  this feature is highly experimental, and parts of it might still be not implemented.
+                properties:
+                  class:
+                    description: class is the name of the ClusterClass object to create
+                      the topology.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  classNamespace:
+                    description: |-
+                      classNamespace is the namespace of the ClusterClass that should be used for the topology.
+                      If classNamespace is empty or not set, it is defaulted to the namespace of the Cluster object.
+                      classNamespace must be a valid namespace name and because of that be at most 63 characters in length
+                      and it must consist only of lower case alphanumeric characters or hyphens (-), and must start
+                      and end with an alphanumeric character.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  controlPlane:
+                    description: controlPlane describes the cluster control plane.
+                    properties:
+                      machineHealthCheck:
+                        description: |-
+                          machineHealthCheck allows to enable, disable and override
+                          the MachineHealthCheck configuration in the ClusterClass for this control plane.
+                        properties:
+                          enable:
+                            description: |-
+                              enable controls if a MachineHealthCheck should be created for the target machines.
+
+                              If false: No MachineHealthCheck will be created.
+
+                              If not set(default): A MachineHealthCheck will be created if it is defined here or
+                               in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                              If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                              block if `enable` is true and no MachineHealthCheck definition is available.
+                            type: boolean
+                          maxUnhealthy:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                              Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                              "selector" are not healthy.
+                            x-kubernetes-int-or-string: true
+                          nodeStartupTimeout:
+                            description: |-
+                              nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                              to consider a Machine unhealthy if a corresponding Node isn't associated
+                              through a `Spec.ProviderID` field.
+
+                              The duration set in this field is compared to the greatest of:
+                              - Cluster's infrastructure ready condition timestamp (if and when available)
+                              - Control Plane's initialized condition timestamp (if and when available)
+                              - Machine's infrastructure ready condition timestamp (if and when available)
+                              - Machine's metadata creation timestamp
+
+                              Defaults to 10 minutes.
+                              If you wish to disable this feature, set the value explicitly to 0.
+                            type: string
+                          remediationTemplate:
+                            description: |-
+                              remediationTemplate is a reference to a remediation template
+                              provided by an infrastructure provider.
+
+                              This field is completely optional, when filled, the MachineHealthCheck controller
+                              creates a new object from the template referenced and hands off remediation of the machine to
+                              a controller that lives outside of Cluster API.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          unhealthyConditions:
+                            description: |-
+                              unhealthyConditions contains a list of the conditions that determine
+                              whether a node is considered unhealthy. The conditions are combined in a
+                              logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                            items:
+                              description: |-
+                                UnhealthyCondition represents a Node condition type and value with a timeout
+                                specified as a duration.  When the named condition has been in the given
+                                status for at least the timeout value, a node is considered unhealthy.
+                              properties:
+                                status:
+                                  description: status of the condition, one of True,
+                                    False, Unknown.
+                                  minLength: 1
+                                  type: string
+                                timeout:
+                                  description: |-
+                                    timeout is the duration that a node must be in a given status for,
+                                    after which the node is considered unhealthy.
+                                    For example, with a value of "1h", the node must match the status
+                                    for at least 1 hour before being considered unhealthy.
+                                  type: string
+                                type:
+                                  description: type of Node condition
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - status
+                              - timeout
+                              - type
+                              type: object
+                            maxItems: 100
+                            type: array
+                          unhealthyRange:
+                            description: |-
+                              unhealthyRange specifies the range of unhealthy machines allowed.
+                              Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                              is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                              Eg. "[3-5]" - This means that remediation will be allowed only when:
+                              (a) there are at least 3 unhealthy machines (and)
+                              (b) there are at most 5 unhealthy machines
+                            maxLength: 32
+                            minLength: 1
+                            pattern: ^\[[0-9]+-[0-9]+\]$
+                            type: string
+                        type: object
+                      metadata:
+                        description: |-
+                          metadata is the metadata applied to the ControlPlane and the Machines of the ControlPlane
+                          if the ControlPlaneTemplate referenced by the ClusterClass is machine based. If not, it
+                          is applied only to the ControlPlane.
+                          At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              annotations is an unstructured key value map stored with a resource that may be
+                              set by external tools to store and retrieve arbitrary metadata. They are not
+                              queryable and should be preserved when modifying objects.
+                              More info: http://kubernetes.io/docs/user-guide/annotations
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              labels is a map of string keys and values that can be used to organize and categorize
+                              (scope and select) objects. May match selectors of replication controllers
+                              and services.
+                              More info: http://kubernetes.io/docs/user-guide/labels
+                            type: object
+                        type: object
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                          computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                          If this field is not defined, readinessGates from the corresponding ControlPlaneClass will be used, if any.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: Specific control plane provider implementations might automatically extend the list of readinessGates;
+                          e.g. the kubeadm control provider adds ReadinessGates for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      replicas:
+                        description: |-
+                          replicas is the number of control plane nodes.
+                          If the value is nil, the ControlPlane object is created without the number of Replicas
+                          and it's assumed that the control plane controller does not implement support for this field.
+                          When specified against a control plane provider that lacks support for this field, this value will be ignored.
+                        format: int32
+                        type: integer
+                      variables:
+                        description: variables can be used to customize the ControlPlane
+                          through patches.
+                        properties:
+                          overrides:
+                            description: overrides can be used to override Cluster
+                              level variables.
+                            items:
+                              description: |-
+                                ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                Variable definition in the ClusterClass `status` variables.
+                              properties:
+                                definitionFrom:
+                                  description: |-
+                                    definitionFrom specifies where the definition of this Variable is from.
+
+                                    Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                  maxLength: 256
+                                  type: string
+                                name:
+                                  description: name of the variable.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                value:
+                                  description: |-
+                                    value of the variable.
+                                    Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                    from the ClusterClass.
+                                    Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                    hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                    i.e. it is not possible to have no type field.
+                                    Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                  x-kubernetes-preserve-unknown-fields: true
+                              required:
+                              - name
+                              - value
+                              type: object
+                            maxItems: 1000
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        type: object
+                    type: object
+                  rolloutAfter:
+                    description: |-
+                      rolloutAfter performs a rollout of the entire cluster one component at a time,
+                      control plane first and then machine deployments.
+
+                      Deprecated: This field has no function and is going to be removed in the next apiVersion.
+                    format: date-time
+                    type: string
+                  variables:
+                    description: |-
+                      variables can be used to customize the Cluster through
+                      patches. They must comply to the corresponding
+                      VariableClasses defined in the ClusterClass.
+                    items:
+                      description: |-
+                        ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                        Variable definition in the ClusterClass `status` variables.
+                      properties:
+                        definitionFrom:
+                          description: |-
+                            definitionFrom specifies where the definition of this Variable is from.
+
+                            Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                          maxLength: 256
+                          type: string
+                        name:
+                          description: name of the variable.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        value:
+                          description: |-
+                            value of the variable.
+                            Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                            from the ClusterClass.
+                            Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                            hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                            i.e. it is not possible to have no type field.
+                            Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                          x-kubernetes-preserve-unknown-fields: true
+                      required:
+                      - name
+                      - value
+                      type: object
+                    maxItems: 1000
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  version:
+                    description: version is the Kubernetes version of the cluster.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  workers:
+                    description: |-
+                      workers encapsulates the different constructs that form the worker nodes
+                      for the cluster.
+                    properties:
+                      machineDeployments:
+                        description: machineDeployments is a list of machine deployments
+                          in the cluster.
+                        items:
+                          description: |-
+                            MachineDeploymentTopology specifies the different parameters for a set of worker nodes in the topology.
+                            This set of nodes is managed by a MachineDeployment object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachineDeploymentClass used to create the set of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            failureDomain:
+                              description: |-
+                                failureDomain is the failure domain the machines will be created in.
+                                Must match a key in the FailureDomains map stored on the cluster object.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            machineHealthCheck:
+                              description: |-
+                                machineHealthCheck allows to enable, disable and override
+                                the MachineHealthCheck configuration in the ClusterClass for this MachineDeployment.
+                              properties:
+                                enable:
+                                  description: |-
+                                    enable controls if a MachineHealthCheck should be created for the target machines.
+
+                                    If false: No MachineHealthCheck will be created.
+
+                                    If not set(default): A MachineHealthCheck will be created if it is defined here or
+                                     in the associated ClusterClass. If no MachineHealthCheck is defined then none will be created.
+
+                                    If true: A MachineHealthCheck is guaranteed to be created. Cluster validation will
+                                    block if `enable` is true and no MachineHealthCheck definition is available.
+                                  type: boolean
+                                maxUnhealthy:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                                    Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                                    "selector" are not healthy.
+                                  x-kubernetes-int-or-string: true
+                                nodeStartupTimeout:
+                                  description: |-
+                                    nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                                    to consider a Machine unhealthy if a corresponding Node isn't associated
+                                    through a `Spec.ProviderID` field.
+
+                                    The duration set in this field is compared to the greatest of:
+                                    - Cluster's infrastructure ready condition timestamp (if and when available)
+                                    - Control Plane's initialized condition timestamp (if and when available)
+                                    - Machine's infrastructure ready condition timestamp (if and when available)
+                                    - Machine's metadata creation timestamp
+
+                                    Defaults to 10 minutes.
+                                    If you wish to disable this feature, set the value explicitly to 0.
+                                  type: string
+                                remediationTemplate:
+                                  description: |-
+                                    remediationTemplate is a reference to a remediation template
+                                    provided by an infrastructure provider.
+
+                                    This field is completely optional, when filled, the MachineHealthCheck controller
+                                    creates a new object from the template referenced and hands off remediation of the machine to
+                                    a controller that lives outside of Cluster API.
+                                  properties:
+                                    apiVersion:
+                                      description: API version of the referent.
+                                      type: string
+                                    fieldPath:
+                                      description: |-
+                                        If referring to a piece of an object instead of an entire object, this string
+                                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                        the event) or if no container name is specified "spec.containers[2]" (container with
+                                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                        referencing a part of an object.
+                                      type: string
+                                    kind:
+                                      description: |-
+                                        Kind of the referent.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                      type: string
+                                    name:
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                      type: string
+                                    resourceVersion:
+                                      description: |-
+                                        Specific resourceVersion to which this reference is made, if any.
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                unhealthyConditions:
+                                  description: |-
+                                    unhealthyConditions contains a list of the conditions that determine
+                                    whether a node is considered unhealthy. The conditions are combined in a
+                                    logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                                  items:
+                                    description: |-
+                                      UnhealthyCondition represents a Node condition type and value with a timeout
+                                      specified as a duration.  When the named condition has been in the given
+                                      status for at least the timeout value, a node is considered unhealthy.
+                                    properties:
+                                      status:
+                                        description: status of the condition, one
+                                          of True, False, Unknown.
+                                        minLength: 1
+                                        type: string
+                                      timeout:
+                                        description: |-
+                                          timeout is the duration that a node must be in a given status for,
+                                          after which the node is considered unhealthy.
+                                          For example, with a value of "1h", the node must match the status
+                                          for at least 1 hour before being considered unhealthy.
+                                        type: string
+                                      type:
+                                        description: type of Node condition
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - status
+                                    - timeout
+                                    - type
+                                    type: object
+                                  maxItems: 100
+                                  type: array
+                                unhealthyRange:
+                                  description: |-
+                                    unhealthyRange specifies the range of unhealthy machines allowed.
+                                    Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                                    is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                                    Eg. "[3-5]" - This means that remediation will be allowed only when:
+                                    (a) there are at least 3 unhealthy machines (and)
+                                    (b) there are at most 5 unhealthy machines
+                                  maxLength: 32
+                                  minLength: 1
+                                  pattern: ^\[[0-9]+-[0-9]+\]$
+                                  type: string
+                              type: object
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachineDeployment and the machines of the MachineDeployment.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: |-
+                                minReadySeconds is the minimum number of seconds for which a newly created machine should
+                                be ready.
+                                Defaults to 0 (machine will be considered available as soon as it
+                                is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachineDeploymentTopology.
+                                The value is used with other unique identifiers to create a MachineDeployment's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            nodeDeletionTimeout:
+                              description: |-
+                                nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                                hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: |-
+                                nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                                The default value is 0, meaning that the node can be drained without any time limitations.
+                                NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: |-
+                                nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              type: string
+                            readinessGates:
+                              description: |-
+                                readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                                This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                                computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                                If this field is not defined, readinessGates from the corresponding MachineDeploymentClass will be used, if any.
+
+                                NOTE: This field is considered only for computing v1beta2 conditions.
+                              items:
+                                description: MachineReadinessGate contains the type
+                                  of a Machine condition to be used as a readiness
+                                  gate.
+                                properties:
+                                  conditionType:
+                                    description: |-
+                                      conditionType refers to a condition with matching type in the Machine's condition list.
+                                      If the conditions doesn't exist, it will be treated as unknown.
+                                      Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                                    maxLength: 316
+                                    minLength: 1
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                  polarity:
+                                    description: |-
+                                      polarity of the conditionType specified in this readinessGate.
+                                      Valid values are Positive, Negative and omitted.
+                                      When omitted, the default behaviour will be Positive.
+                                      A positive polarity means that the condition should report a true status under normal conditions.
+                                      A negative polarity means that the condition should report a false status under normal conditions.
+                                    enum:
+                                    - Positive
+                                    - Negative
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              maxItems: 32
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - conditionType
+                              x-kubernetes-list-type: map
+                            replicas:
+                              description: |-
+                                replicas is the number of worker nodes belonging to this set.
+                                If the value is nil, the MachineDeployment is created without the number of Replicas (defaulting to 1)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            strategy:
+                              description: |-
+                                strategy is the deployment strategy to use to replace existing machines with
+                                new ones.
+                              properties:
+                                remediation:
+                                  description: |-
+                                    remediation controls the strategy of remediating unhealthy machines
+                                    and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                                  properties:
+                                    maxInFlight:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxInFlight determines how many in flight remediations should happen at the same time.
+
+                                        Remediation only happens on the MachineSet with the most current revision, while
+                                        older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                                        Note: In general (independent of remediations), unhealthy machines are always
+                                        prioritized during scale down operations over healthy ones.
+
+                                        MaxInFlight can be set to a fixed number or a percentage.
+                                        Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                                        the desired replicas.
+
+                                        If not set, remediation is limited to all machines (bounded by replicas)
+                                        under the active MachineSet's management.
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                rollingUpdate:
+                                  description: |-
+                                    rollingUpdate is the rolling update config params. Present only if
+                                    MachineDeploymentStrategyType = RollingUpdate.
+                                  properties:
+                                    deletePolicy:
+                                      description: |-
+                                        deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                                        Valid values are "Random", "Newest", "Oldest"
+                                        When no value is supplied, the default DeletePolicy of MachineSet is used
+                                      enum:
+                                      - Random
+                                      - Newest
+                                      - Oldest
+                                      type: string
+                                    maxSurge:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxSurge is the maximum number of machines that can be scheduled above the
+                                        desired number of machines.
+                                        Value can be an absolute number (ex: 5) or a percentage of
+                                        desired machines (ex: 10%).
+                                        This can not be 0 if MaxUnavailable is 0.
+                                        Absolute number is calculated from percentage by rounding up.
+                                        Defaults to 1.
+                                        Example: when this is set to 30%, the new MachineSet can be scaled
+                                        up immediately when the rolling update starts, such that the total
+                                        number of old and new machines do not exceed 130% of desired
+                                        machines. Once old machines have been killed, new MachineSet can
+                                        be scaled up further, ensuring that total number of machines running
+                                        at any time during the update is at most 130% of desired machines.
+                                      x-kubernetes-int-or-string: true
+                                    maxUnavailable:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                                        Value can be an absolute number (ex: 5) or a percentage of desired
+                                        machines (ex: 10%).
+                                        Absolute number is calculated from percentage by rounding down.
+                                        This can not be 0 if MaxSurge is 0.
+                                        Defaults to 0.
+                                        Example: when this is set to 30%, the old MachineSet can be scaled
+                                        down to 70% of desired machines immediately when the rolling update
+                                        starts. Once new machines are ready, old MachineSet can be scaled
+                                        down further, followed by scaling up the new MachineSet, ensuring
+                                        that the total number of machines available at all times
+                                        during the update is at least 70% of desired machines.
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                type:
+                                  description: |-
+                                    type of deployment. Allowed values are RollingUpdate and OnDelete.
+                                    The default is RollingUpdate.
+                                  enum:
+                                  - RollingUpdate
+                                  - OnDelete
+                                  type: string
+                              type: object
+                            variables:
+                              description: variables can be used to customize the
+                                MachineDeployment through patches.
+                              properties:
+                                overrides:
+                                  description: overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: |-
+                                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                      Variable definition in the ClusterClass `status` variables.
+                                    properties:
+                                      definitionFrom:
+                                        description: |-
+                                          definitionFrom specifies where the definition of this Variable is from.
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        maxLength: 256
+                                        type: string
+                                      name:
+                                        description: name of the variable.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value of the variable.
+                                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass.
+                                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                          i.e. it is not possible to have no type field.
+                                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 1000
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        maxItems: 2000
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      machinePools:
+                        description: machinePools is a list of machine pools in the
+                          cluster.
+                        items:
+                          description: |-
+                            MachinePoolTopology specifies the different parameters for a pool of worker nodes in the topology.
+                            This pool of nodes is managed by a MachinePool object whose lifecycle is managed by the Cluster controller.
+                          properties:
+                            class:
+                              description: |-
+                                class is the name of the MachinePoolClass used to create the pool of worker nodes.
+                                This should match one of the deployment classes defined in the ClusterClass object
+                                mentioned in the `Cluster.Spec.Class` field.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            failureDomains:
+                              description: |-
+                                failureDomains is the list of failure domains the machine pool will be created in.
+                                Must match a key in the FailureDomains map stored on the cluster object.
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 100
+                              type: array
+                            metadata:
+                              description: |-
+                                metadata is the metadata applied to the MachinePool.
+                                At runtime this metadata is merged with the corresponding metadata from the ClusterClass.
+                              properties:
+                                annotations:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    annotations is an unstructured key value map stored with a resource that may be
+                                    set by external tools to store and retrieve arbitrary metadata. They are not
+                                    queryable and should be preserved when modifying objects.
+                                    More info: http://kubernetes.io/docs/user-guide/annotations
+                                  type: object
+                                labels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    labels is a map of string keys and values that can be used to organize and categorize
+                                    (scope and select) objects. May match selectors of replication controllers
+                                    and services.
+                                    More info: http://kubernetes.io/docs/user-guide/labels
+                                  type: object
+                              type: object
+                            minReadySeconds:
+                              description: |-
+                                minReadySeconds is the minimum number of seconds for which a newly created machine pool should
+                                be ready.
+                                Defaults to 0 (machine will be considered available as soon as it
+                                is ready)
+                              format: int32
+                              type: integer
+                            name:
+                              description: |-
+                                name is the unique identifier for this MachinePoolTopology.
+                                The value is used with other unique identifiers to create a MachinePool's Name
+                                (e.g. cluster's name, etc). In case the name is greater than the allowed maximum length,
+                                the values are hashed together.
+                              maxLength: 63
+                              minLength: 1
+                              type: string
+                            nodeDeletionTimeout:
+                              description: |-
+                                nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the MachinePool
+                                hosts after the MachinePool is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                                Defaults to 10 seconds.
+                              type: string
+                            nodeDrainTimeout:
+                              description: |-
+                                nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                                The default value is 0, meaning that the node can be drained without any time limitations.
+                                NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                              type: string
+                            nodeVolumeDetachTimeout:
+                              description: |-
+                                nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                                to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                              type: string
+                            replicas:
+                              description: |-
+                                replicas is the number of nodes belonging to this pool.
+                                If the value is nil, the MachinePool is created without the number of Replicas (defaulting to 1)
+                                and it's assumed that an external entity (like cluster autoscaler) is responsible for the management
+                                of this value.
+                              format: int32
+                              type: integer
+                            variables:
+                              description: variables can be used to customize the
+                                MachinePool through patches.
+                              properties:
+                                overrides:
+                                  description: overrides can be used to override Cluster
+                                    level variables.
+                                  items:
+                                    description: |-
+                                      ClusterVariable can be used to customize the Cluster through patches. Each ClusterVariable is associated with a
+                                      Variable definition in the ClusterClass `status` variables.
+                                    properties:
+                                      definitionFrom:
+                                        description: |-
+                                          definitionFrom specifies where the definition of this Variable is from.
+
+                                          Deprecated: This field is deprecated, must not be set anymore and is going to be removed in the next apiVersion.
+                                        maxLength: 256
+                                        type: string
+                                      name:
+                                        description: name of the variable.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      value:
+                                        description: |-
+                                          value of the variable.
+                                          Note: the value will be validated against the schema of the corresponding ClusterClassVariable
+                                          from the ClusterClass.
+                                          Note: We have to use apiextensionsv1.JSON instead of a custom JSON type, because controller-tools has a
+                                          hard-coded schema for apiextensionsv1.JSON which cannot be produced by another type via controller-tools,
+                                          i.e. it is not possible to have no type field.
+                                          Ref: https://github.com/kubernetes-sigs/controller-tools/blob/d0e03a142d0ecdd5491593e941ee1d6b5d91dba6/pkg/crd/known_types.go#L106-L111
+                                        x-kubernetes-preserve-unknown-fields: true
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  maxItems: 1000
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                              type: object
+                          required:
+                          - class
+                          - name
+                          type: object
+                        maxItems: 2000
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                required:
+                - class
+                - version
+                type: object
+            type: object
+          status:
+            description: status is the observed state of Cluster.
+            properties:
+              conditions:
+                description: conditions defines current service state of the cluster.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              controlPlaneReady:
+                description: |-
+                  controlPlaneReady denotes if the control plane became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              failureDomains:
+                additionalProperties:
+                  description: |-
+                    FailureDomainSpec is the Schema for Cluster API failure domains.
+                    It allows controllers to understand how many failure domains a cluster can optionally span across.
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        type: string
+                      description: attributes is a free form map of attributes an
+                        infrastructure provider might use or require.
+                      type: object
+                    controlPlane:
+                      description: controlPlane determines if this failure domain
+                        is suitable for use by control plane machines.
+                      type: boolean
+                  type: object
+                description: failureDomains is a slice of failure domain objects synced
+                  from the infrastructure provider.
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a fatal problem reconciling the
+                  state, and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a fatal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of cluster actuation.
+                enum:
+                - Pending
+                - Provisioning
+                - Provisioned
+                - Deleting
+                - Failed
+                - Unknown
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in Cluster's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a Cluster's current state.
+                      Known condition types are Available, InfrastructureReady, ControlPlaneInitialized, ControlPlaneAvailable, WorkersAvailable, MachinesReady
+                      MachinesUpToDate, RemoteConnectionProbe, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                      Additionally, a TopologyReconciled condition will be added in case the Cluster is referencing a ClusterClass / defining a managed Topology.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  controlPlane:
+                    description: controlPlane groups all the observations about Cluster's
+                      ControlPlane current state.
+                    properties:
+                      availableReplicas:
+                        description: availableReplicas is the total number of available
+                          control plane machines in this cluster. A machine is considered
+                          available when Machine's Available condition is true.
+                        format: int32
+                        type: integer
+                      desiredReplicas:
+                        description: desiredReplicas is the total number of desired
+                          control plane machines in this cluster.
+                        format: int32
+                        type: integer
+                      readyReplicas:
+                        description: readyReplicas is the total number of ready control
+                          plane machines in this cluster. A machine is considered
+                          ready when Machine's Ready condition is true.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: |-
+                          replicas is the total number of control plane machines in this cluster.
+                          NOTE: replicas also includes machines still being provisioned or being deleted.
+                        format: int32
+                        type: integer
+                      upToDateReplicas:
+                        description: upToDateReplicas is the number of up-to-date
+                          control plane machines in this cluster. A machine is considered
+                          up-to-date when Machine's UpToDate condition is true.
+                        format: int32
+                        type: integer
+                    type: object
+                  workers:
+                    description: workers groups all the observations about Cluster's
+                      Workers current state.
+                    properties:
+                      availableReplicas:
+                        description: availableReplicas is the total number of available
+                          worker machines in this cluster. A machine is considered
+                          available when Machine's Available condition is true.
+                        format: int32
+                        type: integer
+                      desiredReplicas:
+                        description: desiredReplicas is the total number of desired
+                          worker machines in this cluster.
+                        format: int32
+                        type: integer
+                      readyReplicas:
+                        description: readyReplicas is the total number of ready worker
+                          machines in this cluster. A machine is considered ready
+                          when Machine's Ready condition is true.
+                        format: int32
+                        type: integer
+                      replicas:
+                        description: |-
+                          replicas is the total number of worker machines in this cluster.
+                          NOTE: replicas also includes machines still being provisioned or being deleted.
+                        format: int32
+                        type: integer
+                      upToDateReplicas:
+                        description: upToDateReplicas is the number of up-to-date
+                          worker machines in this cluster. A machine is considered
+                          up-to-date when Machine's UpToDate condition is true.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinedeployments.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinedeployments.yaml
@@ -1,0 +1,814 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: machinedeployments.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDeployment
+    listKind: MachineDeploymentList
+    plural: machinedeployments
+    shortNames:
+    - md
+    singular: machinedeployment
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachineDeployment
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this MachineDeployment
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this MachineDeployment
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this deployment
+        that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this MachineDeployment
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: MachineDeployment status such as ScalingUp/ScalingDown/Running/Failed/Unknown
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachineDeployment
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineDeployment
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDeployment is the Schema for the machinedeployments API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineDeployment.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              machineNamingStrategy:
+                description: |-
+                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
+                  Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the names of the
+                      Machine objects.
+                      If not defined, it will fallback to `{{ .machineSet.name }}-{{ .random }}`.
+                      If the generated name string exceeds 63 characters, it will be trimmed to
+                      58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      Length of the template string must not exceed 256 characters.
+                      The template allows the following variables `.cluster.name`,
+                      `.machineSet.name` and `.random`.
+                      The variable `.cluster.name` retrieves the name of the cluster object
+                      that owns the Machines being created.
+                      The variable `.machineSet.name` retrieves the name of the MachineSet
+                      object that owns the Machines being created.
+                      The variable `.random` is substituted with random alphanumeric string,
+                      without vowels, of length 5. This variable is required part of the
+                      template. If not provided, validation will fail.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                type: object
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
+                  Defaults to 0 (machine will be considered available as soon as the Node is ready)
+                format: int32
+                type: integer
+              paused:
+                description: paused indicates that the deployment is paused.
+                type: boolean
+              progressDeadlineSeconds:
+                description: |-
+                  progressDeadlineSeconds is the maximum time in seconds for a deployment to make progress before it
+                  is considered to be failed. The deployment controller will continue to
+                  process failed deployments and a condition with a ProgressDeadlineExceeded
+                  reason will be surfaced in the deployment status. Note that progress will
+                  not be estimated during the time a deployment is paused. Defaults to 600s.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/11470 for more details.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired machines.
+                  This is a pointer to distinguish between explicit zero and not specified.
+
+                  Defaults to:
+                  * if the Kubernetes autoscaler min size and max size annotations are set:
+                    - if it's a new MachineDeployment, use min size
+                    - if the replicas field of the old MachineDeployment is < min size, use min size
+                    - if the replicas field of the old MachineDeployment is > max size, use max size
+                    - if the replicas field of the old MachineDeployment is in the (min size, max size) range, keep the value from the oldMD
+                  * otherwise use 1
+                  Note: Defaulting will be run whenever the replicas field is not set:
+                  * A new MachineDeployment is created with replicas not set.
+                  * On an existing MachineDeployment the replicas field was first set and is now unset.
+                  Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+                  * A new MachineDeployment is created and replicas should be managed by the autoscaler
+                  * An existing MachineDeployment which initially wasn't controlled by the autoscaler
+                    should be later controlled by the autoscaler
+                format: int32
+                type: integer
+              revisionHistoryLimit:
+                description: |-
+                  revisionHistoryLimit is the number of old MachineSets to retain to allow rollback.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                  Defaults to 1.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10479 for more details.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: |-
+                  rolloutAfter is a field to indicate a rollout should be performed
+                  after the specified time even if no changes have been made to the
+                  MachineDeployment.
+                  Example: In the YAML the time can be specified in the RFC3339 format.
+                  To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                  use "2023-03-09T09:00:00Z".
+                format: date-time
+                type: string
+              selector:
+                description: |-
+                  selector is the label selector for machines. Existing MachineSets whose machines are
+                  selected by this will be the ones affected by this deployment.
+                  It must match the machine template's labels.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              strategy:
+                description: |-
+                  strategy is the deployment strategy to use to replace existing machines with
+                  new ones.
+                properties:
+                  remediation:
+                    description: |-
+                      remediation controls the strategy of remediating unhealthy machines
+                      and how remediating operations should occur during the lifecycle of the dependant MachineSets.
+                    properties:
+                      maxInFlight:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxInFlight determines how many in flight remediations should happen at the same time.
+
+                          Remediation only happens on the MachineSet with the most current revision, while
+                          older MachineSets (usually present during rollout operations) aren't allowed to remediate.
+
+                          Note: In general (independent of remediations), unhealthy machines are always
+                          prioritized during scale down operations over healthy ones.
+
+                          MaxInFlight can be set to a fixed number or a percentage.
+                          Example: when this is set to 20%, the MachineSet controller deletes at most 20% of
+                          the desired replicas.
+
+                          If not set, remediation is limited to all machines (bounded by replicas)
+                          under the active MachineSet's management.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  rollingUpdate:
+                    description: |-
+                      rollingUpdate is the rolling update config params. Present only if
+                      MachineDeploymentStrategyType = RollingUpdate.
+                    properties:
+                      deletePolicy:
+                        description: |-
+                          deletePolicy defines the policy used by the MachineDeployment to identify nodes to delete when downscaling.
+                          Valid values are "Random", "Newest", "Oldest"
+                          When no value is supplied, the default DeletePolicy of MachineSet is used
+                        enum:
+                        - Random
+                        - Newest
+                        - Oldest
+                        type: string
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxSurge is the maximum number of machines that can be scheduled above the
+                          desired number of machines.
+                          Value can be an absolute number (ex: 5) or a percentage of
+                          desired machines (ex: 10%).
+                          This can not be 0 if MaxUnavailable is 0.
+                          Absolute number is calculated from percentage by rounding up.
+                          Defaults to 1.
+                          Example: when this is set to 30%, the new MachineSet can be scaled
+                          up immediately when the rolling update starts, such that the total
+                          number of old and new machines do not exceed 130% of desired
+                          machines. Once old machines have been killed, new MachineSet can
+                          be scaled up further, ensuring that total number of machines running
+                          at any time during the update is at most 130% of desired machines.
+                        x-kubernetes-int-or-string: true
+                      maxUnavailable:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxUnavailable is the maximum number of machines that can be unavailable during the update.
+                          Value can be an absolute number (ex: 5) or a percentage of desired
+                          machines (ex: 10%).
+                          Absolute number is calculated from percentage by rounding down.
+                          This can not be 0 if MaxSurge is 0.
+                          Defaults to 0.
+                          Example: when this is set to 30%, the old MachineSet can be scaled
+                          down to 70% of desired machines immediately when the rolling update
+                          starts. Once new machines are ready, old MachineSet can be scaled
+                          down further, followed by scaling up the new MachineSet, ensuring
+                          that the total number of machines available at all times
+                          during the update is at least 70% of desired machines.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of deployment. Allowed values are RollingUpdate and OnDelete.
+                      The default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    - OnDelete
+                    type: string
+                type: object
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      taints:
+                        description: |-
+                          The list of the taints to be applied to the corresponding Node in additive
+                          manner. This list will not overwrite any other taints added to the Node on
+                          an ongoing basis by other entities. These taints should be actively reconciled
+                          e.g. if you ask the machine controller to apply a taint and then manually remove
+                          the taint the machine controller will put it back) but not have the machine controller
+                          remove any taints
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachineDeployment.
+            properties:
+              availableReplicas:
+                description: |-
+                  availableReplicas is the total number of available machines (ready for at least minReadySeconds)
+                  targeted by this deployment.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineDeployment.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: observedGeneration is the generation observed by the
+                  deployment controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of a MachineDeployment
+                  (ScalingUp, ScalingDown, Running, Failed, or Unknown).
+                enum:
+                - ScalingUp
+                - ScalingDown
+                - Running
+                - Failed
+                - Unknown
+                type: string
+              readyReplicas:
+                description: readyReplicas is the total number of ready machines targeted
+                  by this deployment.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this deployment
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                maxLength: 4096
+                minLength: 1
+                type: string
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this deployment.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet available or machines
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this deployment
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineDeployment's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachineDeployment. A machine is considered available
+                      when Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineDeployment's current state.
+                      Known condition types are Available, MachinesReady, MachinesUpToDate, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachineDeployment. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this deployment. A machine is considered up-to-date
+                      when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinedrainrules.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinedrainrules.yaml
@@ -1,0 +1,396 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: machinedrainrules.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineDrainRule
+    listKind: MachineDrainRuleList
+    plural: machinedrainrules
+    singular: machinedrainrule
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Drain behavior
+      jsonPath: .spec.drain.behavior
+      name: Behavior
+      type: string
+    - description: Drain order
+      jsonPath: .spec.drain.order
+      name: Order
+      type: string
+    - description: Time duration since creation of the MachineDrainRule
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineDrainRule is the Schema for the MachineDrainRule API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec defines the spec of a MachineDrainRule.
+            properties:
+              drain:
+                description: drain configures if and how Pods are drained.
+                properties:
+                  behavior:
+                    description: |-
+                      behavior defines the drain behavior.
+                      Can be either "Drain", "Skip", or "WaitCompleted".
+                      "Drain" means that the Pods to which this MachineDrainRule applies will be drained.
+                      If behavior is set to "Drain" the order in which Pods are drained can be configured
+                      with the order field. When draining Pods of a Node the Pods will be grouped by order
+                      and one group after another will be drained (by increasing order). Cluster API will
+                      wait until all Pods of a group are terminated / removed from the Node before starting
+                      with the next group.
+                      "Skip" means that the Pods to which this MachineDrainRule applies will be skipped during drain.
+                      "WaitCompleted" means that the pods to which this MachineDrainRule applies will never be evicted
+                      and we wait for them to be completed, it is enforced that pods marked with this behavior always have Order=0.
+                    enum:
+                    - Drain
+                    - Skip
+                    - WaitCompleted
+                    type: string
+                  order:
+                    description: |-
+                      order defines the order in which Pods are drained.
+                      Pods with higher order are drained after Pods with lower order.
+                      order can only be set if behavior is set to "Drain".
+                      If order is not set, 0 will be used.
+                      Valid values for order are from -2147483648 to 2147483647 (inclusive).
+                    format: int32
+                    type: integer
+                required:
+                - behavior
+                type: object
+              machines:
+                description: |-
+                  machines defines to which Machines this MachineDrainRule should be applied.
+
+                  If machines is not set, the MachineDrainRule applies to all Machines in the Namespace.
+                  If machines contains multiple selectors, the results are ORed.
+                  Within a single Machine selector the results of selector and clusterSelector are ANDed.
+                  Machines will be selected from all Clusters in the Namespace unless otherwise
+                  restricted with the clusterSelector.
+
+                  Example: Selects control plane Machines in all Clusters or
+                           Machines with label "os" == "linux" in Clusters with label
+                           "stage" == "production".
+
+                   - selector:
+                       matchExpressions:
+                       - key: cluster.x-k8s.io/control-plane
+                         operator: Exists
+                   - selector:
+                       matchLabels:
+                         os: linux
+                     clusterSelector:
+                       matchExpressions:
+                       - key: stage
+                         operator: In
+                         values:
+                         - production
+                items:
+                  description: MachineDrainRuleMachineSelector defines to which Machines
+                    this MachineDrainRule should be applied.
+                  minProperties: 1
+                  properties:
+                    clusterSelector:
+                      description: |-
+                        clusterSelector is a label selector which selects Machines by the labels of
+                        their Clusters.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects Machines of all Clusters.
+
+                        If selector is also set, then the selector as a whole selects
+                        Machines matching selector belonging to Clusters selected by clusterSelector.
+                        If selector is not set, it selects all Machines belonging to Clusters
+                        selected by clusterSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: |-
+                        selector is a label selector which selects Machines by their labels.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects all Machines.
+
+                        If clusterSelector is also set, then the selector as a whole selects
+                        Machines matching selector belonging to Clusters selected by clusterSelector.
+                        If clusterSelector is not set, it selects all Machines matching selector in
+                        all Clusters.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: entries in machines must be unique
+                  rule: self.all(x, self.exists_one(y, x == y))
+              pods:
+                description: |-
+                  pods defines to which Pods this MachineDrainRule should be applied.
+
+                  If pods is not set, the MachineDrainRule applies to all Pods in all Namespaces.
+                  If pods contains multiple selectors, the results are ORed.
+                  Within a single Pod selector the results of selector and namespaceSelector are ANDed.
+                  Pods will be selected from all Namespaces unless otherwise
+                  restricted with the namespaceSelector.
+
+                  Example: Selects Pods with label "app" == "logging" in all Namespaces or
+                           Pods with label "app" == "prometheus" in the "monitoring"
+                           Namespace.
+
+                   - selector:
+                       matchExpressions:
+                       - key: app
+                         operator: In
+                         values:
+                         - logging
+                   - selector:
+                       matchLabels:
+                         app: prometheus
+                     namespaceSelector:
+                       matchLabels:
+                         kubernetes.io/metadata.name: monitoring
+                items:
+                  description: MachineDrainRulePodSelector defines to which Pods this
+                    MachineDrainRule should be applied.
+                  minProperties: 1
+                  properties:
+                    namespaceSelector:
+                      description: |-
+                        namespaceSelector is a label selector which selects Pods by the labels of
+                        their Namespaces.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects Pods of all Namespaces.
+
+                        If selector is also set, then the selector as a whole selects
+                        Pods matching selector in Namespaces selected by namespaceSelector.
+                        If selector is not set, it selects all Pods in Namespaces selected by
+                        namespaceSelector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    selector:
+                      description: |-
+                        selector is a label selector which selects Pods by their labels.
+                        This field follows standard label selector semantics; if not present or
+                        empty, it selects all Pods.
+
+                        If namespaceSelector is also set, then the selector as a whole selects
+                        Pods matching selector in Namespaces selected by namespaceSelector.
+                        If namespaceSelector is not set, it selects all Pods matching selector in
+                        all Namespaces.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                  type: object
+                maxItems: 32
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: entries in pods must be unique
+                  rule: self.all(x, self.exists_one(y, x == y))
+            required:
+            - drain
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinehealthchecks.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinehealthchecks.yaml
@@ -1,0 +1,411 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: machinehealthchecks.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineHealthCheck
+    listKind: MachineHealthCheckList
+    plural: machinehealthchecks
+    shortNames:
+    - mhc
+    - mhcs
+    singular: machinehealthcheck
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Number of machines currently monitored
+      jsonPath: .status.expectedMachines
+      name: ExpectedMachines
+      type: integer
+    - description: Maximum number of unhealthy machines allowed
+      jsonPath: .spec.maxUnhealthy
+      name: MaxUnhealthy
+      type: string
+    - description: Current observed healthy machines
+      jsonPath: .status.currentHealthy
+      name: CurrentHealthy
+      type: integer
+    - description: Time duration since creation of MachineHealthCheck
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineHealthCheck is the Schema for the machinehealthchecks
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of machine health check policy
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              maxUnhealthy:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  maxUnhealthy specifies the maximum number of unhealthy machines allowed.
+                  Any further remediation is only allowed if at most "maxUnhealthy" machines selected by
+                  "selector" are not healthy.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
+                x-kubernetes-int-or-string: true
+              nodeStartupTimeout:
+                description: |-
+                  nodeStartupTimeout allows to set the maximum time for MachineHealthCheck
+                  to consider a Machine unhealthy if a corresponding Node isn't associated
+                  through a `Spec.ProviderID` field.
+
+                  The duration set in this field is compared to the greatest of:
+                  - Cluster's infrastructure ready condition timestamp (if and when available)
+                  - Control Plane's initialized condition timestamp (if and when available)
+                  - Machine's infrastructure ready condition timestamp (if and when available)
+                  - Machine's metadata creation timestamp
+
+                  Defaults to 10 minutes.
+                  If you wish to disable this feature, set the value explicitly to 0.
+                type: string
+              remediationTemplate:
+                description: |-
+                  remediationTemplate is a reference to a remediation template
+                  provided by an infrastructure provider.
+
+                  This field is completely optional, when filled, the MachineHealthCheck controller
+                  creates a new object from the template referenced and hands off remediation of the machine to
+                  a controller that lives outside of Cluster API.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              selector:
+                description: selector is a label selector to match machines whose
+                  health will be exercised
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              unhealthyConditions:
+                description: |-
+                  unhealthyConditions contains a list of the conditions that determine
+                  whether a node is considered unhealthy.  The conditions are combined in a
+                  logical OR, i.e. if any of the conditions is met, the node is unhealthy.
+                items:
+                  description: |-
+                    UnhealthyCondition represents a Node condition type and value with a timeout
+                    specified as a duration.  When the named condition has been in the given
+                    status for at least the timeout value, a node is considered unhealthy.
+                  properties:
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      minLength: 1
+                      type: string
+                    timeout:
+                      description: |-
+                        timeout is the duration that a node must be in a given status for,
+                        after which the node is considered unhealthy.
+                        For example, with a value of "1h", the node must match the status
+                        for at least 1 hour before being considered unhealthy.
+                      type: string
+                    type:
+                      description: type of Node condition
+                      minLength: 1
+                      type: string
+                  required:
+                  - status
+                  - timeout
+                  - type
+                  type: object
+                maxItems: 100
+                type: array
+              unhealthyRange:
+                description: |-
+                  unhealthyRange specifies the range of unhealthy machines allowed.
+                  Any further remediation is only allowed if the number of machines selected by "selector" as not healthy
+                  is within the range of "unhealthyRange". Takes precedence over maxUnhealthy.
+                  Eg. "[3-5]" - This means that remediation will be allowed only when:
+                  (a) there are at least 3 unhealthy machines (and)
+                  (b) there are at most 5 unhealthy machines
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/issues/10722 for more details.
+                maxLength: 32
+                minLength: 1
+                pattern: ^\[[0-9]+-[0-9]+\]$
+                type: string
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: status is the most recently observed status of MachineHealthCheck
+              resource
+            properties:
+              conditions:
+                description: conditions defines current service state of the MachineHealthCheck.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              currentHealthy:
+                description: currentHealthy is the total number of healthy machines
+                  counted by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              expectedMachines:
+                description: expectedMachines is the total number of machines counted
+                  by this machine health check
+                format: int32
+                minimum: 0
+                type: integer
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              remediationsAllowed:
+                description: |-
+                  remediationsAllowed is the number of further remediations allowed by this machine health check before
+                  maxUnhealthy short circuiting will be applied
+                format: int32
+                minimum: 0
+                type: integer
+              targets:
+                description: targets shows the current list of machines the machine
+                  health check is watching
+                items:
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+                maxItems: 10000
+                type: array
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineHealthCheck's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineHealthCheck's current state.
+                      Known condition types are RemediationAllowed, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinepools.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinepools.yaml
@@ -1,0 +1,665 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: machinepools.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachinePool
+    listKind: MachinePoolList
+    plural: machinepools
+    shortNames:
+    - mp
+    singular: machinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this MachinePool
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: MachinePool replicas count
+      jsonPath: .status.replicas
+      name: Replicas
+      type: string
+    - description: MachinePool status such as Terminating/Pending/Provisioning/Running/Failed
+        etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of MachinePool
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachinePool
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachinePool is the Schema for the machinepools API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachinePool.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              failureDomains:
+                description: failureDomains is the list of failure domains this MachinePool
+                  should be attached to.
+                items:
+                  maxLength: 256
+                  minLength: 1
+                  type: string
+                maxItems: 100
+                type: array
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a newly created machine instances should
+                  be ready.
+                  Defaults to 0 (machine instance will be considered available as soon as it
+                  is ready)
+                format: int32
+                type: integer
+              providerIDList:
+                description: |-
+                  providerIDList are the identification IDs of machine instances provided by the provider.
+                  This field must match the provider IDs as seen on the node objects corresponding to a machine pool's machine instances.
+                items:
+                  maxLength: 512
+                  minLength: 1
+                  type: string
+                maxItems: 10000
+                type: array
+              replicas:
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1.
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              template:
+                description: template describes the machines that will be created.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      taints:
+                        description: |-
+                          The list of the taints to be applied to the corresponding Node in additive
+                          manner. This list will not overwrite any other taints added to the Node on
+                          an ongoing basis by other entities. These taints should be actively reconciled
+                          e.g. if you ask the machine controller to apply a taint and then manually remove
+                          the taint the machine controller will put it back) but not have the machine controller
+                          remove any taints
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - template
+            type: object
+          status:
+            description: status is the observed state of MachinePool.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachinePool.
+                format: int32
+                type: integer
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              conditions:
+                description: conditions define the current service state of the MachinePool.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a problem reconciling the state,
+                  and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a problem reconciling the state, and
+                  will be set to a token value suitable for programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              nodeRefs:
+                description: nodeRefs will point to the corresponding Nodes if
+                  they exist.
+                items:
+                  description: ObjectReference contains enough information to let
+                    you inspect or modify the referred object.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: |-
+                        If referring to a piece of an object instead of an entire object, this string
+                        should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                        For example, if the object reference is to a container within a pod, this would take on a value like:
+                        "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                        the event) or if no container name is specified "spec.containers[2]" (container with
+                        index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                        referencing a part of an object.
+                      type: string
+                    kind:
+                      description: |-
+                        Kind of the referent.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                      type: string
+                    name:
+                      description: |-
+                        Name of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                      type: string
+                    namespace:
+                      description: |-
+                        Namespace of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                      type: string
+                    resourceVersion:
+                      description: |-
+                        Specific resourceVersion to which this reference is made, if any.
+                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                      type: string
+                    uid:
+                      description: |-
+                        UID of the referent.
+                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                maxItems: 10000
+                type: array
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of cluster actuation.
+                enum:
+                - Pending
+                - Provisioning
+                - Provisioned
+                - Running
+                - ScalingUp
+                - ScalingDown
+                - Scaling
+                - Deleting
+                - Failed
+                - Unknown
+                type: string
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachinePool. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machine instances targeted by this machine pool.
+                  This is the total number of machine instances that are still required for
+                  the machine pool to have 100% available capacity. They may either
+                  be machine instances that are running but not yet available or machine instances
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachinePool's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachinePool. A machine is considered available when
+                      Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachinePool's current state.
+                      Known condition types are Available, BootstrapConfigReady, InfrastructureReady, MachinesReady, MachinesUpToDate,
+                      ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachinePool. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this MachinePool. A machine is considered up-to-date
+                      when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machines.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machines.yaml
@@ -1,0 +1,678 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: machines.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: Machine
+    listKind: MachineList
+    plural: machines
+    shortNames:
+    - ma
+    singular: machine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Node name associated with this machine
+      jsonPath: .status.nodeRef.name
+      name: NodeName
+      type: string
+    - description: Provider ID
+      jsonPath: .spec.providerID
+      name: ProviderID
+      type: string
+    - description: Machine status such as Terminating/Pending/Running/Failed etc
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: Time duration since creation of Machine
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this Machine
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Machine is the Schema for the machines API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of Machine.
+            properties:
+              bootstrap:
+                description: |-
+                  bootstrap is a reference to a local struct which encapsulates
+                  fields to configure the Machine’s bootstrapping mechanism.
+                properties:
+                  configRef:
+                    description: |-
+                      configRef is a reference to a bootstrap provider-specific resource
+                      that holds configuration details. The reference is optional to
+                      allow users/operators to specify Bootstrap.DataSecretName without
+                      the need of a controller.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  dataSecretName:
+                    description: |-
+                      dataSecretName is the name of the secret that stores the bootstrap data script.
+                      If nil, the Machine should remain in the Pending state.
+                    maxLength: 253
+                    minLength: 0
+                    type: string
+                type: object
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              failureDomain:
+                description: |-
+                  failureDomain is the failure domain the machine will be created in.
+                  Must match a key in the FailureDomains map stored on the cluster object.
+                maxLength: 256
+                minLength: 1
+                type: string
+              infrastructureRef:
+                description: |-
+                  infrastructureRef is a required reference to a custom resource
+                  offered by an infrastructure provider.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeDeletionTimeout:
+                description: |-
+                  nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                  hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                  Defaults to 10 seconds.
+                type: string
+              nodeDrainTimeout:
+                description: |-
+                  nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                  The default value is 0, meaning that the node can be drained without any time limitations.
+                  NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                type: string
+              nodeVolumeDetachTimeout:
+                description: |-
+                  nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                  to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                type: string
+              providerID:
+                description: |-
+                  providerID is the identification ID of the machine provided by the provider.
+                  This field must match the provider ID as seen on the node object corresponding to this machine.
+                  This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                  with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                  machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                  generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                  able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                  and then a comparison is done to find out unregistered machines and are marked for delete.
+                  This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                  be interfacing with cluster-api as generic provider.
+                maxLength: 512
+                minLength: 1
+                type: string
+              readinessGates:
+                description: |-
+                  readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                  This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                  Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                  for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                  Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                  they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                  NOTE: This field is considered only for computing v1beta2 conditions.
+                  NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                  readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                  readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                  This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                items:
+                  description: MachineReadinessGate contains the type of a Machine
+                    condition to be used as a readiness gate.
+                  properties:
+                    conditionType:
+                      description: |-
+                        conditionType refers to a condition with matching type in the Machine's condition list.
+                        If the conditions doesn't exist, it will be treated as unknown.
+                        Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                      maxLength: 316
+                      minLength: 1
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                    polarity:
+                      description: |-
+                        polarity of the conditionType specified in this readinessGate.
+                        Valid values are Positive, Negative and omitted.
+                        When omitted, the default behaviour will be Positive.
+                        A positive polarity means that the condition should report a true status under normal conditions.
+                        A negative polarity means that the condition should report a false status under normal conditions.
+                      enum:
+                      - Positive
+                      - Negative
+                      type: string
+                  required:
+                  - conditionType
+                  type: object
+                maxItems: 32
+                type: array
+                x-kubernetes-list-map-keys:
+                - conditionType
+                x-kubernetes-list-type: map
+              taints:
+                description: |-
+                  The list of the taints to be applied to the corresponding Node in additive
+                  manner. This list will not overwrite any other taints added to the Node on
+                  an ongoing basis by other entities. These taints should be actively reconciled
+                  e.g. if you ask the machine controller to apply a taint and then manually remove
+                  the taint the machine controller will put it back) but not have the machine controller
+                  remove any taints
+                items:
+                  description: |-
+                    The node this Taint is attached to has the "effect" on
+                    any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: |-
+                        Required. The effect of the taint on pods
+                        that do not tolerate the taint.
+                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: |-
+                        TimeAdded represents the time at which the taint was added.
+                        It is only written for NoExecute taints.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  This field is meant to be optionally used by bootstrap providers.
+                maxLength: 256
+                minLength: 1
+                type: string
+            required:
+            - bootstrap
+            - clusterName
+            - infrastructureRef
+            type: object
+          status:
+            description: status is the observed state of Machine.
+            properties:
+              addresses:
+                description: |-
+                  addresses is a list of addresses assigned to the machine.
+                  This field is copied from the infrastructure provider reference.
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              bootstrapReady:
+                description: bootstrapReady is the state of the bootstrap provider.
+                type: boolean
+              certificatesExpiryDate:
+                description: |-
+                  certificatesExpiryDate is the expiry date of the machine certificates.
+                  This value is only set for control plane machines.
+                format: date-time
+                type: string
+              conditions:
+                description: conditions defines current service state of the Machine.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              deletion:
+                description: |-
+                  deletion contains information relating to removal of the Machine.
+                  Only present when the Machine has a deletionTimestamp and drain or wait for volume detach started.
+                properties:
+                  nodeDrainStartTime:
+                    description: |-
+                      nodeDrainStartTime is the time when the drain of the node started and is used to determine
+                      if the NodeDrainTimeout is exceeded.
+                      Only present when the Machine has a deletionTimestamp and draining the node had been started.
+                    format: date-time
+                    type: string
+                  waitForNodeVolumeDetachStartTime:
+                    description: |-
+                      waitForNodeVolumeDetachStartTime is the time when waiting for volume detachment started
+                      and is used to determine if the NodeVolumeDetachTimeout is exceeded.
+                      Detaching volumes from nodes is usually done by CSI implementations and the current state
+                      is observed from the node's `.Status.VolumesAttached` field.
+                      Only present when the Machine has a deletionTimestamp and waiting for volume detachments had been started.
+                    format: date-time
+                    type: string
+                type: object
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  This field should not be set for transitive errors that a controller
+                  faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the Machine's spec or the configuration of
+                  the controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the controller, or the
+                  responsible controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the Machine object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              infrastructureReady:
+                description: infrastructureReady is the state of the infrastructure
+                  provider.
+                type: boolean
+              lastUpdated:
+                description: lastUpdated identifies when the phase of the Machine
+                  last transitioned.
+                format: date-time
+                type: string
+              nodeInfo:
+                description: |-
+                  nodeInfo is a set of ids/uuids to uniquely identify the node.
+                  More info: https://kubernetes.io/docs/concepts/nodes/node/#info
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: 'Deprecated: KubeProxy Version reported by the node.'
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: nodeRef will point to the corresponding Node if it exists.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              phase:
+                description: phase represents the current phase of machine actuation.
+                enum:
+                - Pending
+                - Provisioning
+                - Provisioned
+                - Running
+                - Deleting
+                - Deleted
+                - Failed
+                - Unknown
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in Machine's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a Machine's current state.
+                      Known condition types are Available, Ready, UpToDate, BootstrapConfigReady, InfrastructureReady, NodeReady,
+                      NodeHealthy, Deleting, Paused.
+                      If a MachineHealthCheck is targeting this machine, also HealthCheckSucceeded, OwnerRemediated conditions are added.
+                      Additionally control plane Machines controlled by KubeadmControlPlane will have following additional conditions:
+                      APIServerPodHealthy, ControllerManagerPodHealthy, SchedulerPodHealthy, EtcdPodHealthy, EtcdMemberHealthy.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinesets.yaml
+++ b/docs/shared/crds/cluster_api/core/cluster.x-k8s.io_machinesets.yaml
@@ -1,0 +1,706 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: machinesets.cluster.x-k8s.io
+spec:
+  group: cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: MachineSet
+    listKind: MachineSetList
+    plural: machinesets
+    shortNames:
+    - ms
+    singular: machineset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .spec.clusterName
+      name: Cluster
+      type: string
+    - description: Total number of machines desired by this machineset
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this machineset
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of ready machines targeted by this machineset.
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of available machines (ready for at least minReadySeconds)
+      jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - description: Time duration since creation of MachineSet
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this MachineSet
+      jsonPath: .spec.template.spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: MachineSet is the Schema for the machinesets API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of MachineSet.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              deletePolicy:
+                description: |-
+                  deletePolicy defines the policy used to identify nodes to delete when downscaling.
+                  Defaults to "Random". Valid values are "Random", "Newest", "Oldest"
+                enum:
+                - Random
+                - Newest
+                - Oldest
+                type: string
+              machineNamingStrategy:
+                description: |-
+                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
+                  Note: InfraMachines & BootstrapConfigs will use the same name as the corresponding Machines.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the names of the
+                      Machine objects.
+                      If not defined, it will fallback to `{{ .machineSet.name }}-{{ .random }}`.
+                      If the generated name string exceeds 63 characters, it will be trimmed to
+                      58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      Length of the template string must not exceed 256 characters.
+                      The template allows the following variables `.cluster.name`,
+                      `.machineSet.name` and `.random`.
+                      The variable `.cluster.name` retrieves the name of the cluster object
+                      that owns the Machines being created.
+                      The variable `.machineSet.name` retrieves the name of the MachineSet
+                      object that owns the Machines being created.
+                      The variable `.random` is substituted with random alphanumeric string,
+                      without vowels, of length 5. This variable is required part of the
+                      template. If not provided, validation will fail.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                type: object
+              minReadySeconds:
+                description: |-
+                  minReadySeconds is the minimum number of seconds for which a Node for a newly created machine should be ready before considering the replica available.
+                  Defaults to 0 (machine will be considered available as soon as the Node is ready)
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the number of desired replicas.
+                  This is a pointer to distinguish between explicit zero and unspecified.
+
+                  Defaults to:
+                  * if the Kubernetes autoscaler min size and max size annotations are set:
+                    - if it's a new MachineSet, use min size
+                    - if the replicas field of the old MachineSet is < min size, use min size
+                    - if the replicas field of the old MachineSet is > max size, use max size
+                    - if the replicas field of the old MachineSet is in the (min size, max size) range, keep the value from the oldMS
+                  * otherwise use 1
+                  Note: Defaulting will be run whenever the replicas field is not set:
+                  * A new MachineSet is created with replicas not set.
+                  * On an existing MachineSet the replicas field was first set and is now unset.
+                  Those cases are especially relevant for the following Kubernetes autoscaler use cases:
+                  * A new MachineSet is created and replicas should be managed by the autoscaler
+                  * An existing MachineSet which initially wasn't controlled by the autoscaler
+                    should be later controlled by the autoscaler
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is a label query over machines that should match the replica count.
+                  Label keys and values that must match in order to be controlled by this MachineSet.
+                  It must match the machine template's labels.
+                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              template:
+                description: |-
+                  template is the object that describes the machine that will be created if
+                  insufficient replicas are detected.
+                  Object references to custom resources are treated as templates.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      spec is the specification of the desired behavior of the machine.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                    properties:
+                      bootstrap:
+                        description: |-
+                          bootstrap is a reference to a local struct which encapsulates
+                          fields to configure the Machine’s bootstrapping mechanism.
+                        properties:
+                          configRef:
+                            description: |-
+                              configRef is a reference to a bootstrap provider-specific resource
+                              that holds configuration details. The reference is optional to
+                              allow users/operators to specify Bootstrap.DataSecretName without
+                              the need of a controller.
+                            properties:
+                              apiVersion:
+                                description: API version of the referent.
+                                type: string
+                              fieldPath:
+                                description: |-
+                                  If referring to a piece of an object instead of an entire object, this string
+                                  should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                                  For example, if the object reference is to a container within a pod, this would take on a value like:
+                                  "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                                  the event) or if no container name is specified "spec.containers[2]" (container with
+                                  index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                                  referencing a part of an object.
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind of the referent.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              name:
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              namespace:
+                                description: |-
+                                  Namespace of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                                type: string
+                              resourceVersion:
+                                description: |-
+                                  Specific resourceVersion to which this reference is made, if any.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                type: string
+                              uid:
+                                description: |-
+                                  UID of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          dataSecretName:
+                            description: |-
+                              dataSecretName is the name of the secret that stores the bootstrap data script.
+                              If nil, the Machine should remain in the Pending state.
+                            maxLength: 253
+                            minLength: 0
+                            type: string
+                        type: object
+                      clusterName:
+                        description: clusterName is the name of the Cluster this object
+                          belongs to.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      failureDomain:
+                        description: |-
+                          failureDomain is the failure domain the machine will be created in.
+                          Must match a key in the FailureDomains map stored on the cluster object.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      infrastructureRef:
+                        description: |-
+                          infrastructureRef is a required reference to a custom resource
+                          offered by an infrastructure provider.
+                        properties:
+                          apiVersion:
+                            description: API version of the referent.
+                            type: string
+                          fieldPath:
+                            description: |-
+                              If referring to a piece of an object instead of an entire object, this string
+                              should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                              For example, if the object reference is to a container within a pod, this would take on a value like:
+                              "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                              the event) or if no container name is specified "spec.containers[2]" (container with
+                              index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                              referencing a part of an object.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind of the referent.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          name:
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                          namespace:
+                            description: |-
+                              Namespace of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                            type: string
+                          resourceVersion:
+                            description: |-
+                              Specific resourceVersion to which this reference is made, if any.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                            type: string
+                          uid:
+                            description: |-
+                              UID of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      nodeDeletionTimeout:
+                        description: |-
+                          nodeDeletionTimeout defines how long the controller will attempt to delete the Node that the Machine
+                          hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                          Defaults to 10 seconds.
+                        type: string
+                      nodeDrainTimeout:
+                        description: |-
+                          nodeDrainTimeout is the total amount of time that the controller will spend on draining a node.
+                          The default value is 0, meaning that the node can be drained without any time limitations.
+                          NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                        type: string
+                      nodeVolumeDetachTimeout:
+                        description: |-
+                          nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                          to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                        type: string
+                      providerID:
+                        description: |-
+                          providerID is the identification ID of the machine provided by the provider.
+                          This field must match the provider ID as seen on the node object corresponding to this machine.
+                          This field is required by higher level consumers of cluster-api. Example use case is cluster autoscaler
+                          with cluster-api as provider. Clean-up logic in the autoscaler compares machines to nodes to find out
+                          machines at provider which could not get registered as Kubernetes nodes. With cluster-api as a
+                          generic out-of-tree provider for autoscaler, this field is required by autoscaler to be
+                          able to have a provider view of the list of machines. Another list of nodes is queried from the k8s apiserver
+                          and then a comparison is done to find out unregistered machines and are marked for delete.
+                          This field will be set by the actuators and consumed by higher level entities like autoscaler that will
+                          be interfacing with cluster-api as generic provider.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      readinessGates:
+                        description: |-
+                          readinessGates specifies additional conditions to include when evaluating Machine Ready condition.
+
+                          This field can be used e.g. by Cluster API control plane providers to extend the semantic of the
+                          Ready condition for the Machine they control, like the kubeadm control provider adding ReadinessGates
+                          for the APIServerPodHealthy, SchedulerPodHealthy conditions, etc.
+
+                          Another example are external controllers, e.g. responsible to install special software/hardware on the Machines;
+                          they can include the status of those components with a new condition and add this condition to ReadinessGates.
+
+                          NOTE: This field is considered only for computing v1beta2 conditions.
+                          NOTE: In case readinessGates conditions start with the APIServer, ControllerManager, Scheduler prefix, and all those
+                          readiness gates condition are reporting the same message, when computing the Machine's Ready condition those
+                          readinessGates will be replaced by a single entry reporting "Control plane components: " + message.
+                          This helps to improve readability of conditions bubbling up to the Machine's owner resource / to the Cluster).
+                        items:
+                          description: MachineReadinessGate contains the type of a
+                            Machine condition to be used as a readiness gate.
+                          properties:
+                            conditionType:
+                              description: |-
+                                conditionType refers to a condition with matching type in the Machine's condition list.
+                                If the conditions doesn't exist, it will be treated as unknown.
+                                Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                              maxLength: 316
+                              minLength: 1
+                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                              type: string
+                            polarity:
+                              description: |-
+                                polarity of the conditionType specified in this readinessGate.
+                                Valid values are Positive, Negative and omitted.
+                                When omitted, the default behaviour will be Positive.
+                                A positive polarity means that the condition should report a true status under normal conditions.
+                                A negative polarity means that the condition should report a false status under normal conditions.
+                              enum:
+                              - Positive
+                              - Negative
+                              type: string
+                          required:
+                          - conditionType
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - conditionType
+                        x-kubernetes-list-type: map
+                      taints:
+                        description: |-
+                          The list of the taints to be applied to the corresponding Node in additive
+                          manner. This list will not overwrite any other taints added to the Node on
+                          an ongoing basis by other entities. These taints should be actively reconciled
+                          e.g. if you ask the machine controller to apply a taint and then manually remove
+                          the taint the machine controller will put it back) but not have the machine controller
+                          remove any taints
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        type: array
+                      version:
+                        description: |-
+                          version defines the desired Kubernetes version.
+                          This field is meant to be optionally used by bootstrap providers.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    required:
+                    - bootstrap
+                    - clusterName
+                    - infrastructureRef
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - selector
+            type: object
+          status:
+            description: status is the observed state of MachineSet.
+            properties:
+              availableReplicas:
+                description: availableReplicas is the number of available replicas
+                  (ready for at least minReadySeconds) for this MachineSet.
+                format: int32
+                type: integer
+              conditions:
+                description: conditions defines current service state of the MachineSet.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a more verbose string suitable
+                  for logging and human consumption.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set in the event that there is a terminal problem
+                  reconciling the Machine and will contain a succinct value suitable
+                  for machine interpretation.
+
+                  In the event that there is a terminal problem reconciling the
+                  replicas, both FailureReason and FailureMessage will be set. FailureReason
+                  will be populated with a succinct value suitable for machine
+                  interpretation, while FailureMessage will contain a more verbose
+                  string suitable for logging and human consumption.
+
+                  These fields should not be set for transitive errors that a
+                  controller faces that are expected to be fixed automatically over
+                  time (like service outages), but instead indicate that something is
+                  fundamentally wrong with the MachineTemplate's spec or the configuration of
+                  the machine controller, and that manual intervention is required. Examples
+                  of terminal errors would be invalid combinations of settings in the
+                  spec, values that are unsupported by the machine controller, or the
+                  responsible machine controller itself being critically misconfigured.
+
+                  Any transient errors that occur during the reconciliation of Machines
+                  can be added as events to the MachineSet object and/or logged in the
+                  controller's output.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              fullyLabeledReplicas:
+                description: |-
+                  fullyLabeledReplicas is the number of replicas that have labels matching the labels of the machine template of the MachineSet.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration reflects the generation of the most
+                  recently observed MachineSet.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: readyReplicas is the number of ready replicas for this
+                  MachineSet. A machine is considered ready when the node has been
+                  created and is "Ready".
+                format: int32
+                type: integer
+              replicas:
+                description: replicas is the most recently observed number of replicas.
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the same as the label selector but in the string format to avoid introspection
+                  by clients. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                maxLength: 4096
+                minLength: 1
+                type: string
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in MachineSet's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      for this MachineSet. A machine is considered available when
+                      Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a MachineSet's current state.
+                      Known condition types are MachinesReady, MachinesUpToDate, ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this MachineSet. A machine is considered ready when Machine's
+                      Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      for this MachineSet. A machine is considered up-to-date when
+                      Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/docs/shared/crds/cluster_api/hosted_control_plane/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
+++ b/docs/shared/crds/cluster_api/hosted_control_plane/controlplane.cluster.x-k8s.io_kamajicontrolplanes.yaml
@@ -1,0 +1,6713 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    cluster.x-k8s.io/provider: kamaji
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: kamajicontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    - kamaji
+    kind: KamajiControlPlane
+    listKind: KamajiControlPlaneList
+    plural: kamajicontrolplanes
+    shortNames:
+    - ktcp
+    singular: kamajicontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The desired Kubernetes version
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    - description: Check if the Kamaji Control Plane has been initialized
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: Check if the Kamaji Control Plane is up and running
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - description: Age
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KamajiControlPlane is the Schema for the kamajicontrolplanes API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KamajiControlPlaneSpec defines the desired state of KamajiControlPlane.
+            properties:
+              addons:
+                description: The addons that must be managed by Kamaji, such as CoreDNS, kube-proxy, and konnectivity.
+                properties:
+                  coreDNS:
+                    description: |-
+                      Enables the DNS addon in the Tenant Cluster.
+                      The registry and the tag are configurable, the image is hard-coded to `coredns`.
+                    properties:
+                      dnsServiceIPs:
+                        description: |-
+                          DNSServiceIPs contains the CoreDNS Service IPs.
+                          When set to an empty slice, Kamaji will automatically inflect it from the Service CIDR.
+                        items:
+                          type: string
+                        type: array
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the default ImageRepository will be used instead.
+                        type: string
+                      imageTag:
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                  konnectivity:
+                    description: Enables the Konnectivity addon in the Tenant Cluster, required if the worker nodes are in a different network.
+                    properties:
+                      agent:
+                        properties:
+                          extraArgs:
+                            description: |-
+                              ExtraArgs allows adding additional arguments to said component.
+                              WARNING - This option can override existing konnectivity
+                              parameters and cause konnectivity components to misbehave in
+                              unxpected ways. Only modify if you know what you are doing.
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: AgentImage defines the container image for Konnectivity's agent.
+                            type: string
+                          tolerations:
+                            default:
+                            - key: CriticalAddonsOnly
+                              operator: Exists
+                            description: |-
+                              Tolerations for the deployed agent.
+                              Can be customized to start the konnectivity-agent even if the nodes are not ready or tainted.
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                          version:
+                            description: Version for Konnectivity agent.
+                            type: string
+                        type: object
+                      server:
+                        properties:
+                          extraArgs:
+                            description: |-
+                              ExtraArgs allows adding additional arguments to said component.
+                              WARNING - This option can override existing konnectivity
+                              parameters and cause konnectivity components to misbehave in
+                              unxpected ways. Only modify if you know what you are doing.
+                            items:
+                              type: string
+                            type: array
+                          image:
+                            description: Container image used by the Konnectivity server.
+                            type: string
+                          port:
+                            description: The port which Konnectivity server is listening to.
+                            format: int32
+                            type: integer
+                          resources:
+                            description: Resources define the amount of CPU and memory to allocate to the Konnectivity server.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                          version:
+                            description: Container image version of the Konnectivity server.
+                            type: string
+                        required:
+                        - port
+                        type: object
+                    type: object
+                  kubeProxy:
+                    description: |-
+                      Enables the kube-proxy addon in the Tenant Cluster.
+                      The registry and the tag are configurable, the image is hard-coded to `kube-proxy`.
+                    properties:
+                      imageRepository:
+                        description: |-
+                          ImageRepository sets the container registry to pull images from.
+                          if not set, the default ImageRepository will be used instead.
+                        type: string
+                      imageTag:
+                        description: |-
+                          ImageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        type: string
+                    type: object
+                type: object
+              admissionControllers:
+                description: |-
+                  List of the admission controllers to configure for the TenantControlPlane kube-apiserver.
+                  By default, no admission controllers are enabled, refer to the desired Kubernetes version.
+
+                  More info: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+                items:
+                  enum:
+                  - AlwaysAdmit
+                  - AlwaysDeny
+                  - AlwaysPullImages
+                  - CertificateApproval
+                  - CertificateSigning
+                  - CertificateSubjectRestriction
+                  - DefaultIngressClass
+                  - DefaultStorageClass
+                  - DefaultTolerationSeconds
+                  - DenyEscalatingExec
+                  - DenyExecOnPrivileged
+                  - DenyServiceExternalIPs
+                  - EventRateLimit
+                  - ExtendedResourceToleration
+                  - ImagePolicyWebhook
+                  - LimitPodHardAntiAffinityTopology
+                  - LimitRanger
+                  - MutatingAdmissionWebhook
+                  - NamespaceAutoProvision
+                  - NamespaceExists
+                  - NamespaceLifecycle
+                  - NodeRestriction
+                  - OwnerReferencesPermissionEnforcement
+                  - PersistentVolumeClaimResize
+                  - PersistentVolumeLabel
+                  - PodNodeSelector
+                  - PodSecurity
+                  - PodSecurityPolicy
+                  - PodTolerationRestriction
+                  - Priority
+                  - ResourceQuota
+                  - RuntimeClass
+                  - SecurityContextDeny
+                  - ServiceAccount
+                  - StorageObjectInUseProtection
+                  - TaintNodesByCondition
+                  - ValidatingAdmissionWebhook
+                  type: string
+                type: array
+              apiServer:
+                description: ControlPlaneComponent allows the customization for the given component of the control plane.
+                properties:
+                  containerImageName:
+                    description: |-
+                      In combination with the container registry, it can override the component container image.
+                      With no value, the default images will be used.
+                    minLength: 1
+                    type: string
+                  extraArgs:
+                    items:
+                      type: string
+                    type: array
+                  extraVolumeMounts:
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              controlPlaneEndpoint:
+                description: ControlPlaneEndpoint propagates the endpoint the Kubernetes API Server managed by Kamaji is located.
+                properties:
+                  host:
+                    description: host is the hostname on which the API server is serving.
+                    maxLength: 512
+                    type: string
+                  port:
+                    description: port is the port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controllerManager:
+                description: ControlPlaneComponent allows the customization for the given component of the control plane.
+                properties:
+                  containerImageName:
+                    description: |-
+                      In combination with the container registry, it can override the component container image.
+                      With no value, the default images will be used.
+                    minLength: 1
+                    type: string
+                  extraArgs:
+                    items:
+                      type: string
+                    type: array
+                  extraVolumeMounts:
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              dataStoreName:
+                description: |-
+                  The Kamaji DataStore to use for the given TenantControlPlane.
+                  Retrieve the list of the allowed ones by issuing "kubectl get datastores.kamaji.clastix.io".
+                type: string
+              dataStoreSchema:
+                description: DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd)
+                type: string
+              deployment:
+                description: Configure how the TenantControlPlane Deployment object should be configured.
+                properties:
+                  additionalMetadata:
+                    description: |-
+                      AdditionalMetadata refers to the additional labels and annotations attached
+                      to the resulting Deployment managed by Kamaji.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  affinity:
+                    description: Affinity is a group of affinity scheduling rules.
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node matches the corresponding matchExpressions; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: |-
+                                An empty preferred scheduling term matches all objects with implicit weight 0
+                                (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                weight:
+                                  description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms. The terms are ORed.
+                                items:
+                                  description: |-
+                                    A null or empty node selector term matches no objects. The requirements of
+                                    them are ANDed.
+                                    The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements by node's labels.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchFields:
+                                      description: A list of node selector requirements by node's fields.
+                                      items:
+                                        description: |-
+                                          A node selector requirement is a selector that contains values, a key, and an operator
+                                          that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              An array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. If the operator is Gt or Lt, the values
+                                              array must have a single element, which will be interpreted as an integer.
+                                              This array is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              The scheduler will prefer to schedule pods to nodes that satisfy
+                              the anti-affinity expressions specified by this field, but it may choose
+                              a node that violates one or more of the expressions. The node that is
+                              most preferred is the one with the greatest sum of weights, i.e.
+                              for each node that meets all of the scheduling requirements (resource
+                              request, requiredDuringScheduling anti-affinity expressions, etc.),
+                              compute a sum by iterating through the elements of this field and adding
+                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  description: |-
+                                    weight associated with matching the corresponding podAffinityTerm,
+                                    in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: |-
+                              If the anti-affinity requirements specified by this field are not met at
+                              scheduling time, the pod will not be scheduled onto the node.
+                              If the anti-affinity requirements specified by this field cease to be met
+                              at some point during pod execution (e.g. due to a pod label update), the
+                              system may or may not try to eventually evict the pod from its node.
+                              When there are multiple elements, the lists of nodes corresponding to each
+                              podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: |-
+                                Defines a set of pods (namely those matching the labelSelector
+                                relative to the given namespace(s)) that this pod should be
+                                co-located (affinity) or not co-located (anti-affinity) with,
+                                where co-located is defined as running on a node whose value of
+                                the label with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        type: object
+                    type: object
+                  externalClusterReference:
+                    description: |-
+                      ExternalClusterReference allows defining the target Cluster where the Tenant Control Plane components must be deployed.
+                      When this value is nil, the Cluster API management cluster will be used as a target.
+                      The ExternalClusterReference feature gate must be enabled with one of the available flags.
+                    properties:
+                      deploymentNamespace:
+                        description: The Namespace where the resulting TenantControlPlane must be deployed to.
+                        type: string
+                      kubeconfigSecretKey:
+                        description: The key used to extract the kubeconfig from the specified Secret.
+                        minLength: 1
+                        type: string
+                      kubeconfigSecretName:
+                        description: |-
+                          The Secret object containing the kubeconfig used to interact with the remote cluster that will host
+                          the Tenant Control Plane resources generated by the Control Plane Provider.
+                        minLength: 1
+                        type: string
+                      kubeconfigSecretNamespace:
+                        description: |-
+                          When ExternalClusterReferenceCrossNamespace is enabled allows specifying a different Namespace where the kubeconfig can be retrieved.
+                          With ExternalClusterReference this value can be left empty since the KamajiControlPlane object Namespace will be used.
+                        type: string
+                    required:
+                    - deploymentNamespace
+                    - kubeconfigSecretKey
+                    - kubeconfigSecretName
+                    type: object
+                  extraContainers:
+                    items:
+                      description: A single application container that you want to run within a pod.
+                      properties:
+                        args:
+                          description: |-
+                            Arguments to the entrypoint.
+                            The container image's CMD is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                            cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                            produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Cannot be updated.
+                            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          description: |-
+                            Entrypoint array. Not executed within a shell.
+                            The container image's ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                            cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                            produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Cannot be updated.
+                            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        env:
+                          description: |-
+                            List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: |-
+                            List of sources to populate environment variables in the container.
+                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                            will be reported as an event when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take precedence.
+                            Values defined by an Env with a duplicate key will take precedence.
+                            Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              prefix:
+                                description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        image:
+                          description: |-
+                            Container image name.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy.
+                            One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                          type: string
+                        lifecycle:
+                          description: |-
+                            Actions that the management system should take in response to container lifecycle events.
+                            Cannot be updated.
+                          properties:
+                            postStart:
+                              description: |-
+                                PostStart is called immediately after a container is created. If the handler fails,
+                                the container is terminated and restarted according to its restart policy.
+                                Other management of the container blocks until the hook completes.
+                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request. HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: |-
+                                    Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: |-
+                                PreStop is called immediately before a container is terminated due to an
+                                API request or management event such as liveness/startup probe failure,
+                                preemption, resource contention, etc. The handler is not called if the
+                                container crashes or exits. The Pod's termination grace period countdown begins before the
+                                PreStop hook is executed. Regardless of the outcome of the handler, the
+                                container will eventually terminate within the Pod's termination grace
+                                period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                or until the termination grace period is reached.
+                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request. HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: |-
+                                    Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
+                          type: object
+                        livenessProbe:
+                          description: |-
+                            Periodic probe of container liveness.
+                            Container will be restarted if the probe fails.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: |-
+                            Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: |-
+                            List of ports to expose from the container. Not specifying a port here
+                            DOES NOT prevent that port from being exposed. Any port which is
+                            listening on the default "0.0.0.0" address inside a container will be
+                            accessible from the network.
+                            Modifying this array with strategic merge patch may corrupt the data.
+                            For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single container.
+                            properties:
+                              containerPort:
+                                description: |-
+                                  Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: |-
+                                  Number of port to expose on the host.
+                                  If specified, this must be a valid port number, 0 < x < 65536.
+                                  If HostNetwork is specified, this must match ContainerPort.
+                                  Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: |-
+                                  If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                  named port in a pod must have a unique name. Name for the port that can be
+                                  referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP.
+                                  Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: |-
+                            Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the probe fails.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: |-
+                                  Name of the resource to which this resource resize policy applies.
+                                  Supported values: cpu, memory.
+                                type: string
+                              restartPolicy:
+                                description: |-
+                                  Restart policy to apply when specified resource is resized.
+                                  If not specified, it defaults to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Compute Resources required by this container.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        restartPolicy:
+                          description: |-
+                            RestartPolicy defines the restart behavior of individual containers in a pod.
+                            This field may only be set for init containers, and the only allowed value is "Always".
+                            For non-init containers or when this field is not specified,
+                            the restart behavior is defined by the Pod's restart policy and the container type.
+                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            this init container will be continually restarted on
+                            exit until all regular containers have terminated. Once all regular
+                            containers have completed, all init containers with restartPolicy "Always"
+                            will be shut down. This lifecycle differs from normal init containers and
+                            is often referred to as a "sidecar" container. Although this init
+                            container still starts in the init container sequence, it does not wait
+                            for the container to complete before proceeding to the next init
+                            container. Instead, the next init container starts immediately after this
+                            init container is started, or after any startupProbe has successfully
+                            completed.
+                          type: string
+                        securityContext:
+                          description: |-
+                            SecurityContext defines the security options the container should be run with.
+                            If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: |-
+                                AllowPrivilegeEscalation controls whether a process can gain more
+                                privileges than its parent process. This bool directly controls if
+                                the no_new_privs flag will be set on the container process.
+                                AllowPrivilegeEscalation is true always when the container is:
+                                1) run as Privileged
+                                2) has CAP_SYS_ADMIN
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                overrides the pod's appArmorProfile.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            capabilities:
+                              description: |-
+                                The capabilities to add/drop when running containers.
+                                Defaults to the default set of capabilities granted by the container runtime.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            privileged:
+                              description: |-
+                                Run container in privileged mode.
+                                Processes in privileged containers are essentially equivalent to root on the host.
+                                Defaults to false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: |-
+                                procMount denotes the type of proc mount to use for the containers.
+                                The default value is Default which uses the container runtime defaults for
+                                readonly paths and masked paths.
+                                This requires the ProcMountType feature flag to be enabled.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: |-
+                                Whether this container has a read-only root filesystem.
+                                Default is false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: |-
+                                The GID to run the entrypoint of the container process.
+                                Uses runtime default if unset.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: |-
+                                Indicates that the container must run as a non-root user.
+                                If true, the Kubelet will validate the image at runtime to ensure that it
+                                does not run as UID 0 (root) and fail to start the container if it does.
+                                If unset or false, no such validation will be performed.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: |-
+                                The UID to run the entrypoint of the container process.
+                                Defaults to user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: |-
+                                The SELinux context to be applied to the container.
+                                If unspecified, the container runtime will allocate a random SELinux context for each
+                                container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: |-
+                                The seccomp options to use by this container. If seccomp options are
+                                provided at both the pod & container level, the container options
+                                override the pod options.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied.
+                                    Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used.
+                                    RuntimeDefault - the container runtime default profile should be used.
+                                    Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: |-
+                                The Windows specific settings applied to all containers.
+                                If unspecified, the options from the PodSecurityContext will be used.
+                                If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: |-
+                                    GMSACredentialSpec is where the GMSA admission webhook
+                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: |-
+                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                    All of a Pod's containers must have the same effective HostProcess value
+                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: |-
+                                    The UserName in Windows to run the entrypoint of the container process.
+                                    Defaults to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: |-
+                            StartupProbe indicates that the Pod has successfully initialized.
+                            If specified, no other probes are executed until this completes successfully.
+                            If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                            This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                            when it might take a long time to load data or warm a cache, than during steady-state operation.
+                            This cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: |-
+                            Whether this container should allocate a buffer for stdin in the container runtime. If this
+                            is not set, reads from stdin in the container will always result in EOF.
+                            Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: |-
+                            Whether the container runtime should close the stdin channel after it has been opened by
+                            a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                            first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container is restarted. If this
+                            flag is false, a container processes that reads from stdin will never receive an EOF.
+                            Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: |-
+                            Optional: Path at which the file to which the container's termination message
+                            will be written is mounted into the container's filesystem.
+                            Message written is intended to be brief final status, such as an assertion failure message.
+                            Will be truncated by the node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb.
+                            Defaults to /dev/termination-log.
+                            Cannot be updated.
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of
+                            terminationMessagePath to populate the container status message on both success and failure.
+                            FallbackToLogsOnError will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                            Defaults to File.
+                            Cannot be updated.
+                          type: string
+                        tty:
+                          description: |-
+                            Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                            Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: |-
+                            Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within a container.
+                            properties:
+                              mountPath:
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: |-
+                                  mountPropagation determines how mounts are propagated from the host
+                                  to container and the other way around.
+                                  When not set, MountPropagationNone is used.
+                                  This field is beta in 1.10.
+                                  When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                  (which defaults to None).
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  Mounted read-only if true, read-write otherwise (false or unspecified).
+                                  Defaults to false.
+                                type: boolean
+                              recursiveReadOnly:
+                                description: |-
+                                  RecursiveReadOnly specifies whether read-only mounts should be handled
+                                  recursively.
+
+                                  If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                  If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                  recursively read-only.  If this field is set to IfPossible, the mount is made
+                                  recursively read-only, if it is supported by the container runtime.  If this
+                                  field is set to Enabled, the mount is made recursively read-only if it is
+                                  supported by the container runtime, otherwise the pod will not be started and
+                                  an error will be generated to indicate the reason.
+
+                                  If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                  None (or be unspecified, which defaults to None).
+
+                                  If this field is not specified, it is treated as an equivalent of Disabled.
+                                type: string
+                              subPath:
+                                description: |-
+                                  Path within the volume from which the container's volume should be mounted.
+                                  Defaults to "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: |-
+                                  Expanded path within the volume from which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root).
+                                  SubPathExpr and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: |-
+                            Container's working directory.
+                            If not specified, the container runtime's default will be used, which
+                            might be configured in the container image.
+                            Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  extraInitContainers:
+                    items:
+                      description: A single application container that you want to run within a pod.
+                      properties:
+                        args:
+                          description: |-
+                            Arguments to the entrypoint.
+                            The container image's CMD is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                            cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                            produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Cannot be updated.
+                            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        command:
+                          description: |-
+                            Entrypoint array. Not executed within a shell.
+                            The container image's ENTRYPOINT is used if this is not provided.
+                            Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                            cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                            produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                            of whether the variable exists or not. Cannot be updated.
+                            More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        env:
+                          description: |-
+                            List of environment variables to set in the container.
+                            Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fieldRef:
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - name
+                          x-kubernetes-list-type: map
+                        envFrom:
+                          description: |-
+                            List of sources to populate environment variables in the container.
+                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                            will be reported as an event when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take precedence.
+                            Values defined by an Env with a duplicate key will take precedence.
+                            Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              prefix:
+                                description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        image:
+                          description: |-
+                            Container image name.
+                            More info: https://kubernetes.io/docs/concepts/containers/images
+                            This field is optional to allow higher level config management to default or override
+                            container images in workload controllers like Deployments and StatefulSets.
+                          type: string
+                        imagePullPolicy:
+                          description: |-
+                            Image pull policy.
+                            One of Always, Never, IfNotPresent.
+                            Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                          type: string
+                        lifecycle:
+                          description: |-
+                            Actions that the management system should take in response to container lifecycle events.
+                            Cannot be updated.
+                          properties:
+                            postStart:
+                              description: |-
+                                PostStart is called immediately after a container is created. If the handler fails,
+                                the container is terminated and restarted according to its restart policy.
+                                Other management of the container blocks until the hook completes.
+                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request. HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: |-
+                                    Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: |-
+                                PreStop is called immediately before a container is terminated due to an
+                                API request or management event such as liveness/startup probe failure,
+                                preemption, resource contention, etc. The handler is not called if the
+                                container crashes or exits. The Pod's termination grace period countdown begins before the
+                                PreStop hook is executed. Regardless of the outcome of the handler, the
+                                container will eventually terminate within the Pod's termination grace
+                                period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                or until the termination grace period is reached.
+                                More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute in the container.
+                                  properties:
+                                    command:
+                                      description: |-
+                                        Command is the command line to execute inside the container, the working directory for the
+                                        command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                        not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                        a shell, you need to explicitly call out to that shell.
+                                        Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request to perform.
+                                  properties:
+                                    host:
+                                      description: |-
+                                        Host name to connect to, defaults to the pod IP. You probably want to set
+                                        "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request. HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: |-
+                                              The header field name.
+                                              This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Name or number of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: |-
+                                        Scheme to use for connecting to the host.
+                                        Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: |-
+                                    Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                    for backward compatibility. There is no validation of this field and
+                                    lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        Number or name of the port to access on the container.
+                                        Number must be in the range 1 to 65535.
+                                        Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
+                          type: object
+                        livenessProbe:
+                          description: |-
+                            Periodic probe of container liveness.
+                            Container will be restarted if the probe fails.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: |-
+                            Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                            Cannot be updated.
+                          type: string
+                        ports:
+                          description: |-
+                            List of ports to expose from the container. Not specifying a port here
+                            DOES NOT prevent that port from being exposed. Any port which is
+                            listening on the default "0.0.0.0" address inside a container will be
+                            accessible from the network.
+                            Modifying this array with strategic merge patch may corrupt the data.
+                            For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                            Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single container.
+                            properties:
+                              containerPort:
+                                description: |-
+                                  Number of port to expose on the pod's IP address.
+                                  This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: |-
+                                  Number of port to expose on the host.
+                                  If specified, this must be a valid port number, 0 < x < 65536.
+                                  If HostNetwork is specified, this must match ContainerPort.
+                                  Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: |-
+                                  If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                  named port in a pod must have a unique name. Name for the port that can be
+                                  referred to by services.
+                                type: string
+                              protocol:
+                                default: TCP
+                                description: |-
+                                  Protocol for port. Must be UDP, TCP, or SCTP.
+                                  Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - containerPort
+                          - protocol
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: |-
+                            Periodic probe of container service readiness.
+                            Container will be removed from service endpoints if the probe fails.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: |-
+                                  Name of the resource to which this resource resize policy applies.
+                                  Supported values: cpu, memory.
+                                type: string
+                              restartPolicy:
+                                description: |-
+                                  Restart policy to apply when specified resource is resized.
+                                  If not specified, it defaults to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        resources:
+                          description: |-
+                            Compute Resources required by this container.
+                            Cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims,
+                                that are used by this container.
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name must match the name of one entry in pod.spec.resourceClaims of
+                                      the Pod where this field is used. It makes that resource available
+                                      inside a container.
+                                    type: string
+                                  request:
+                                    description: |-
+                                      Request is the name chosen for a request in the referenced claim.
+                                      If empty, everything from the claim is made available, otherwise
+                                      only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                              type: object
+                          type: object
+                        restartPolicy:
+                          description: |-
+                            RestartPolicy defines the restart behavior of individual containers in a pod.
+                            This field may only be set for init containers, and the only allowed value is "Always".
+                            For non-init containers or when this field is not specified,
+                            the restart behavior is defined by the Pod's restart policy and the container type.
+                            Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                            this init container will be continually restarted on
+                            exit until all regular containers have terminated. Once all regular
+                            containers have completed, all init containers with restartPolicy "Always"
+                            will be shut down. This lifecycle differs from normal init containers and
+                            is often referred to as a "sidecar" container. Although this init
+                            container still starts in the init container sequence, it does not wait
+                            for the container to complete before proceeding to the next init
+                            container. Instead, the next init container starts immediately after this
+                            init container is started, or after any startupProbe has successfully
+                            completed.
+                          type: string
+                        securityContext:
+                          description: |-
+                            SecurityContext defines the security options the container should be run with.
+                            If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: |-
+                                AllowPrivilegeEscalation controls whether a process can gain more
+                                privileges than its parent process. This bool directly controls if
+                                the no_new_privs flag will be set on the container process.
+                                AllowPrivilegeEscalation is true always when the container is:
+                                1) run as Privileged
+                                2) has CAP_SYS_ADMIN
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            appArmorProfile:
+                              description: |-
+                                appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                overrides the pod's appArmorProfile.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must match the loaded name of the profile.
+                                    Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied.
+                                    Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            capabilities:
+                              description: |-
+                                The capabilities to add/drop when running containers.
+                                Defaults to the default set of capabilities granted by the container runtime.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    description: Capability represent POSIX capabilities type
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            privileged:
+                              description: |-
+                                Run container in privileged mode.
+                                Processes in privileged containers are essentially equivalent to root on the host.
+                                Defaults to false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: |-
+                                procMount denotes the type of proc mount to use for the containers.
+                                The default value is Default which uses the container runtime defaults for
+                                readonly paths and masked paths.
+                                This requires the ProcMountType feature flag to be enabled.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: |-
+                                Whether this container has a read-only root filesystem.
+                                Default is false.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: |-
+                                The GID to run the entrypoint of the container process.
+                                Uses runtime default if unset.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: |-
+                                Indicates that the container must run as a non-root user.
+                                If true, the Kubelet will validate the image at runtime to ensure that it
+                                does not run as UID 0 (root) and fail to start the container if it does.
+                                If unset or false, no such validation will be performed.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: |-
+                                The UID to run the entrypoint of the container process.
+                                Defaults to user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: |-
+                                The SELinux context to be applied to the container.
+                                If unspecified, the container runtime will allocate a random SELinux context for each
+                                container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: |-
+                                The seccomp options to use by this container. If seccomp options are
+                                provided at both the pod & container level, the container options
+                                override the pod options.
+                                Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: |-
+                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                    The profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied.
+                                    Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used.
+                                    RuntimeDefault - the container runtime default profile should be used.
+                                    Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: |-
+                                The Windows specific settings applied to all containers.
+                                If unspecified, the options from the PodSecurityContext will be used.
+                                If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: |-
+                                    GMSACredentialSpec is where the GMSA admission webhook
+                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: |-
+                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                    All of a Pod's containers must have the same effective HostProcess value
+                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: |-
+                                    The UserName in Windows to run the entrypoint of the container process.
+                                    Defaults to the user specified in image metadata if unspecified.
+                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: |-
+                            StartupProbe indicates that the Pod has successfully initialized.
+                            If specified, no other probes are executed until this completes successfully.
+                            If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                            This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                            when it might take a long time to load data or warm a cache, than during steady-state operation.
+                            This cannot be updated.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: |-
+                                    Command is the command line to execute inside the container, the working directory for the
+                                    command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                    not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                    a shell, you need to explicitly call out to that shell.
+                                    Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            failureThreshold:
+                              description: |-
+                                Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  default: ""
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest
+                                    (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: |-
+                                    Host name to connect to, defaults to the pod IP. You probably want to set
+                                    "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: |-
+                                          The header field name.
+                                          This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Name or number of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: |-
+                                    Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: |-
+                                Number of seconds after the container has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: |-
+                                How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: |-
+                                Minimum consecutive successes for the probe to be considered successful after having failed.
+                                Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    Number or name of the port to access on the container.
+                                    Number must be in the range 1 to 65535.
+                                    Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                value overrides the value provided by the pod spec.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: |-
+                                Number of seconds after which the probe times out.
+                                Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: |-
+                            Whether this container should allocate a buffer for stdin in the container runtime. If this
+                            is not set, reads from stdin in the container will always result in EOF.
+                            Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: |-
+                            Whether the container runtime should close the stdin channel after it has been opened by
+                            a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                            sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                            first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                            at which time stdin is closed and remains closed until the container is restarted. If this
+                            flag is false, a container processes that reads from stdin will never receive an EOF.
+                            Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: |-
+                            Optional: Path at which the file to which the container's termination message
+                            will be written is mounted into the container's filesystem.
+                            Message written is intended to be brief final status, such as an assertion failure message.
+                            Will be truncated by the node if greater than 4096 bytes. The total message length across
+                            all containers will be limited to 12kb.
+                            Defaults to /dev/termination-log.
+                            Cannot be updated.
+                          type: string
+                        terminationMessagePolicy:
+                          description: |-
+                            Indicate how the termination message should be populated. File will use the contents of
+                            terminationMessagePath to populate the container status message on both success and failure.
+                            FallbackToLogsOnError will use the last chunk of container log output if the termination
+                            message file is empty and the container exited with an error.
+                            The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                            Defaults to File.
+                            Cannot be updated.
+                          type: string
+                        tty:
+                          description: |-
+                            Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                            Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - devicePath
+                          x-kubernetes-list-type: map
+                        volumeMounts:
+                          description: |-
+                            Pod volumes to mount into the container's filesystem.
+                            Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within a container.
+                            properties:
+                              mountPath:
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: |-
+                                  mountPropagation determines how mounts are propagated from the host
+                                  to container and the other way around.
+                                  When not set, MountPropagationNone is used.
+                                  This field is beta in 1.10.
+                                  When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                  (which defaults to None).
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: |-
+                                  Mounted read-only if true, read-write otherwise (false or unspecified).
+                                  Defaults to false.
+                                type: boolean
+                              recursiveReadOnly:
+                                description: |-
+                                  RecursiveReadOnly specifies whether read-only mounts should be handled
+                                  recursively.
+
+                                  If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                  If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                  recursively read-only.  If this field is set to IfPossible, the mount is made
+                                  recursively read-only, if it is supported by the container runtime.  If this
+                                  field is set to Enabled, the mount is made recursively read-only if it is
+                                  supported by the container runtime, otherwise the pod will not be started and
+                                  an error will be generated to indicate the reason.
+
+                                  If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                  None (or be unspecified, which defaults to None).
+
+                                  If this field is not specified, it is treated as an equivalent of Disabled.
+                                type: string
+                              subPath:
+                                description: |-
+                                  Path within the volume from which the container's volume should be mounted.
+                                  Defaults to "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: |-
+                                  Expanded path within the volume from which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root).
+                                  SubPathExpr and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                          - mountPath
+                          x-kubernetes-list-type: map
+                        workingDir:
+                          description: |-
+                            Container's working directory.
+                            If not specified, the container runtime's default will be used, which
+                            might be configured in the container image.
+                            Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  extraVolumes:
+                    items:
+                      description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: |-
+                            awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                            awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly value true will force the readOnly setting in VolumeMounts.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: boolean
+                            volumeID:
+                              description: |-
+                                volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: |-
+                            azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                            are redirected to the disk.csi.azure.com CSI driver.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the blob storage
+                              type: string
+                            fsType:
+                              default: ext4
+                              description: |-
+                                fsType is Filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                              type: string
+                            readOnly:
+                              default: false
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: |-
+                            azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                            are redirected to the file.csi.azure.com CSI driver.
+                          properties:
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: |-
+                            cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                            Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                          properties:
+                            monitors:
+                              description: |-
+                                monitors is Required: Monitors is a collection of Ceph monitors
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: boolean
+                            secretFile:
+                              description: |-
+                                secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              description: |-
+                                user is optional: User is the rados user name, default is admin
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: |-
+                            cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                            are redirected to the cinder.csi.openstack.org CSI driver.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is optional: points to a secret object containing parameters used to connect
+                                to OpenStack.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeID:
+                              description: |-
+                                volumeID used to identify the volume in cinder.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
+                          properties:
+                            driver:
+                              description: |-
+                                driver is the name of the CSI driver that handles this volume.
+                                Consult with your admin for the correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the associated CSI driver
+                                which will determine the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: |-
+                                nodePublishSecretRef is a reference to the secret object containing
+                                sensitive information to pass to the CSI driver to complete the CSI
+                                NodePublishVolume and NodeUnpublishVolume calls.
+                                This field is optional, and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret references are passed.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly specifies a read-only configuration for the volume.
+                                Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                volumeAttributes stores driver-specific properties that are passed to the CSI
+                                driver. Consult your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                Optional: mode bits to use on created files by default. Must be a
+                                Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume file
+                              items:
+                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        emptyDir:
+                          description: |-
+                            emptyDir represents a temporary directory that shares a pod's lifetime.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          properties:
+                            medium:
+                              description: |-
+                                medium represents what type of storage medium should back this directory.
+                                The default is "" which means to use the node's default medium.
+                                Must be an empty string (default) or Memory.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                The size limit is also applicable for memory medium.
+                                The maximum usage on memory medium EmptyDir would be the minimum value between
+                                the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                The default is nil which means that the limit is undefined.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver.
+                            The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                            and deleted when the pod is removed.
+
+                            Use this if:
+                            a) the volume is only needed while the pod runs,
+                            b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and
+                            d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific
+                            APIs for volumes that persist for longer than the lifecycle
+                            of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                            be used that way - see the documentation of the driver for
+                            more information.
+
+                            A pod can use both types of ephemeral volumes and
+                            persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume.
+                                The pod in which this EphemeralVolumeSource is embedded will be the
+                                owner of the PVC, i.e. the PVC will be deleted together with the
+                                pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                `<volume name>` is the name from the `PodSpec.Volumes` array
+                                entry. Pod validation will reject the pod if the concatenated name
+                                is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod
+                                will *not* be used for the pod to avoid using an unrelated
+                                volume by mistake. Starting the pod is then blocked until
+                                the unrelated PVC is removed. If such a pre-created PVC is
+                                meant to be used by the pod, the PVC has to updated with an
+                                owner reference to the pod once the pod exists. Normally
+                                this should not be necessary, but it may be useful when
+                                manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes
+                                to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    May contain labels and annotations that will be copied into the PVC
+                                    when creating it. No other fields are allowed and will be rejected during
+                                    validation.
+                                  type: object
+                                spec:
+                                  description: |-
+                                    The specification for the PersistentVolumeClaim. The entire content is
+                                    copied unchanged into the PVC that gets created from this
+                                    template. The same fields as in a PersistentVolumeClaim
+                                    are also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: |-
+                                        accessModes contains the desired access modes the volume should have.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    dataSource:
+                                      description: |-
+                                        dataSource field can be used to specify either:
+                                        * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller can support the specified data source,
+                                        it will create a new volume based on the contents of the specified data source.
+                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                        volume is desired. This may be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding will only succeed if the type of
+                                        the specified object matches some installed volume populator or dynamic
+                                        provisioner.
+                                        This field will replace the functionality of the dataSource field and as such
+                                        if both fields are non-empty, they must have the same value. For backwards
+                                        compatibility, when namespace isn't specified in dataSourceRef,
+                                        both fields (dataSource and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty and the other is non-empty.
+                                        When namespace is specified in dataSourceRef,
+                                        dataSource isn't set to the same value and must be empty.
+                                        There are three important differences between dataSource and dataSourceRef:
+                                        * While dataSource only allows two specific types of objects, dataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        * While dataSource only allows local objects, dataSourceRef allows objects
+                                          in any namespaces.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource being referenced
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of resource being referenced
+                                            Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                            (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: |-
+                                        resources represents the minimum resources the volume should have.
+                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        that are lower than previous value but must still be higher than capacity recorded in the
+                                        status field of the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
+                                      description: |-
+                                        storageClassName is the name of the StorageClass required by the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: |-
+                                        volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                        If specified, the CSI driver will create or update the volume with the attributes defined
+                                        in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller if it exists.
+                                        If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                        set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                        exists.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                      type: string
+                                    volumeMode:
+                                      description: |-
+                                        volumeMode defines what type of volume is required by the claim.
+                                        Value of Filesystem is implied when not included in claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            wwids:
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        flexVolume:
+                          description: |-
+                            flexVolume represents a generic volume resource that is
+                            provisioned/attached using an exec based plugin.
+                            Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use for this volume.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: secretRef is reference to the secret object containing
+                                sensitive information to pass to the plugin scripts. This may be
+                                empty if no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed to the plugin
+                                scripts.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: |-
+                            flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                            Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                          properties:
+                            datasetName:
+                              description: |-
+                                datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                should be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: |-
+                            gcePersistentDisk represents a GCE Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                            gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: |-
+                                pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: |-
+                            gitRepo represents a git repository at a particular revision.
+                            Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                            EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                            into the Pod's container.
+                          properties:
+                            directory:
+                              description: |-
+                                directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: |-
+                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                            Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                          properties:
+                            endpoints:
+                              description: |-
+                                endpoints is the endpoint name that details Glusterfs topology.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            path:
+                              description: |-
+                                path is the Glusterfs volume path.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: |-
+                            hostPath represents a pre-existing file or directory on the host
+                            machine that is directly exposed to the container. This is generally
+                            used for system agents or other privileged things that are allowed
+                            to see the host machine. Most containers will NOT need this.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          properties:
+                            path:
+                              description: |-
+                                path of the directory on the host.
+                                If the path is a symlink, it will follow the link to the real path.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                            type:
+                              description: |-
+                                type for HostPath Volume
+                                Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        image:
+                          description: |-
+                            image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                            The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                            - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                            The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                            A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                            The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                            The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                            The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                                Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                          type: object
+                        iscsi:
+                          description: |-
+                            iscsi represents an ISCSI Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              type: string
+                            initiatorName:
+                              description: |-
+                                initiatorName is the custom iSCSI Initiator Name.
+                                If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                <target portal>:<volume name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              default: default
+                              description: |-
+                                iscsiInterface is the interface Name that uses an iSCSI transport.
+                                Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: |-
+                                portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            targetPortal:
+                              description: |-
+                                targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          description: |-
+                            name of the volume.
+                            Must be a DNS_LABEL and unique within the pod.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        nfs:
+                          description: |-
+                            nfs represents an NFS mount on the host that shares a pod's lifetime
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          properties:
+                            path:
+                              description: |-
+                                path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the NFS export to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: boolean
+                            server:
+                              description: |-
+                                server is the hostname or IP address of the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          description: |-
+                            persistentVolumeClaimVolumeSource represents a reference to a
+                            PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          properties:
+                            claimName:
+                              description: |-
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: |-
+                            photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                            Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: |-
+                            portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                            Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                            is on.
+                          properties:
+                            fsType:
+                              description: |-
+                                fSType represents the filesystem type to mount
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets, configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode are the mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: |-
+                                sources is the list of volume projections. Each entry in this list
+                                handles one source.
+                              items:
+                                description: |-
+                                  Projection that may be projected along with other supported volume types.
+                                  Exactly one of these fields must be set.
+                                properties:
+                                  clusterTrustBundle:
+                                    description: |-
+                                      ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                      of ClusterTrustBundle objects in an auto-updating file.
+
+                                      Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                      ClusterTrustBundle objects can either be selected by name, or by the
+                                      combination of signer name and a label selector.
+
+                                      Kubelet performs aggressive normalization of the PEM contents written
+                                      into the pod filesystem.  Esoteric PEM features such as inter-block
+                                      comments and block headers are stripped.  Certificates are deduplicated.
+                                      The ordering of certificates within the file is arbitrary, and Kubelet
+                                      may change the order over time.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                          interpreted as "match nothing".  If set but empty, interpreted as "match
+                                          everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: |-
+                                          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                          with signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the named ClusterTrustBundle is
+                                          allowed not to exist.  If using signerName, then the combination of
+                                          signerName and labelSelector is allowed to match zero
+                                          ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this signer name.
+                                          Mutually-exclusive with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  configMap:
+                                    description: configMap information about the configMap data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  downwardAPI:
+                                    description: downwardAPI information about the downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: |-
+                                          audience is the intended audience of the token. A recipient of a token
+                                          must identify itself with an identifier specified in the audience of the
+                                          token, and otherwise should reject the token. The audience defaults to the
+                                          identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: |-
+                                          expirationSeconds is the requested duration of validity of the service
+                                          account token. As the token approaches expiration, the kubelet volume
+                                          plugin will proactively rotate the service account token. The kubelet will
+                                          start trying to rotate the token if the token is older than 80 percent of
+                                          its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                          and must be at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the path relative to the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        quobyte:
+                          description: |-
+                            quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                            Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                          properties:
+                            group:
+                              description: |-
+                                group to map volume access to
+                                Default is no group
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                Defaults to false.
+                              type: boolean
+                            registry:
+                              description: |-
+                                registry represents a single or multiple Quobyte Registry services
+                                specified as a string as host:port pair (multiple entries are separated with commas)
+                                which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: |-
+                                tenant owning the given Quobyte volume in the Backend
+                                Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: |-
+                                user to map volume access to
+                                Defaults to serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: |-
+                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                            Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              type: string
+                            image:
+                              description: |-
+                                image is the rados image name.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            keyring:
+                              default: /etc/ceph/keyring
+                              description: |-
+                                keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            monitors:
+                              description: |-
+                                monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            pool:
+                              default: rbd
+                              description: |-
+                                pool is the rados pool name.
+                                Default is rbd.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is name of the authentication secret for RBDUser. If provided
+                                overrides keyring.
+                                Default is nil.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              default: admin
+                              description: |-
+                                user is the rados user name.
+                                Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          description: |-
+                            scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                          properties:
+                            fsType:
+                              default: xfs
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs".
+                                Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef references to the secret for ScaleIO user and other
+                                sensitive information. If this is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              default: ThinProvisioned
+                              description: |-
+                                storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: |-
+                                volumeName is the name of a volume already created in the ScaleIO system
+                                that is associated with this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          description: |-
+                            secret represents a secret that should populate this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values
+                                for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items If unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            optional:
+                              description: optional field specify whether the Secret or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: |-
+                                secretName is the name of the secret in the pod's namespace to use.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              type: string
+                          type: object
+                        storageos:
+                          description: |-
+                            storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef specifies the secret to use for obtaining the StorageOS API
+                                credentials.  If not specified, default values will be attempted.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeName:
+                              description: |-
+                                volumeName is the human-readable name of the StorageOS volume.  Volume
+                                names are only unique within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: |-
+                                volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                namespace is specified then the Pod's namespace will be used.  This allows the
+                                Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                Set VolumeName to any name to override the default behaviour.
+                                Set to "default" if you are not using namespaces within StorageOS.
+                                Namespaces that do not pre-exist within StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: |-
+                            vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                            Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                            are redirected to the csi.vsphere.vmware.com CSI driver.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  podAdditionalMetadata:
+                    description: |-
+                      PodAdditionalMetadata defines the additional labels and annotations that must be attached
+                      to the resulting Pods managed by the Deployment.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    type: object
+                  runtimeClassName:
+                    type: string
+                  serviceAccountName:
+                    type: string
+                  strategy:
+                    description: DeploymentStrategy describes how to replace existing pods with new ones.
+                    properties:
+                      rollingUpdate:
+                        description: |-
+                          Rolling update config params. Present only if DeploymentStrategyType =
+                          RollingUpdate.
+                        properties:
+                          maxSurge:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be scheduled above the desired number of
+                              pods.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              This can not be 0 if MaxUnavailable is 0.
+                              Absolute number is calculated from percentage by rounding up.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                              the rolling update starts, such that the total number of old and new pods do not exceed
+                              130% of desired pods. Once old pods have been killed,
+                              new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                              at any time during the update is at most 130% of desired pods.
+                            x-kubernetes-int-or-string: true
+                          maxUnavailable:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              The maximum number of pods that can be unavailable during the update.
+                              Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                              Absolute number is calculated from percentage by rounding down.
+                              This can not be 0 if MaxSurge is 0.
+                              Defaults to 25%.
+                              Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                              immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                              can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                              that the total number of pods available at all times during the update is at
+                              least 70% of desired pods.
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      type:
+                        description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                        type: string
+                    type: object
+                  tolerations:
+                    items:
+                      description: |-
+                        The pod this Toleration is attached to tolerates any taint that matches
+                        the triple <key,value,effect> using the matching operator <operator>.
+                      properties:
+                        effect:
+                          description: |-
+                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: |-
+                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                          type: string
+                        operator:
+                          description: |-
+                            Operator represents a key's relationship to the value.
+                            Valid operators are Exists and Equal. Defaults to Equal.
+                            Exists is equivalent to wildcard for value, so that a pod can
+                            tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: |-
+                            TolerationSeconds represents the period of time the toleration (which must be
+                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                            negative values will be treated as 0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: |-
+                            Value is the taint value the toleration matches to.
+                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  topologySpreadConstraints:
+                    items:
+                      description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                      properties:
+                        labelSelector:
+                          description: |-
+                            LabelSelector is used to find matching pods.
+                            Pods that match this label selector are counted to determine the number of pods
+                            in their corresponding topology domain.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        matchLabelKeys:
+                          description: |-
+                            MatchLabelKeys is a set of pod label keys to select the pods over which
+                            spreading will be calculated. The keys are used to lookup values from the
+                            incoming pod labels, those key-value labels are ANDed with labelSelector
+                            to select the group of existing pods over which spreading will be calculated
+                            for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                            MatchLabelKeys cannot be set when LabelSelector isn't set.
+                            Keys that don't exist in the incoming pod labels will
+                            be ignored. A null or empty list means only match against labelSelector.
+
+                            This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        maxSkew:
+                          description: |-
+                            MaxSkew describes the degree to which pods may be unevenly distributed.
+                            When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                            between the number of matching pods in the target topology and the global minimum.
+                            The global minimum is the minimum number of matching pods in an eligible domain
+                            or zero if the number of eligible domains is less than MinDomains.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 2/2/1:
+                            In this case, the global minimum is 1.
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |   P   |
+                            - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                            scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                            violate MaxSkew(1).
+                            - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                            When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                            to topologies that satisfy it.
+                            It's a required field. Default value is 1 and 0 is not allowed.
+                          format: int32
+                          type: integer
+                        minDomains:
+                          description: |-
+                            MinDomains indicates a minimum number of eligible domains.
+                            When the number of eligible domains with matching topology keys is less than minDomains,
+                            Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                            And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                            this value has no effect on scheduling.
+                            As a result, when the number of eligible domains is less than minDomains,
+                            scheduler won't schedule more than maxSkew Pods to those domains.
+                            If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                            Valid values are integers greater than 0.
+                            When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                            For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                            labelSelector spread as 2/2/2:
+                            | zone1 | zone2 | zone3 |
+                            |  P P  |  P P  |  P P  |
+                            The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                            In this situation, new pod with the same labelSelector cannot be scheduled,
+                            because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                            it will violate MaxSkew.
+                          format: int32
+                          type: integer
+                        nodeAffinityPolicy:
+                          description: |-
+                            NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                            when calculating pod topology spread skew. Options are:
+                            - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                            - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                            If this value is nil, the behavior is equivalent to the Honor policy.
+                          type: string
+                        nodeTaintsPolicy:
+                          description: |-
+                            NodeTaintsPolicy indicates how we will treat node taints when calculating
+                            pod topology spread skew. Options are:
+                            - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                            has a toleration, are included.
+                            - Ignore: node taints are ignored. All nodes are included.
+
+                            If this value is nil, the behavior is equivalent to the Ignore policy.
+                          type: string
+                        topologyKey:
+                          description: |-
+                            TopologyKey is the key of node labels. Nodes that have a label with this key
+                            and identical values are considered to be in the same topology.
+                            We consider each <key, value> as a "bucket", and try to put balanced number
+                            of pods into each bucket.
+                            We define a domain as a particular instance of a topology.
+                            Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                            nodeAffinityPolicy and nodeTaintsPolicy.
+                            e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                            And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                            It's a required field.
+                          type: string
+                        whenUnsatisfiable:
+                          description: |-
+                            WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                            the spread constraint.
+                            - DoNotSchedule (default) tells the scheduler not to schedule it.
+                            - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                              but giving higher precedence to topologies that would help reduce the
+                              skew.
+                            A constraint is considered "Unsatisfiable" for an incoming pod
+                            if and only if every possible node assignment for that pod would violate
+                            "MaxSkew" on some topology.
+                            For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                            labelSelector spread as 3/1/1:
+                            | zone1 | zone2 | zone3 |
+                            | P P P |   P   |   P   |
+                            If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                            to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                            MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                            won't make it *more* imbalanced.
+                            It's a required field.
+                          type: string
+                      required:
+                      - maxSkew
+                      - topologyKey
+                      - whenUnsatisfiable
+                      type: object
+                    type: array
+                type: object
+              kine:
+                description: |-
+                  KineComponent allows the customization for the kine component of the control plane.
+                  Available only if Kamaji is running using Kine as backing storage.
+                properties:
+                  extraArgs:
+                    items:
+                      type: string
+                    type: array
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              kubelet:
+                default:
+                  cgroupfs: systemd
+                  preferredAddressTypes:
+                  - InternalIP
+                  - ExternalIP
+                  - Hostname
+                description: Configure the Kubelet options, such as the preferred address types, or the expected cgroupfs.
+                properties:
+                  cgroupfs:
+                    description: |-
+                      CGroupFS defines the  cgroup driver for Kubelet
+                      https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/
+                    enum:
+                    - systemd
+                    - cgroupfs
+                    type: string
+                  preferredAddressTypes:
+                    default:
+                    - Hostname
+                    - InternalIP
+                    - ExternalIP
+                    description: |-
+                      Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
+                      Default to Hostname, InternalIP, ExternalIP.
+                    items:
+                      enum:
+                      - Hostname
+                      - InternalIP
+                      - ExternalIP
+                      - InternalDNS
+                      - ExternalDNS
+                      type: string
+                    minItems: 1
+                    type: array
+                type: object
+              network:
+                default:
+                  serviceType: LoadBalancer
+                description: Configure how the TenantControlPlane should be exposed.
+                properties:
+                  certSANs:
+                    description: |-
+                      Configure additional Subject Address Names for the kube-apiserver certificate,
+                      useful if the TenantControlPlane is going to be exposed behind a FQDN with NAT.
+                    items:
+                      type: string
+                    type: array
+                  dnsServiceIPs:
+                    description: |-
+                      DNSServiceIPs contains the DNS Service IPs.
+                      If the CoreDNS addon is specified, its DNSServiceIPs will be used instead.
+                      When set to an empty slice, Kamaji will automatically inflect it from the Service CIDR.
+                    items:
+                      type: string
+                    type: array
+                  ingress:
+                    description: |-
+                      When specified, the KamajiControlPlane will be reachable using an Ingress object
+                      deployed in the management cluster.
+                    properties:
+                      className:
+                        description: Defines the Ingress Class for the Ingress object.
+                        type: string
+                      extraAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Defines the extra annotations for the Ingress object.
+                          Useful if you need to define TLS/SSL passthrough, or other Ingress Controller-specific options.
+                        type: object
+                      extraLabels:
+                        additionalProperties:
+                          type: string
+                        description: Defines the extra labels for the Ingress object.
+                        type: object
+                      hostname:
+                        description: |-
+                          Defines the hostname for the Ingress object.
+                          When using an Ingress object the FQDN is automatically added to the Certificate SANs.
+                        minLength: 1
+                        type: string
+                    required:
+                    - hostname
+                    type: object
+                  loadBalancerConfig:
+                    description: Optional configuration for the LoadBalancer service that exposes the Kamaji control plane.
+                    properties:
+                      loadBalancerClass:
+                        description: |-
+                          Specify the LoadBalancer class in case of multiple load balancer implementations.
+                          Field supported only for Tenant Control Plane instances exposed using a LoadBalancer Service.
+                        minLength: 1
+                        type: string
+                        x-kubernetes-validations:
+                        - message: LoadBalancerClass is immutable
+                          rule: self == oldSelf
+                      loadBalancerSourceRanges:
+                        description: |-
+                          LoadBalancerSourceRanges restricts the IP ranges that can access
+                          the LoadBalancer type Service. This field defines a list of IP
+                          address ranges (in CIDR format) that are allowed to access the service.
+                          If left empty, the service will allow traffic from all IP ranges (0.0.0.0/0).
+                          This feature is useful for restricting access to API servers or services
+                          to specific networks for security purposes.
+                          Example: {"192.168.1.0/24", "10.0.0.0/8"}
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  serviceAddress:
+                    description: |-
+                      This field can be used in case of pre-assigned address, such as a VIP,
+                      helping when serviceType is NodePort.
+                    type: string
+                  serviceAnnotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  serviceLabels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  serviceType:
+                    default: LoadBalancer
+                    description: Service Type string describes ingress methods for a service
+                    enum:
+                    - ClusterIP
+                    - NodePort
+                    - LoadBalancer
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: LoadBalancerSourceRanges are supported only with LoadBalancer service type
+                  rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerSourceRanges) || (size(self.loadBalancerConfig.loadBalancerSourceRanges) == 0 || self.serviceType == ''LoadBalancer'')'
+                - message: LoadBalancerClass is supported only with LoadBalancer service type
+                  rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass) || self.serviceType == ''LoadBalancer'''
+                - message: LoadBalancerClass cannot be set or unset at runtime
+                  rule: self.serviceType != 'LoadBalancer' || (oldSelf.serviceType != 'LoadBalancer' && self.serviceType == 'LoadBalancer') || !has(self.loadBalancerConfig) || has(self.loadBalancerConfig) && has(self.loadBalancerConfig.loadBalancerClass) == has(oldSelf.loadBalancerConfig.loadBalancerClass)
+              registry:
+                description: |-
+                  Override the container registry used to pull the components image.
+                  Helpful if running in an air-gapped environment.
+                type: string
+              replicas:
+                default: 2
+                description: |-
+                  Number of desired replicas for the given TenantControlPlane.
+                  Defaults to 2.
+                format: int32
+                type: integer
+              scheduler:
+                description: ControlPlaneComponent allows the customization for the given component of the control plane.
+                properties:
+                  containerImageName:
+                    description: |-
+                      In combination with the container registry, it can override the component container image.
+                      With no value, the default images will be used.
+                    minLength: 1
+                    type: string
+                  extraArgs:
+                    items:
+                      type: string
+                    type: array
+                  extraVolumeMounts:
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within a container.
+                      properties:
+                        mountPath:
+                          description: |-
+                            Path within the container at which the volume should be mounted.  Must
+                            not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: |-
+                            mountPropagation determines how mounts are propagated from the host
+                            to container and the other way around.
+                            When not set, MountPropagationNone is used.
+                            This field is beta in 1.10.
+                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                            (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: |-
+                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                            Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                            recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                            recursively read-only, if it is supported by the container runtime.  If this
+                            field is set to Enabled, the mount is made recursively read-only if it is
+                            supported by the container runtime, otherwise the pod will not be started and
+                            an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                            None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: |-
+                            Path within the volume from which the container's volume should be mounted.
+                            Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: |-
+                            Expanded path within the volume from which the container's volume should be mounted.
+                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                            Defaults to "" (volume's root).
+                            SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    type: array
+                  resources:
+                    description: ResourceRequirements describes the compute resource requirements.
+                    properties:
+                      claims:
+                        description: |-
+                          Claims lists the names of resources, defined in spec.resourceClaims,
+                          that are used by this container.
+
+                          This is an alpha field and requires enabling the
+                          DynamicResourceAllocation feature gate.
+
+                          This field is immutable. It can only be set for containers.
+                        items:
+                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                          properties:
+                            name:
+                              description: |-
+                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                the Pod where this field is used. It makes that resource available
+                                inside a container.
+                              type: string
+                            request:
+                              description: |-
+                                Request is the name chosen for a request in the referenced claim.
+                                If empty, everything from the claim is made available, otherwise
+                                only the result of this request.
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Limits describes the maximum amount of compute resources allowed.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: |-
+                          Requests describes the minimum amount of compute resources required.
+                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        type: object
+                    type: object
+                type: object
+              version:
+                description: Version defines the desired Kubernetes version.
+                type: string
+            required:
+            - version
+            type: object
+          status:
+            description: KamajiControlPlaneStatus defines the observed state of KamajiControlPlane.
+            properties:
+              conditions:
+                items:
+                  description: Condition contains details for one aspect of the current state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              externalManagedControlPlane:
+                default: true
+                description: |-
+                  ExternalManagedControlPlane indicates to Cluster API that the Control Plane
+                  is externally managed by Kamaji.
+                type: boolean
+              failureMessage:
+                description: The error message, if available, for the failing reconciliation.
+                type: string
+              failureReason:
+                description: Share the failed process of the KamajiControlPlane provider which wasn't able to complete the reconciliation for the given resource.
+                type: string
+              initialized:
+                description: The TenantControlPlane has completed initialization.
+                type: boolean
+              ready:
+                description: The Kamaji Control Plane is ready to link Cluster API with the Tenant Control Plane.
+                type: boolean
+              readyReplicas:
+                description: Total number of fully running and ready control plane instances.
+                format: int32
+                type: integer
+              replicas:
+                description: Total number of non-terminated control plane instances.
+                format: int32
+                type: integer
+              selector:
+                type: string
+              unavailableReplicas:
+                description: |-
+                  Total number of unavailable TenantControlPlane instances targeted by this control plane,
+                  equal to the desired number of control plane instances - ready instances.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: Total number of non-terminated Pods targeted by this control plane that have the desired template spec.
+                format: int32
+                type: integer
+              version:
+                description: String representing the minimum Kubernetes version for the control plane machines in the cluster.
+                type: string
+            required:
+            - externalManagedControlPlane
+            - initialized
+            - ready
+            - readyReplicas
+            - replicas
+            - selector
+            - unavailableReplicas
+            - updatedReplicas
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/docs/shared/crds/cluster_api/hosted_control_plane/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
+++ b/docs/shared/crds/cluster_api/hosted_control_plane/controlplane.cluster.x-k8s.io_kamajicontrolplanetemplates.yaml
@@ -1,0 +1,6600 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.4
+  labels:
+    cluster.x-k8s.io/provider: kamaji
+    cluster.x-k8s.io/v1beta1: v1alpha1
+  name: kamajicontrolplanetemplates.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    - kamaji
+    kind: KamajiControlPlaneTemplate
+    listKind: KamajiControlPlaneTemplateList
+    plural: kamajicontrolplanetemplates
+    shortNames:
+    - ktcpt
+    singular: kamajicontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KamajiControlPlaneTemplate is the Schema for the kamajicontrolplanetemplates API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KamajiControlPlaneTemplateSpec defines the desired state of KamajiControlPlaneTemplate.
+            properties:
+              template:
+                description: KamajiControlPlaneTemplateResource describes the data needed to create a KamajiControlPlane from a template.
+                properties:
+                  metadata:
+                    description: |-
+                      Standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    properties:
+                      addons:
+                        description: The addons that must be managed by Kamaji, such as CoreDNS, kube-proxy, and konnectivity.
+                        properties:
+                          coreDNS:
+                            description: |-
+                              Enables the DNS addon in the Tenant Cluster.
+                              The registry and the tag are configurable, the image is hard-coded to `coredns`.
+                            properties:
+                              dnsServiceIPs:
+                                description: |-
+                                  DNSServiceIPs contains the CoreDNS Service IPs.
+                                  When set to an empty slice, Kamaji will automatically inflect it from the Service CIDR.
+                                items:
+                                  type: string
+                                type: array
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the default ImageRepository will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                          konnectivity:
+                            description: Enables the Konnectivity addon in the Tenant Cluster, required if the worker nodes are in a different network.
+                            properties:
+                              agent:
+                                default:
+                                  image: registry.k8s.io/kas-network-proxy/proxy-agent
+                                  version: v0.28.6
+                                properties:
+                                  extraArgs:
+                                    description: |-
+                                      ExtraArgs allows adding additional arguments to said component.
+                                      WARNING - This option can override existing konnectivity
+                                      parameters and cause konnectivity components to misbehave in
+                                      unxpected ways. Only modify if you know what you are doing.
+                                    items:
+                                      type: string
+                                    type: array
+                                  image:
+                                    default: registry.k8s.io/kas-network-proxy/proxy-agent
+                                    description: AgentImage defines the container image for Konnectivity's agent.
+                                    type: string
+                                  tolerations:
+                                    default:
+                                    - key: CriticalAddonsOnly
+                                      operator: Exists
+                                    description: |-
+                                      Tolerations for the deployed agent.
+                                      Can be customized to start the konnectivity-agent even if the nodes are not ready or tainted.
+                                    items:
+                                      description: |-
+                                        The pod this Toleration is attached to tolerates any taint that matches
+                                        the triple <key,value,effect> using the matching operator <operator>.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Effect indicates the taint effect to match. Empty means match all taint effects.
+                                            When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: |-
+                                            Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                            If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            Operator represents a key's relationship to the value.
+                                            Valid operators are Exists and Equal. Defaults to Equal.
+                                            Exists is equivalent to wildcard for value, so that a pod can
+                                            tolerate all taints of a particular category.
+                                          type: string
+                                        tolerationSeconds:
+                                          description: |-
+                                            TolerationSeconds represents the period of time the toleration (which must be
+                                            of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                            it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                            negative values will be treated as 0 (evict immediately) by the system.
+                                          format: int64
+                                          type: integer
+                                        value:
+                                          description: |-
+                                            Value is the taint value the toleration matches to.
+                                            If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  version:
+                                    default: v0.28.6
+                                    description: Version for Konnectivity agent.
+                                    type: string
+                                type: object
+                              server:
+                                default:
+                                  image: registry.k8s.io/kas-network-proxy/proxy-server
+                                  port: 8132
+                                  version: v0.28.6
+                                properties:
+                                  extraArgs:
+                                    description: |-
+                                      ExtraArgs allows adding additional arguments to said component.
+                                      WARNING - This option can override existing konnectivity
+                                      parameters and cause konnectivity components to misbehave in
+                                      unxpected ways. Only modify if you know what you are doing.
+                                    items:
+                                      type: string
+                                    type: array
+                                  image:
+                                    default: registry.k8s.io/kas-network-proxy/proxy-server
+                                    description: Container image used by the Konnectivity server.
+                                    type: string
+                                  port:
+                                    description: The port which Konnectivity server is listening to.
+                                    format: int32
+                                    type: integer
+                                  resources:
+                                    description: Resources define the amount of CPU and memory to allocate to the Konnectivity server.
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                            request:
+                                              description: |-
+                                                Request is the name chosen for a request in the referenced claim.
+                                                If empty, everything from the claim is made available, otherwise
+                                                only the result of this request.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                  version:
+                                    default: v0.28.6
+                                    description: Container image version of the Konnectivity server.
+                                    type: string
+                                required:
+                                - port
+                                type: object
+                            type: object
+                          kubeProxy:
+                            description: |-
+                              Enables the kube-proxy addon in the Tenant Cluster.
+                              The registry and the tag are configurable, the image is hard-coded to `kube-proxy`.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  ImageRepository sets the container registry to pull images from.
+                                  if not set, the default ImageRepository will be used instead.
+                                type: string
+                              imageTag:
+                                description: |-
+                                  ImageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                type: string
+                            type: object
+                        type: object
+                      admissionControllers:
+                        description: |-
+                          List of the admission controllers to configure for the TenantControlPlane kube-apiserver.
+                          By default, no admission controllers are enabled, refer to the desired Kubernetes version.
+
+                          More info: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/
+                        items:
+                          enum:
+                          - AlwaysAdmit
+                          - AlwaysDeny
+                          - AlwaysPullImages
+                          - CertificateApproval
+                          - CertificateSigning
+                          - CertificateSubjectRestriction
+                          - DefaultIngressClass
+                          - DefaultStorageClass
+                          - DefaultTolerationSeconds
+                          - DenyEscalatingExec
+                          - DenyExecOnPrivileged
+                          - DenyServiceExternalIPs
+                          - EventRateLimit
+                          - ExtendedResourceToleration
+                          - ImagePolicyWebhook
+                          - LimitPodHardAntiAffinityTopology
+                          - LimitRanger
+                          - MutatingAdmissionWebhook
+                          - NamespaceAutoProvision
+                          - NamespaceExists
+                          - NamespaceLifecycle
+                          - NodeRestriction
+                          - OwnerReferencesPermissionEnforcement
+                          - PersistentVolumeClaimResize
+                          - PersistentVolumeLabel
+                          - PodNodeSelector
+                          - PodSecurity
+                          - PodSecurityPolicy
+                          - PodTolerationRestriction
+                          - Priority
+                          - ResourceQuota
+                          - RuntimeClass
+                          - SecurityContextDeny
+                          - ServiceAccount
+                          - StorageObjectInUseProtection
+                          - TaintNodesByCondition
+                          - ValidatingAdmissionWebhook
+                          type: string
+                        type: array
+                      apiServer:
+                        description: ControlPlaneComponent allows the customization for the given component of the control plane.
+                        properties:
+                          containerImageName:
+                            description: |-
+                              In combination with the container registry, it can override the component container image.
+                              With no value, the default images will be used.
+                            minLength: 1
+                            type: string
+                          extraArgs:
+                            items:
+                              type: string
+                            type: array
+                          extraVolumeMounts:
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                      controllerManager:
+                        description: ControlPlaneComponent allows the customization for the given component of the control plane.
+                        properties:
+                          containerImageName:
+                            description: |-
+                              In combination with the container registry, it can override the component container image.
+                              With no value, the default images will be used.
+                            minLength: 1
+                            type: string
+                          extraArgs:
+                            items:
+                              type: string
+                            type: array
+                          extraVolumeMounts:
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                      dataStoreName:
+                        description: |-
+                          The Kamaji DataStore to use for the given TenantControlPlane.
+                          Retrieve the list of the allowed ones by issuing "kubectl get datastores.kamaji.clastix.io".
+                        type: string
+                      dataStoreSchema:
+                        description: DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd)
+                        type: string
+                      deployment:
+                        description: Configure how the TenantControlPlane Deployment object should be configured.
+                        properties:
+                          additionalMetadata:
+                            description: |-
+                              AdditionalMetadata refers to the additional labels and annotations attached
+                              to the resulting Deployment managed by Kamaji.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          affinity:
+                            description: Affinity is a group of affinity scheduling rules.
+                            properties:
+                              nodeAffinity:
+                                description: Describes node affinity scheduling rules for the pod.
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                      node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: |-
+                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                      properties:
+                                        preference:
+                                          description: A node selector term, associated with the corresponding weight.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector requirements by node's labels.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              description: A list of node selector requirements by node's fields.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        weight:
+                                          description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - preference
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      If the affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to an update), the system
+                                      may or may not try to eventually evict the pod from its node.
+                                    properties:
+                                      nodeSelectorTerms:
+                                        description: Required. A list of node selector terms. The terms are ORed.
+                                        items:
+                                          description: |-
+                                            A null or empty node selector term matches no objects. The requirements of
+                                            them are ANDed.
+                                            The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                          properties:
+                                            matchExpressions:
+                                              description: A list of node selector requirements by node's labels.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchFields:
+                                              description: A list of node selector requirements by node's fields.
+                                              items:
+                                                description: |-
+                                                  A node selector requirement is a selector that contains values, a key, and an operator
+                                                  that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: The label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      Represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      An array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. If the operator is Gt or Lt, the values
+                                                      array must have a single element, which will be interpreted as an integer.
+                                                      This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - nodeSelectorTerms
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                type: object
+                              podAffinity:
+                                description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                      node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          description: |-
+                                            weight associated with matching the corresponding podAffinityTerm,
+                                            in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      If the affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to a pod label update), the
+                                      system may or may not try to eventually evict the pod from its node.
+                                      When there are multiple elements, the lists of nodes corresponding to each
+                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: |-
+                                        Defines a set of pods (namely those matching the labelSelector
+                                        relative to the given namespace(s)) that this pod should be
+                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                        where co-located is defined as running on a node whose value of
+                                        the label with key <topologyKey> matches that of any node on which
+                                        a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              podAntiAffinity:
+                                description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                properties:
+                                  preferredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      The scheduler will prefer to schedule pods to nodes that satisfy
+                                      the anti-affinity expressions specified by this field, but it may choose
+                                      a node that violates one or more of the expressions. The node that is
+                                      most preferred is the one with the greatest sum of weights, i.e.
+                                      for each node that meets all of the scheduling requirements (resource
+                                      request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                      compute a sum by iterating through the elements of this field and adding
+                                      "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                      node(s) with the highest sum are the most preferred.
+                                    items:
+                                      description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                      properties:
+                                        podAffinityTerm:
+                                          description: Required. A pod affinity term, associated with the corresponding weight.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                A label query over a set of resources, in this case pods.
+                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            matchLabelKeys:
+                                              description: |-
+                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            mismatchLabelKeys:
+                                              description: |-
+                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                be taken into consideration. The keys are used to lookup values from the
+                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                to select the group of existing pods which pods will be taken into consideration
+                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                pod labels will be ignored. The default value is empty.
+                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            namespaceSelector:
+                                              description: |-
+                                                A label query over the set of namespaces that the term applies to.
+                                                The term is applied to the union of the namespaces selected by this field
+                                                and the ones listed in the namespaces field.
+                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                An empty selector ({}) matches all namespaces.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            namespaces:
+                                              description: |-
+                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                The term is applied to the union of the namespaces listed in this field
+                                                and the ones selected by namespaceSelector.
+                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            topologyKey:
+                                              description: |-
+                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                selected pods is running.
+                                                Empty topologyKey is not allowed.
+                                              type: string
+                                          required:
+                                          - topologyKey
+                                          type: object
+                                        weight:
+                                          description: |-
+                                            weight associated with matching the corresponding podAffinityTerm,
+                                            in the range 1-100.
+                                          format: int32
+                                          type: integer
+                                      required:
+                                      - podAffinityTerm
+                                      - weight
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  requiredDuringSchedulingIgnoredDuringExecution:
+                                    description: |-
+                                      If the anti-affinity requirements specified by this field are not met at
+                                      scheduling time, the pod will not be scheduled onto the node.
+                                      If the anti-affinity requirements specified by this field cease to be met
+                                      at some point during pod execution (e.g. due to a pod label update), the
+                                      system may or may not try to eventually evict the pod from its node.
+                                      When there are multiple elements, the lists of nodes corresponding to each
+                                      podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                    items:
+                                      description: |-
+                                        Defines a set of pods (namely those matching the labelSelector
+                                        relative to the given namespace(s)) that this pod should be
+                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                        where co-located is defined as running on a node whose value of
+                                        the label with key <topologyKey> matches that of any node on which
+                                        a pod of the set of pods is running
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                            Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                            Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                            type: object
+                          externalClusterReference:
+                            description: |-
+                              ExternalClusterReference allows defining the target Cluster where the Tenant Control Plane components must be deployed.
+                              When this value is nil, the Cluster API management cluster will be used as a target.
+                              The ExternalClusterReference feature gate must be enabled with one of the available flags.
+                            properties:
+                              deploymentNamespace:
+                                description: The Namespace where the resulting TenantControlPlane must be deployed to.
+                                type: string
+                              kubeconfigSecretKey:
+                                description: The key used to extract the kubeconfig from the specified Secret.
+                                minLength: 1
+                                type: string
+                              kubeconfigSecretName:
+                                description: |-
+                                  The Secret object containing the kubeconfig used to interact with the remote cluster that will host
+                                  the Tenant Control Plane resources generated by the Control Plane Provider.
+                                minLength: 1
+                                type: string
+                              kubeconfigSecretNamespace:
+                                description: |-
+                                  When ExternalClusterReferenceCrossNamespace is enabled allows specifying a different Namespace where the kubeconfig can be retrieved.
+                                  With ExternalClusterReference this value can be left empty since the KamajiControlPlane object Namespace will be used.
+                                type: string
+                            required:
+                            - deploymentNamespace
+                            - kubeconfigSecretKey
+                            - kubeconfigSecretName
+                            type: object
+                          extraContainers:
+                            items:
+                              description: A single application container that you want to run within a pod.
+                              properties:
+                                args:
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The container image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The container image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvVar represents an environment variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                    will be reported as an event when the container is starting. When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                    properties:
+                                      configMapRef:
+                                        description: The ConfigMap to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                        type: string
+                                      secretRef:
+                                        description: The Secret to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                  type: string
+                                lifecycle:
+                                  description: |-
+                                    Actions that the management system should take in response to container lifecycle events.
+                                    Cannot be updated.
+                                  properties:
+                                    postStart:
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              items:
+                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              items:
+                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  description: |-
+                                    Periodic probe of container liveness.
+                                    Container will be restarted if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the container specified as a DNS_LABEL.
+                                    Each container in a pod must have a unique name (DNS_LABEL).
+                                    Cannot be updated.
+                                  type: string
+                                ports:
+                                  description: |-
+                                    List of ports to expose from the container. Not specifying a port here
+                                    DOES NOT prevent that port from being exposed. Any port which is
+                                    listening on the default "0.0.0.0" address inside a container will be
+                                    accessible from the network.
+                                    Modifying this array with strategic merge patch may corrupt the data.
+                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                    Cannot be updated.
+                                  items:
+                                    description: ContainerPort represents a network port in a single container.
+                                    properties:
+                                      containerPort:
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        description: What host IP to bind the external port to.
+                                        type: string
+                                      hostPort:
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
+                                          Most containers do not need this.
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  description: |-
+                                    Periodic probe of container service readiness.
+                                    Container will be removed from service endpoints if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  description: Resources resize policy for the container.
+                                  items:
+                                    description: ContainerResizePolicy represents resource resize policy for the container.
+                                    properties:
+                                      resourceName:
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
+                                        type: string
+                                      restartPolicy:
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  description: |-
+                                    Compute Resources required by this container.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This is an alpha field and requires enabling the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  description: |-
+                                    RestartPolicy defines the restart behavior of individual containers in a pod.
+                                    This field may only be set for init containers, and the only allowed value is "Always".
+                                    For non-init containers or when this field is not specified,
+                                    the restart behavior is defined by the Pod's restart policy and the container type.
+                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                    this init container will be continually restarted on
+                                    exit until all regular containers have terminated. Once all regular
+                                    containers have completed, all init containers with restartPolicy "Always"
+                                    will be shut down. This lifecycle differs from normal init containers and
+                                    is often referred to as a "sidecar" container. Although this init
+                                    container still starts in the init container sequence, it does not wait
+                                    for the container to complete before proceeding to the next init
+                                    container. Instead, the next init container starts immediately after this
+                                    init container is started, or after any startupProbe has successfully
+                                    completed.
+                                  type: string
+                                securityContext:
+                                  description: |-
+                                    SecurityContext defines the security options the container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  description: |-
+                                    StartupProbe indicates that the Pod has successfully initialized.
+                                    If specified, no other probes are executed until this completes successfully.
+                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                    This cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
+                                  type: boolean
+                                stdinOnce:
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
+                                  type: boolean
+                                terminationMessagePath:
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
+                                  type: string
+                                terminationMessagePolicy:
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
+                                  type: string
+                                tty:
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
+                                  type: boolean
+                                volumeDevices:
+                                  description: volumeDevices is the list of block devices to be used by the container.
+                                  items:
+                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                    properties:
+                                      devicePath:
+                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                        type: string
+                                      name:
+                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem.
+                                    Cannot be updated.
+                                  items:
+                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                    properties:
+                                      mountPath:
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
+                                          not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
+                                          When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                          (which defaults to None).
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a Volume.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        description: |-
+                                          RecursiveReadOnly specifies whether read-only mounts should be handled
+                                          recursively.
+
+                                          If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                          If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                          recursively read-only.  If this field is set to IfPossible, the mount is made
+                                          recursively read-only, if it is supported by the container runtime.  If this
+                                          field is set to Enabled, the mount is made recursively read-only if it is
+                                          supported by the container runtime, otherwise the pod will not be started and
+                                          an error will be generated to indicate the reason.
+
+                                          If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                          None (or be unspecified, which defaults to None).
+
+                                          If this field is not specified, it is treated as an equivalent of Disabled.
+                                        type: string
+                                      subPath:
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
+                                          Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraInitContainers:
+                            items:
+                              description: A single application container that you want to run within a pod.
+                              properties:
+                                args:
+                                  description: |-
+                                    Arguments to the entrypoint.
+                                    The container image's CMD is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                command:
+                                  description: |-
+                                    Entrypoint array. Not executed within a shell.
+                                    The container image's ENTRYPOINT is used if this is not provided.
+                                    Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                    cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                    produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Cannot be updated.
+                                    More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                env:
+                                  description: |-
+                                    List of environment variables to set in the container.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvVar represents an environment variable present in a Container.
+                                    properties:
+                                      name:
+                                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                        type: string
+                                      value:
+                                        description: |-
+                                          Variable references $(VAR_NAME) are expanded
+                                          using the previously defined environment variables in the container and
+                                          any service environment variables. If a variable cannot be resolved,
+                                          the reference in the input string will be unchanged. Double $$ are reduced
+                                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                          Escaped references will never be expanded, regardless of whether the variable
+                                          exists or not.
+                                          Defaults to "".
+                                        type: string
+                                      valueFrom:
+                                        description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                        properties:
+                                          configMapKeyRef:
+                                            description: Selects a key of a ConfigMap.
+                                            properties:
+                                              key:
+                                                description: The key to select.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the ConfigMap or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          fieldRef:
+                                            description: |-
+                                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          secretKeyRef:
+                                            description: Selects a key of a secret in the pod's namespace
+                                            properties:
+                                              key:
+                                                description: The key of the secret to select from.  Must be a valid secret key.
+                                                type: string
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: Specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            required:
+                                            - key
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        type: object
+                                    required:
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - name
+                                  x-kubernetes-list-type: map
+                                envFrom:
+                                  description: |-
+                                    List of sources to populate environment variables in the container.
+                                    The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                    will be reported as an event when the container is starting. When a key exists in multiple
+                                    sources, the value associated with the last source will take precedence.
+                                    Values defined by an Env with a duplicate key will take precedence.
+                                    Cannot be updated.
+                                  items:
+                                    description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                    properties:
+                                      configMapRef:
+                                        description: The ConfigMap to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      prefix:
+                                        description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                        type: string
+                                      secretRef:
+                                        description: The Secret to select from
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                image:
+                                  description: |-
+                                    Container image name.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images
+                                    This field is optional to allow higher level config management to default or override
+                                    container images in workload controllers like Deployments and StatefulSets.
+                                  type: string
+                                imagePullPolicy:
+                                  description: |-
+                                    Image pull policy.
+                                    One of Always, Never, IfNotPresent.
+                                    Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                  type: string
+                                lifecycle:
+                                  description: |-
+                                    Actions that the management system should take in response to container lifecycle events.
+                                    Cannot be updated.
+                                  properties:
+                                    postStart:
+                                      description: |-
+                                        PostStart is called immediately after a container is created. If the handler fails,
+                                        the container is terminated and restarted according to its restart policy.
+                                        Other management of the container blocks until the hook completes.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              items:
+                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    preStop:
+                                      description: |-
+                                        PreStop is called immediately before a container is terminated due to an
+                                        API request or management event such as liveness/startup probe failure,
+                                        preemption, resource contention, etc. The handler is not called if the
+                                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                                        container will eventually terminate within the Pod's termination grace
+                                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                        or until the termination grace period is reached.
+                                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                      properties:
+                                        exec:
+                                          description: Exec specifies a command to execute in the container.
+                                          properties:
+                                            command:
+                                              description: |-
+                                                Command is the command line to execute inside the container, the working directory for the
+                                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                a shell, you need to explicitly call out to that shell.
+                                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        httpGet:
+                                          description: HTTPGet specifies an HTTP GET request to perform.
+                                          properties:
+                                            host:
+                                              description: |-
+                                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                                "Host" in httpHeaders instead.
+                                              type: string
+                                            httpHeaders:
+                                              description: Custom headers to set in the request. HTTP allows repeated headers.
+                                              items:
+                                                description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      The header field name.
+                                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                    type: string
+                                                  value:
+                                                    description: The header field value
+                                                    type: string
+                                                required:
+                                                - name
+                                                - value
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            path:
+                                              description: Path to access on the HTTP server.
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Name or number of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                            scheme:
+                                              description: |-
+                                                Scheme to use for connecting to the host.
+                                                Defaults to HTTP.
+                                              type: string
+                                          required:
+                                          - port
+                                          type: object
+                                        sleep:
+                                          description: Sleep represents a duration that the container should sleep.
+                                          properties:
+                                            seconds:
+                                              description: Seconds is the number of seconds to sleep.
+                                              format: int64
+                                              type: integer
+                                          required:
+                                          - seconds
+                                          type: object
+                                        tcpSocket:
+                                          description: |-
+                                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                            for backward compatibility. There is no validation of this field and
+                                            lifecycle hooks will fail at runtime when it is specified.
+                                          properties:
+                                            host:
+                                              description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                              type: string
+                                            port:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: |-
+                                                Number or name of the port to access on the container.
+                                                Number must be in the range 1 to 65535.
+                                                Name must be an IANA_SVC_NAME.
+                                              x-kubernetes-int-or-string: true
+                                          required:
+                                          - port
+                                          type: object
+                                      type: object
+                                    stopSignal:
+                                      description: |-
+                                        StopSignal defines which signal will be sent to a container when it is being stopped.
+                                        If not specified, the default is defined by the container runtime in use.
+                                        StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                      type: string
+                                  type: object
+                                livenessProbe:
+                                  description: |-
+                                    Periodic probe of container liveness.
+                                    Container will be restarted if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                name:
+                                  description: |-
+                                    Name of the container specified as a DNS_LABEL.
+                                    Each container in a pod must have a unique name (DNS_LABEL).
+                                    Cannot be updated.
+                                  type: string
+                                ports:
+                                  description: |-
+                                    List of ports to expose from the container. Not specifying a port here
+                                    DOES NOT prevent that port from being exposed. Any port which is
+                                    listening on the default "0.0.0.0" address inside a container will be
+                                    accessible from the network.
+                                    Modifying this array with strategic merge patch may corrupt the data.
+                                    For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                    Cannot be updated.
+                                  items:
+                                    description: ContainerPort represents a network port in a single container.
+                                    properties:
+                                      containerPort:
+                                        description: |-
+                                          Number of port to expose on the pod's IP address.
+                                          This must be a valid port number, 0 < x < 65536.
+                                        format: int32
+                                        type: integer
+                                      hostIP:
+                                        description: What host IP to bind the external port to.
+                                        type: string
+                                      hostPort:
+                                        description: |-
+                                          Number of port to expose on the host.
+                                          If specified, this must be a valid port number, 0 < x < 65536.
+                                          If HostNetwork is specified, this must match ContainerPort.
+                                          Most containers do not need this.
+                                        format: int32
+                                        type: integer
+                                      name:
+                                        description: |-
+                                          If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                          named port in a pod must have a unique name. Name for the port that can be
+                                          referred to by services.
+                                        type: string
+                                      protocol:
+                                        default: TCP
+                                        description: |-
+                                          Protocol for port. Must be UDP, TCP, or SCTP.
+                                          Defaults to "TCP".
+                                        type: string
+                                    required:
+                                    - containerPort
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                  x-kubernetes-list-type: map
+                                readinessProbe:
+                                  description: |-
+                                    Periodic probe of container service readiness.
+                                    Container will be removed from service endpoints if the probe fails.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                resizePolicy:
+                                  description: Resources resize policy for the container.
+                                  items:
+                                    description: ContainerResizePolicy represents resource resize policy for the container.
+                                    properties:
+                                      resourceName:
+                                        description: |-
+                                          Name of the resource to which this resource resize policy applies.
+                                          Supported values: cpu, memory.
+                                        type: string
+                                      restartPolicy:
+                                        description: |-
+                                          Restart policy to apply when specified resource is resized.
+                                          If not specified, it defaults to NotRequired.
+                                        type: string
+                                    required:
+                                    - resourceName
+                                    - restartPolicy
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                resources:
+                                  description: |-
+                                    Compute Resources required by this container.
+                                    Cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  properties:
+                                    claims:
+                                      description: |-
+                                        Claims lists the names of resources, defined in spec.resourceClaims,
+                                        that are used by this container.
+
+                                        This is an alpha field and requires enabling the
+                                        DynamicResourceAllocation feature gate.
+
+                                        This field is immutable. It can only be set for containers.
+                                      items:
+                                        description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name must match the name of one entry in pod.spec.resourceClaims of
+                                              the Pod where this field is used. It makes that resource available
+                                              inside a container.
+                                            type: string
+                                          request:
+                                            description: |-
+                                              Request is the name chosen for a request in the referenced claim.
+                                              If empty, everything from the claim is made available, otherwise
+                                              only the result of this request.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Limits describes the maximum amount of compute resources allowed.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Requests describes the minimum amount of compute resources required.
+                                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                      type: object
+                                  type: object
+                                restartPolicy:
+                                  description: |-
+                                    RestartPolicy defines the restart behavior of individual containers in a pod.
+                                    This field may only be set for init containers, and the only allowed value is "Always".
+                                    For non-init containers or when this field is not specified,
+                                    the restart behavior is defined by the Pod's restart policy and the container type.
+                                    Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                    this init container will be continually restarted on
+                                    exit until all regular containers have terminated. Once all regular
+                                    containers have completed, all init containers with restartPolicy "Always"
+                                    will be shut down. This lifecycle differs from normal init containers and
+                                    is often referred to as a "sidecar" container. Although this init
+                                    container still starts in the init container sequence, it does not wait
+                                    for the container to complete before proceeding to the next init
+                                    container. Instead, the next init container starts immediately after this
+                                    init container is started, or after any startupProbe has successfully
+                                    completed.
+                                  type: string
+                                securityContext:
+                                  description: |-
+                                    SecurityContext defines the security options the container should be run with.
+                                    If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                  properties:
+                                    allowPrivilegeEscalation:
+                                      description: |-
+                                        AllowPrivilegeEscalation controls whether a process can gain more
+                                        privileges than its parent process. This bool directly controls if
+                                        the no_new_privs flag will be set on the container process.
+                                        AllowPrivilegeEscalation is true always when the container is:
+                                        1) run as Privileged
+                                        2) has CAP_SYS_ADMIN
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    appArmorProfile:
+                                      description: |-
+                                        appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                        overrides the pod's appArmorProfile.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must match the loaded name of the profile.
+                                            Must be set if and only if type is "Localhost".
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of AppArmor profile will be applied.
+                                            Valid options are:
+                                              Localhost - a profile pre-loaded on the node.
+                                              RuntimeDefault - the container runtime's default profile.
+                                              Unconfined - no AppArmor enforcement.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    capabilities:
+                                      description: |-
+                                        The capabilities to add/drop when running containers.
+                                        Defaults to the default set of capabilities granted by the container runtime.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        add:
+                                          description: Added capabilities
+                                          items:
+                                            description: Capability represent POSIX capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        drop:
+                                          description: Removed capabilities
+                                          items:
+                                            description: Capability represent POSIX capabilities type
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    privileged:
+                                      description: |-
+                                        Run container in privileged mode.
+                                        Processes in privileged containers are essentially equivalent to root on the host.
+                                        Defaults to false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    procMount:
+                                      description: |-
+                                        procMount denotes the type of proc mount to use for the containers.
+                                        The default value is Default which uses the container runtime defaults for
+                                        readonly paths and masked paths.
+                                        This requires the ProcMountType feature flag to be enabled.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: string
+                                    readOnlyRootFilesystem:
+                                      description: |-
+                                        Whether this container has a read-only root filesystem.
+                                        Default is false.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      type: boolean
+                                    runAsGroup:
+                                      description: |-
+                                        The GID to run the entrypoint of the container process.
+                                        Uses runtime default if unset.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    runAsNonRoot:
+                                      description: |-
+                                        Indicates that the container must run as a non-root user.
+                                        If true, the Kubelet will validate the image at runtime to ensure that it
+                                        does not run as UID 0 (root) and fail to start the container if it does.
+                                        If unset or false, no such validation will be performed.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: boolean
+                                    runAsUser:
+                                      description: |-
+                                        The UID to run the entrypoint of the container process.
+                                        Defaults to user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      format: int64
+                                      type: integer
+                                    seLinuxOptions:
+                                      description: |-
+                                        The SELinux context to be applied to the container.
+                                        If unspecified, the container runtime will allocate a random SELinux context for each
+                                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        level:
+                                          description: Level is SELinux level label that applies to the container.
+                                          type: string
+                                        role:
+                                          description: Role is a SELinux role label that applies to the container.
+                                          type: string
+                                        type:
+                                          description: Type is a SELinux type label that applies to the container.
+                                          type: string
+                                        user:
+                                          description: User is a SELinux user label that applies to the container.
+                                          type: string
+                                      type: object
+                                    seccompProfile:
+                                      description: |-
+                                        The seccomp options to use by this container. If seccomp options are
+                                        provided at both the pod & container level, the container options
+                                        override the pod options.
+                                        Note that this field cannot be set when spec.os.name is windows.
+                                      properties:
+                                        localhostProfile:
+                                          description: |-
+                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                            The profile must be preconfigured on the node to work.
+                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                          type: string
+                                        type:
+                                          description: |-
+                                            type indicates which kind of seccomp profile will be applied.
+                                            Valid options are:
+
+                                            Localhost - a profile defined in a file on the node should be used.
+                                            RuntimeDefault - the container runtime default profile should be used.
+                                            Unconfined - no profile should be applied.
+                                          type: string
+                                      required:
+                                      - type
+                                      type: object
+                                    windowsOptions:
+                                      description: |-
+                                        The Windows specific settings applied to all containers.
+                                        If unspecified, the options from the PodSecurityContext will be used.
+                                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        Note that this field cannot be set when spec.os.name is linux.
+                                      properties:
+                                        gmsaCredentialSpec:
+                                          description: |-
+                                            GMSACredentialSpec is where the GMSA admission webhook
+                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                          type: string
+                                        gmsaCredentialSpecName:
+                                          description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                          type: string
+                                        hostProcess:
+                                          description: |-
+                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                            All of a Pod's containers must have the same effective HostProcess value
+                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                          type: boolean
+                                        runAsUserName:
+                                          description: |-
+                                            The UserName in Windows to run the entrypoint of the container process.
+                                            Defaults to the user specified in image metadata if unspecified.
+                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: string
+                                      type: object
+                                  type: object
+                                startupProbe:
+                                  description: |-
+                                    StartupProbe indicates that the Pod has successfully initialized.
+                                    If specified, no other probes are executed until this completes successfully.
+                                    If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                    This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                    when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                    This cannot be updated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                  properties:
+                                    exec:
+                                      description: Exec specifies a command to execute in the container.
+                                      properties:
+                                        command:
+                                          description: |-
+                                            Command is the command line to execute inside the container, the working directory for the
+                                            command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                            not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                            a shell, you need to explicitly call out to that shell.
+                                            Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      type: object
+                                    failureThreshold:
+                                      description: |-
+                                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                        Defaults to 3. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    grpc:
+                                      description: GRPC specifies a GRPC HealthCheckRequest.
+                                      properties:
+                                        port:
+                                          description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                          format: int32
+                                          type: integer
+                                        service:
+                                          default: ""
+                                          description: |-
+                                            Service is the name of the service to place in the gRPC HealthCheckRequest
+                                            (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                            If this is not specified, the default behavior is defined by gRPC.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    httpGet:
+                                      description: HTTPGet specifies an HTTP GET request to perform.
+                                      properties:
+                                        host:
+                                          description: |-
+                                            Host name to connect to, defaults to the pod IP. You probably want to set
+                                            "Host" in httpHeaders instead.
+                                          type: string
+                                        httpHeaders:
+                                          description: Custom headers to set in the request. HTTP allows repeated headers.
+                                          items:
+                                            description: HTTPHeader describes a custom header to be used in HTTP probes
+                                            properties:
+                                              name:
+                                                description: |-
+                                                  The header field name.
+                                                  This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                type: string
+                                              value:
+                                                description: The header field value
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        path:
+                                          description: Path to access on the HTTP server.
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Name or number of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                        scheme:
+                                          description: |-
+                                            Scheme to use for connecting to the host.
+                                            Defaults to HTTP.
+                                          type: string
+                                      required:
+                                      - port
+                                      type: object
+                                    initialDelaySeconds:
+                                      description: |-
+                                        Number of seconds after the container has started before liveness probes are initiated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                    periodSeconds:
+                                      description: |-
+                                        How often (in seconds) to perform the probe.
+                                        Default to 10 seconds. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    successThreshold:
+                                      description: |-
+                                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                      format: int32
+                                      type: integer
+                                    tcpSocket:
+                                      description: TCPSocket specifies a connection to a TCP port.
+                                      properties:
+                                        host:
+                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                          type: string
+                                        port:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: |-
+                                            Number or name of the port to access on the container.
+                                            Number must be in the range 1 to 65535.
+                                            Name must be an IANA_SVC_NAME.
+                                          x-kubernetes-int-or-string: true
+                                      required:
+                                      - port
+                                      type: object
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                        value overrides the value provided by the pod spec.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                      format: int64
+                                      type: integer
+                                    timeoutSeconds:
+                                      description: |-
+                                        Number of seconds after which the probe times out.
+                                        Defaults to 1 second. Minimum value is 1.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                      format: int32
+                                      type: integer
+                                  type: object
+                                stdin:
+                                  description: |-
+                                    Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                    is not set, reads from stdin in the container will always result in EOF.
+                                    Default is false.
+                                  type: boolean
+                                stdinOnce:
+                                  description: |-
+                                    Whether the container runtime should close the stdin channel after it has been opened by
+                                    a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                    sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                    first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                    at which time stdin is closed and remains closed until the container is restarted. If this
+                                    flag is false, a container processes that reads from stdin will never receive an EOF.
+                                    Default is false
+                                  type: boolean
+                                terminationMessagePath:
+                                  description: |-
+                                    Optional: Path at which the file to which the container's termination message
+                                    will be written is mounted into the container's filesystem.
+                                    Message written is intended to be brief final status, such as an assertion failure message.
+                                    Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                    all containers will be limited to 12kb.
+                                    Defaults to /dev/termination-log.
+                                    Cannot be updated.
+                                  type: string
+                                terminationMessagePolicy:
+                                  description: |-
+                                    Indicate how the termination message should be populated. File will use the contents of
+                                    terminationMessagePath to populate the container status message on both success and failure.
+                                    FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                    message file is empty and the container exited with an error.
+                                    The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                    Defaults to File.
+                                    Cannot be updated.
+                                  type: string
+                                tty:
+                                  description: |-
+                                    Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                    Default is false.
+                                  type: boolean
+                                volumeDevices:
+                                  description: volumeDevices is the list of block devices to be used by the container.
+                                  items:
+                                    description: volumeDevice describes a mapping of a raw block device within a container.
+                                    properties:
+                                      devicePath:
+                                        description: devicePath is the path inside of the container that the device will be mapped to.
+                                        type: string
+                                      name:
+                                        description: name must match the name of a persistentVolumeClaim in the pod
+                                        type: string
+                                    required:
+                                    - devicePath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - devicePath
+                                  x-kubernetes-list-type: map
+                                volumeMounts:
+                                  description: |-
+                                    Pod volumes to mount into the container's filesystem.
+                                    Cannot be updated.
+                                  items:
+                                    description: VolumeMount describes a mounting of a Volume within a container.
+                                    properties:
+                                      mountPath:
+                                        description: |-
+                                          Path within the container at which the volume should be mounted.  Must
+                                          not contain ':'.
+                                        type: string
+                                      mountPropagation:
+                                        description: |-
+                                          mountPropagation determines how mounts are propagated from the host
+                                          to container and the other way around.
+                                          When not set, MountPropagationNone is used.
+                                          This field is beta in 1.10.
+                                          When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                          (which defaults to None).
+                                        type: string
+                                      name:
+                                        description: This must match the Name of a Volume.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                                          Defaults to false.
+                                        type: boolean
+                                      recursiveReadOnly:
+                                        description: |-
+                                          RecursiveReadOnly specifies whether read-only mounts should be handled
+                                          recursively.
+
+                                          If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                          If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                          recursively read-only.  If this field is set to IfPossible, the mount is made
+                                          recursively read-only, if it is supported by the container runtime.  If this
+                                          field is set to Enabled, the mount is made recursively read-only if it is
+                                          supported by the container runtime, otherwise the pod will not be started and
+                                          an error will be generated to indicate the reason.
+
+                                          If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                          None (or be unspecified, which defaults to None).
+
+                                          If this field is not specified, it is treated as an equivalent of Disabled.
+                                        type: string
+                                      subPath:
+                                        description: |-
+                                          Path within the volume from which the container's volume should be mounted.
+                                          Defaults to "" (volume's root).
+                                        type: string
+                                      subPathExpr:
+                                        description: |-
+                                          Expanded path within the volume from which the container's volume should be mounted.
+                                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                          Defaults to "" (volume's root).
+                                          SubPathExpr and SubPath are mutually exclusive.
+                                        type: string
+                                    required:
+                                    - mountPath
+                                    - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                  - mountPath
+                                  x-kubernetes-list-type: map
+                                workingDir:
+                                  description: |-
+                                    Container's working directory.
+                                    If not specified, the container runtime's default will be used, which
+                                    might be configured in the container image.
+                                    Cannot be updated.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          extraVolumes:
+                            items:
+                              description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                              properties:
+                                awsElasticBlockStore:
+                                  description: |-
+                                    awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                    awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      type: string
+                                    partition:
+                                      description: |-
+                                        partition is the partition in the volume that you want to mount.
+                                        If omitted, the default is to mount by volume name.
+                                        Examples: For volume /dev/sda1, you specify the partition as "1".
+                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: |-
+                                        readOnly value true will force the readOnly setting in VolumeMounts.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      type: boolean
+                                    volumeID:
+                                      description: |-
+                                        volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                azureDisk:
+                                  description: |-
+                                    azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                    Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                    are redirected to the disk.csi.azure.com CSI driver.
+                                  properties:
+                                    cachingMode:
+                                      description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                      type: string
+                                    diskName:
+                                      description: diskName is the Name of the data disk in the blob storage
+                                      type: string
+                                    diskURI:
+                                      description: diskURI is the URI of data disk in the blob storage
+                                      type: string
+                                    fsType:
+                                      default: ext4
+                                      description: |-
+                                        fsType is Filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    kind:
+                                      description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                      type: string
+                                    readOnly:
+                                      default: false
+                                      description: |-
+                                        readOnly Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                  required:
+                                  - diskName
+                                  - diskURI
+                                  type: object
+                                azureFile:
+                                  description: |-
+                                    azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                    Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                    are redirected to the file.csi.azure.com CSI driver.
+                                  properties:
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretName:
+                                      description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                      type: string
+                                    shareName:
+                                      description: shareName is the azure share Name
+                                      type: string
+                                  required:
+                                  - secretName
+                                  - shareName
+                                  type: object
+                                cephfs:
+                                  description: |-
+                                    cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                    Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                  properties:
+                                    monitors:
+                                      description: |-
+                                        monitors is Required: Monitors is a collection of Ceph monitors
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    path:
+                                      description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      type: boolean
+                                    secretFile:
+                                      description: |-
+                                        secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      type: string
+                                    secretRef:
+                                      description: |-
+                                        secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      description: |-
+                                        user is optional: User is the rados user name, default is admin
+                                        More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                      type: string
+                                  required:
+                                  - monitors
+                                  type: object
+                                cinder:
+                                  description: |-
+                                    cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                    Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                    are redirected to the cinder.csi.openstack.org CSI driver.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef is optional: points to a secret object containing parameters used to connect
+                                        to OpenStack.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeID:
+                                      description: |-
+                                        volumeID used to identify the volume in cinder.
+                                        More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                configMap:
+                                  description: configMap represents a configMap that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        defaultMode is optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                csi:
+                                  description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
+                                  properties:
+                                    driver:
+                                      description: |-
+                                        driver is the name of the CSI driver that handles this volume.
+                                        Consult with your admin for the correct name as registered in the cluster.
+                                      type: string
+                                    fsType:
+                                      description: |-
+                                        fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                        If not provided, the empty value is passed to the associated CSI driver
+                                        which will determine the default filesystem to apply.
+                                      type: string
+                                    nodePublishSecretRef:
+                                      description: |-
+                                        nodePublishSecretRef is a reference to the secret object containing
+                                        sensitive information to pass to the CSI driver to complete the CSI
+                                        NodePublishVolume and NodeUnpublishVolume calls.
+                                        This field is optional, and  may be empty if no secret is required. If the
+                                        secret object contains more than one secret, all secret references are passed.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    readOnly:
+                                      description: |-
+                                        readOnly specifies a read-only configuration for the volume.
+                                        Defaults to false (read/write).
+                                      type: boolean
+                                    volumeAttributes:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        volumeAttributes stores driver-specific properties that are passed to the CSI
+                                        driver. Consult your driver's documentation for supported values.
+                                      type: object
+                                  required:
+                                  - driver
+                                  type: object
+                                downwardAPI:
+                                  description: downwardAPI represents downward API about the pod that should populate this volume
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        Optional: mode bits to use on created files by default. Must be a
+                                        Optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: Items is a list of downward API volume file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          mode:
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                emptyDir:
+                                  description: |-
+                                    emptyDir represents a temporary directory that shares a pod's lifetime.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                  properties:
+                                    medium:
+                                      description: |-
+                                        medium represents what type of storage medium should back this directory.
+                                        The default is "" which means to use the node's default medium.
+                                        Must be an empty string (default) or Memory.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      type: string
+                                    sizeLimit:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                        The size limit is also applicable for memory medium.
+                                        The maximum usage on memory medium EmptyDir would be the minimum value between
+                                        the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                        The default is nil which means that the limit is undefined.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  type: object
+                                ephemeral:
+                                  description: |-
+                                    ephemeral represents a volume that is handled by a cluster storage driver.
+                                    The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                    and deleted when the pod is removed.
+
+                                    Use this if:
+                                    a) the volume is only needed while the pod runs,
+                                    b) features of normal volumes like restoring from snapshot or capacity
+                                       tracking are needed,
+                                    c) the storage driver is specified through a storage class, and
+                                    d) the storage driver supports dynamic volume provisioning through
+                                       a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                       information on the connection between this volume type
+                                       and PersistentVolumeClaim).
+
+                                    Use PersistentVolumeClaim or one of the vendor-specific
+                                    APIs for volumes that persist for longer than the lifecycle
+                                    of an individual pod.
+
+                                    Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                    be used that way - see the documentation of the driver for
+                                    more information.
+
+                                    A pod can use both types of ephemeral volumes and
+                                    persistent volumes at the same time.
+                                  properties:
+                                    volumeClaimTemplate:
+                                      description: |-
+                                        Will be used to create a stand-alone PVC to provision the volume.
+                                        The pod in which this EphemeralVolumeSource is embedded will be the
+                                        owner of the PVC, i.e. the PVC will be deleted together with the
+                                        pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                        `<volume name>` is the name from the `PodSpec.Volumes` array
+                                        entry. Pod validation will reject the pod if the concatenated name
+                                        is not valid for a PVC (for example, too long).
+
+                                        An existing PVC with that name that is not owned by the pod
+                                        will *not* be used for the pod to avoid using an unrelated
+                                        volume by mistake. Starting the pod is then blocked until
+                                        the unrelated PVC is removed. If such a pre-created PVC is
+                                        meant to be used by the pod, the PVC has to updated with an
+                                        owner reference to the pod once the pod exists. Normally
+                                        this should not be necessary, but it may be useful when
+                                        manually reconstructing a broken cluster.
+
+                                        This field is read-only and no changes will be made by Kubernetes
+                                        to the PVC after it has been created.
+
+                                        Required, must not be nil.
+                                      properties:
+                                        metadata:
+                                          description: |-
+                                            May contain labels and annotations that will be copied into the PVC
+                                            when creating it. No other fields are allowed and will be rejected during
+                                            validation.
+                                          type: object
+                                        spec:
+                                          description: |-
+                                            The specification for the PersistentVolumeClaim. The entire content is
+                                            copied unchanged into the PVC that gets created from this
+                                            template. The same fields as in a PersistentVolumeClaim
+                                            are also valid here.
+                                          properties:
+                                            accessModes:
+                                              description: |-
+                                                accessModes contains the desired access modes the volume should have.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            dataSource:
+                                              description: |-
+                                                dataSource field can be used to specify either:
+                                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                * An existing PVC (PersistentVolumeClaim)
+                                                If the provisioner or an external controller can support the specified data source,
+                                                it will create a new volume based on the contents of the specified data source.
+                                                When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                              properties:
+                                                apiGroup:
+                                                  description: |-
+                                                    APIGroup is the group for the resource being referenced.
+                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                    For any other third-party types, APIGroup is required.
+                                                  type: string
+                                                kind:
+                                                  description: Kind is the type of resource being referenced
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of resource being referenced
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            dataSourceRef:
+                                              description: |-
+                                                dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                volume is desired. This may be any object from a non-empty API group (non
+                                                core object) or a PersistentVolumeClaim object.
+                                                When this field is specified, volume binding will only succeed if the type of
+                                                the specified object matches some installed volume populator or dynamic
+                                                provisioner.
+                                                This field will replace the functionality of the dataSource field and as such
+                                                if both fields are non-empty, they must have the same value. For backwards
+                                                compatibility, when namespace isn't specified in dataSourceRef,
+                                                both fields (dataSource and dataSourceRef) will be set to the same
+                                                value automatically if one of them is empty and the other is non-empty.
+                                                When namespace is specified in dataSourceRef,
+                                                dataSource isn't set to the same value and must be empty.
+                                                There are three important differences between dataSource and dataSourceRef:
+                                                * While dataSource only allows two specific types of objects, dataSourceRef
+                                                  allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                  preserves all values, and generates an error if a disallowed value is
+                                                  specified.
+                                                * While dataSource only allows local objects, dataSourceRef allows objects
+                                                  in any namespaces.
+                                                (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                              properties:
+                                                apiGroup:
+                                                  description: |-
+                                                    APIGroup is the group for the resource being referenced.
+                                                    If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                    For any other third-party types, APIGroup is required.
+                                                  type: string
+                                                kind:
+                                                  description: Kind is the type of resource being referenced
+                                                  type: string
+                                                name:
+                                                  description: Name is the name of resource being referenced
+                                                  type: string
+                                                namespace:
+                                                  description: |-
+                                                    Namespace is the namespace of resource being referenced
+                                                    Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                    (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                  type: string
+                                              required:
+                                              - kind
+                                              - name
+                                              type: object
+                                            resources:
+                                              description: |-
+                                                resources represents the minimum resources the volume should have.
+                                                If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                that are lower than previous value but must still be higher than capacity recorded in the
+                                                status field of the claim.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                              properties:
+                                                limits:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: |-
+                                                    Limits describes the maximum amount of compute resources allowed.
+                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                  type: object
+                                                requests:
+                                                  additionalProperties:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  description: |-
+                                                    Requests describes the minimum amount of compute resources required.
+                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                  type: object
+                                              type: object
+                                            selector:
+                                              description: selector is a label query over volumes to consider for binding.
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                    - key
+                                                    - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            storageClassName:
+                                              description: |-
+                                                storageClassName is the name of the StorageClass required by the claim.
+                                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                              type: string
+                                            volumeAttributesClassName:
+                                              description: |-
+                                                volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                If specified, the CSI driver will create or update the volume with the attributes defined
+                                                in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                                will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                                If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                                will be set by the persistentvolume controller if it exists.
+                                                If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                exists.
+                                                More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                                (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                              type: string
+                                            volumeMode:
+                                              description: |-
+                                                volumeMode defines what type of volume is required by the claim.
+                                                Value of Filesystem is implied when not included in claim spec.
+                                              type: string
+                                            volumeName:
+                                              description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                              type: string
+                                          type: object
+                                      required:
+                                      - spec
+                                      type: object
+                                  type: object
+                                fc:
+                                  description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    lun:
+                                      description: 'lun is Optional: FC target lun number'
+                                      format: int32
+                                      type: integer
+                                    readOnly:
+                                      description: |-
+                                        readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    targetWWNs:
+                                      description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    wwids:
+                                      description: |-
+                                        wwids Optional: FC volume world wide identifiers (wwids)
+                                        Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                flexVolume:
+                                  description: |-
+                                    flexVolume represents a generic volume resource that is
+                                    provisioned/attached using an exec based plugin.
+                                    Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                  properties:
+                                    driver:
+                                      description: driver is the name of the driver to use for this volume.
+                                      type: string
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                      type: string
+                                    options:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'options is Optional: this field holds extra command options if any.'
+                                      type: object
+                                    readOnly:
+                                      description: |-
+                                        readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef is Optional: secretRef is reference to the secret object containing
+                                        sensitive information to pass to the plugin scripts. This may be
+                                        empty if no secret object is specified. If the secret object
+                                        contains more than one secret, all secrets are passed to the plugin
+                                        scripts.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - driver
+                                  type: object
+                                flocker:
+                                  description: |-
+                                    flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                    Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                  properties:
+                                    datasetName:
+                                      description: |-
+                                        datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                        should be considered as deprecated
+                                      type: string
+                                    datasetUUID:
+                                      description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                      type: string
+                                  type: object
+                                gcePersistentDisk:
+                                  description: |-
+                                    gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                    gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      type: string
+                                    partition:
+                                      description: |-
+                                        partition is the partition in the volume that you want to mount.
+                                        If omitted, the default is to mount by volume name.
+                                        Examples: For volume /dev/sda1, you specify the partition as "1".
+                                        Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      format: int32
+                                      type: integer
+                                    pdName:
+                                      description: |-
+                                        pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                      type: boolean
+                                  required:
+                                  - pdName
+                                  type: object
+                                gitRepo:
+                                  description: |-
+                                    gitRepo represents a git repository at a particular revision.
+                                    Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                    EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                    into the Pod's container.
+                                  properties:
+                                    directory:
+                                      description: |-
+                                        directory is the target directory name.
+                                        Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                        git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                        the subdirectory with the given name.
+                                      type: string
+                                    repository:
+                                      description: repository is the URL
+                                      type: string
+                                    revision:
+                                      description: revision is the commit hash for the specified revision.
+                                      type: string
+                                  required:
+                                  - repository
+                                  type: object
+                                glusterfs:
+                                  description: |-
+                                    glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                    Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                  properties:
+                                    endpoints:
+                                      description: |-
+                                        endpoints is the endpoint name that details Glusterfs topology.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                      type: string
+                                    path:
+                                      description: |-
+                                        path is the Glusterfs volume path.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                        Defaults to false.
+                                        More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                      type: boolean
+                                  required:
+                                  - endpoints
+                                  - path
+                                  type: object
+                                hostPath:
+                                  description: |-
+                                    hostPath represents a pre-existing file or directory on the host
+                                    machine that is directly exposed to the container. This is generally
+                                    used for system agents or other privileged things that are allowed
+                                    to see the host machine. Most containers will NOT need this.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  properties:
+                                    path:
+                                      description: |-
+                                        path of the directory on the host.
+                                        If the path is a symlink, it will follow the link to the real path.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type for HostPath Volume
+                                        Defaults to ""
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                                image:
+                                  description: |-
+                                    image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                    The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                    - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                    - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                    - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                    The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                    A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                    The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                    The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                    The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                    Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                    The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                  properties:
+                                    pullPolicy:
+                                      description: |-
+                                        Policy for pulling OCI objects. Possible values are:
+                                        Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                        Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                        IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                        Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      type: string
+                                    reference:
+                                      description: |-
+                                        Required: Image or artifact reference to be used.
+                                        Behaves in the same way as pod.spec.containers[*].image.
+                                        Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images
+                                        This field is optional to allow higher level config management to default or override
+                                        container images in workload controllers like Deployments and StatefulSets.
+                                      type: string
+                                  type: object
+                                iscsi:
+                                  description: |-
+                                    iscsi represents an ISCSI Disk resource that is attached to a
+                                    kubelet's host machine and then exposed to the pod.
+                                    More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                  properties:
+                                    chapAuthDiscovery:
+                                      description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                      type: boolean
+                                    chapAuthSession:
+                                      description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                      type: boolean
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      type: string
+                                    initiatorName:
+                                      description: |-
+                                        initiatorName is the custom iSCSI Initiator Name.
+                                        If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                        <target portal>:<volume name> will be created for the connection.
+                                      type: string
+                                    iqn:
+                                      description: iqn is the target iSCSI Qualified Name.
+                                      type: string
+                                    iscsiInterface:
+                                      default: default
+                                      description: |-
+                                        iscsiInterface is the interface Name that uses an iSCSI transport.
+                                        Defaults to 'default' (tcp).
+                                      type: string
+                                    lun:
+                                      description: lun represents iSCSI Target Lun number.
+                                      format: int32
+                                      type: integer
+                                    portals:
+                                      description: |-
+                                        portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                        is other than default (typically TCP ports 860 and 3260).
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                      type: boolean
+                                    secretRef:
+                                      description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    targetPortal:
+                                      description: |-
+                                        targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                        is other than default (typically TCP ports 860 and 3260).
+                                      type: string
+                                  required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                  type: object
+                                name:
+                                  description: |-
+                                    name of the volume.
+                                    Must be a DNS_LABEL and unique within the pod.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                                nfs:
+                                  description: |-
+                                    nfs represents an NFS mount on the host that shares a pod's lifetime
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                  properties:
+                                    path:
+                                      description: |-
+                                        path that is exported by the NFS server.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the NFS export to be mounted with read-only permissions.
+                                        Defaults to false.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      type: boolean
+                                    server:
+                                      description: |-
+                                        server is the hostname or IP address of the NFS server.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                      type: string
+                                  required:
+                                  - path
+                                  - server
+                                  type: object
+                                persistentVolumeClaim:
+                                  description: |-
+                                    persistentVolumeClaimVolumeSource represents a reference to a
+                                    PersistentVolumeClaim in the same namespace.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                  properties:
+                                    claimName:
+                                      description: |-
+                                        claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly Will force the ReadOnly setting in VolumeMounts.
+                                        Default false.
+                                      type: boolean
+                                  required:
+                                  - claimName
+                                  type: object
+                                photonPersistentDisk:
+                                  description: |-
+                                    photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                    Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    pdID:
+                                      description: pdID is the ID that identifies Photon Controller persistent disk
+                                      type: string
+                                  required:
+                                  - pdID
+                                  type: object
+                                portworxVolume:
+                                  description: |-
+                                    portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                    Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                    are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                    is on.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fSType represents the filesystem type to mount
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    volumeID:
+                                      description: volumeID uniquely identifies a Portworx volume
+                                      type: string
+                                  required:
+                                  - volumeID
+                                  type: object
+                                projected:
+                                  description: projected items for all in one resources secrets, configmaps, and downward API
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        defaultMode are the mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    sources:
+                                      description: |-
+                                        sources is the list of volume projections. Each entry in this list
+                                        handles one source.
+                                      items:
+                                        description: |-
+                                          Projection that may be projected along with other supported volume types.
+                                          Exactly one of these fields must be set.
+                                        properties:
+                                          clusterTrustBundle:
+                                            description: |-
+                                              ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                              of ClusterTrustBundle objects in an auto-updating file.
+
+                                              Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                              ClusterTrustBundle objects can either be selected by name, or by the
+                                              combination of signer name and a label selector.
+
+                                              Kubelet performs aggressive normalization of the PEM contents written
+                                              into the pod filesystem.  Esoteric PEM features such as inter-block
+                                              comments and block headers are stripped.  Certificates are deduplicated.
+                                              The ordering of certificates within the file is arbitrary, and Kubelet
+                                              may change the order over time.
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  Select all ClusterTrustBundles that match this label selector.  Only has
+                                                  effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                  interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                  everything".
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the label key that the selector applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              name:
+                                                description: |-
+                                                  Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                  with signerName and labelSelector.
+                                                type: string
+                                              optional:
+                                                description: |-
+                                                  If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                  aren't available.  If using name, then the named ClusterTrustBundle is
+                                                  allowed not to exist.  If using signerName, then the combination of
+                                                  signerName and labelSelector is allowed to match zero
+                                                  ClusterTrustBundles.
+                                                type: boolean
+                                              path:
+                                                description: Relative path from the volume root to write the bundle.
+                                                type: string
+                                              signerName:
+                                                description: |-
+                                                  Select all ClusterTrustBundles that match this signer name.
+                                                  Mutually-exclusive with name.  The contents of all selected
+                                                  ClusterTrustBundles will be unified and deduplicated.
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          configMap:
+                                            description: configMap information about the configMap data to project
+                                            properties:
+                                              items:
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  ConfigMap will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the ConfigMap,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: key is the key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: optional specify whether the ConfigMap or its keys must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          downwardAPI:
+                                            description: downwardAPI information about the downwardAPI data to project
+                                            properties:
+                                              items:
+                                                description: Items is a list of DownwardAPIVolume file
+                                                items:
+                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                  properties:
+                                                    fieldRef:
+                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    mode:
+                                                      description: |-
+                                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          secret:
+                                            description: secret information about the secret data to project
+                                            properties:
+                                              items:
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  Secret will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the Secret,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: key is the key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              name:
+                                                default: ""
+                                                description: |-
+                                                  Name of the referent.
+                                                  This field is effectively required, but due to backwards compatibility is
+                                                  allowed to be empty. Instances of this type with an empty value here are
+                                                  almost certainly wrong.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                type: string
+                                              optional:
+                                                description: optional field specify whether the Secret or its key must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          serviceAccountToken:
+                                            description: serviceAccountToken is information about the serviceAccountToken data to project
+                                            properties:
+                                              audience:
+                                                description: |-
+                                                  audience is the intended audience of the token. A recipient of a token
+                                                  must identify itself with an identifier specified in the audience of the
+                                                  token, and otherwise should reject the token. The audience defaults to the
+                                                  identifier of the apiserver.
+                                                type: string
+                                              expirationSeconds:
+                                                description: |-
+                                                  expirationSeconds is the requested duration of validity of the service
+                                                  account token. As the token approaches expiration, the kubelet volume
+                                                  plugin will proactively rotate the service account token. The kubelet will
+                                                  start trying to rotate the token if the token is older than 80 percent of
+                                                  its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                  and must be at least 10 minutes.
+                                                format: int64
+                                                type: integer
+                                              path:
+                                                description: |-
+                                                  path is the path relative to the mount point of the file to project the
+                                                  token into.
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                quobyte:
+                                  description: |-
+                                    quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                    Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                  properties:
+                                    group:
+                                      description: |-
+                                        group to map volume access to
+                                        Default is no group
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                        Defaults to false.
+                                      type: boolean
+                                    registry:
+                                      description: |-
+                                        registry represents a single or multiple Quobyte Registry services
+                                        specified as a string as host:port pair (multiple entries are separated with commas)
+                                        which acts as the central registry for volumes
+                                      type: string
+                                    tenant:
+                                      description: |-
+                                        tenant owning the given Quobyte volume in the Backend
+                                        Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                      type: string
+                                    user:
+                                      description: |-
+                                        user to map volume access to
+                                        Defaults to serivceaccount user
+                                      type: string
+                                    volume:
+                                      description: volume is a string that references an already created Quobyte volume by name.
+                                      type: string
+                                  required:
+                                  - registry
+                                  - volume
+                                  type: object
+                                rbd:
+                                  description: |-
+                                    rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                    Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type of the volume that you want to mount.
+                                        Tip: Ensure that the filesystem type is supported by the host operating system.
+                                        Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      type: string
+                                    image:
+                                      description: |-
+                                        image is the rados image name.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                    keyring:
+                                      default: /etc/ceph/keyring
+                                      description: |-
+                                        keyring is the path to key ring for RBDUser.
+                                        Default is /etc/ceph/keyring.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                    monitors:
+                                      description: |-
+                                        monitors is a collection of Ceph monitors.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    pool:
+                                      default: rbd
+                                      description: |-
+                                        pool is the rados pool name.
+                                        Default is rbd.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly here will force the ReadOnly setting in VolumeMounts.
+                                        Defaults to false.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef is name of the authentication secret for RBDUser. If provided
+                                        overrides keyring.
+                                        Default is nil.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    user:
+                                      default: admin
+                                      description: |-
+                                        user is the rados user name.
+                                        Default is admin.
+                                        More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                      type: string
+                                  required:
+                                  - image
+                                  - monitors
+                                  type: object
+                                scaleIO:
+                                  description: |-
+                                    scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                    Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      default: xfs
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs".
+                                        Default is "xfs".
+                                      type: string
+                                    gateway:
+                                      description: gateway is the host address of the ScaleIO API Gateway.
+                                      type: string
+                                    protectionDomain:
+                                      description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly Defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef references to the secret for ScaleIO user and other
+                                        sensitive information. If this is not provided, Login operation will fail.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    sslEnabled:
+                                      description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                      type: boolean
+                                    storageMode:
+                                      default: ThinProvisioned
+                                      description: |-
+                                        storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                        Default is ThinProvisioned.
+                                      type: string
+                                    storagePool:
+                                      description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                      type: string
+                                    system:
+                                      description: system is the name of the storage system as configured in ScaleIO.
+                                      type: string
+                                    volumeName:
+                                      description: |-
+                                        volumeName is the name of a volume already created in the ScaleIO system
+                                        that is associated with this volume source.
+                                      type: string
+                                  required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                  type: object
+                                secret:
+                                  description: |-
+                                    secret represents a secret that should populate this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                  properties:
+                                    defaultMode:
+                                      description: |-
+                                        defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                        YAML accepts both octal and decimal values, JSON requires decimal values
+                                        for mode bits. Defaults to 0644.
+                                        Directories within the path are not affected by this setting.
+                                        This might be in conflict with other options that affect the file
+                                        mode, like fsGroup, and the result can be other mode bits set.
+                                      format: int32
+                                      type: integer
+                                    items:
+                                      description: |-
+                                        items If unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    optional:
+                                      description: optional field specify whether the Secret or its keys must be defined
+                                      type: boolean
+                                    secretName:
+                                      description: |-
+                                        secretName is the name of the secret in the pod's namespace to use.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                      type: string
+                                  type: object
+                                storageos:
+                                  description: |-
+                                    storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                    Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is the filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        readOnly defaults to false (read/write). ReadOnly here will force
+                                        the ReadOnly setting in VolumeMounts.
+                                      type: boolean
+                                    secretRef:
+                                      description: |-
+                                        secretRef specifies the secret to use for obtaining the StorageOS API
+                                        credentials.  If not specified, default values will be attempted.
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    volumeName:
+                                      description: |-
+                                        volumeName is the human-readable name of the StorageOS volume.  Volume
+                                        names are only unique within a namespace.
+                                      type: string
+                                    volumeNamespace:
+                                      description: |-
+                                        volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                        namespace is specified then the Pod's namespace will be used.  This allows the
+                                        Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                        Set VolumeName to any name to override the default behaviour.
+                                        Set to "default" if you are not using namespaces within StorageOS.
+                                        Namespaces that do not pre-exist within StorageOS will be created.
+                                      type: string
+                                  type: object
+                                vsphereVolume:
+                                  description: |-
+                                    vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                    Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                    are redirected to the csi.vsphere.vmware.com CSI driver.
+                                  properties:
+                                    fsType:
+                                      description: |-
+                                        fsType is filesystem type to mount.
+                                        Must be a filesystem type supported by the host operating system.
+                                        Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      type: string
+                                    storagePolicyID:
+                                      description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                      type: string
+                                    storagePolicyName:
+                                      description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                      type: string
+                                    volumePath:
+                                      description: volumePath is the path that identifies vSphere volume vmdk
+                                      type: string
+                                  required:
+                                  - volumePath
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          podAdditionalMetadata:
+                            description: |-
+                              PodAdditionalMetadata defines the additional labels and annotations that must be attached
+                              to the resulting Pods managed by the Deployment.
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          runtimeClassName:
+                            type: string
+                          serviceAccountName:
+                            type: string
+                          strategy:
+                            description: DeploymentStrategy describes how to replace existing pods with new ones.
+                            properties:
+                              rollingUpdate:
+                                description: |-
+                                  Rolling update config params. Present only if DeploymentStrategyType =
+                                  RollingUpdate.
+                                properties:
+                                  maxSurge:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of pods that can be scheduled above the desired number of
+                                      pods.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                      This can not be 0 if MaxUnavailable is 0.
+                                      Absolute number is calculated from percentage by rounding up.
+                                      Defaults to 25%.
+                                      Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                      the rolling update starts, such that the total number of old and new pods do not exceed
+                                      130% of desired pods. Once old pods have been killed,
+                                      new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                      at any time during the update is at most 130% of desired pods.
+                                    x-kubernetes-int-or-string: true
+                                  maxUnavailable:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    description: |-
+                                      The maximum number of pods that can be unavailable during the update.
+                                      Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                      Absolute number is calculated from percentage by rounding down.
+                                      This can not be 0 if MaxSurge is 0.
+                                      Defaults to 25%.
+                                      Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                      immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                      can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                      that the total number of pods available at all times during the update is at
+                                      least 70% of desired pods.
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              type:
+                                description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                                type: string
+                            type: object
+                          tolerations:
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            type: array
+                          topologySpreadConstraints:
+                            items:
+                              description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    LabelSelector is used to find matching pods.
+                                    Pods that match this label selector are counted to determine the number of pods
+                                    in their corresponding topology domain.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select the pods over which
+                                    spreading will be calculated. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are ANDed with labelSelector
+                                    to select the group of existing pods over which spreading will be calculated
+                                    for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                    MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                    Keys that don't exist in the incoming pod labels will
+                                    be ignored. A null or empty list means only match against labelSelector.
+
+                                    This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                maxSkew:
+                                  description: |-
+                                    MaxSkew describes the degree to which pods may be unevenly distributed.
+                                    When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                    between the number of matching pods in the target topology and the global minimum.
+                                    The global minimum is the minimum number of matching pods in an eligible domain
+                                    or zero if the number of eligible domains is less than MinDomains.
+                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                    labelSelector spread as 2/2/1:
+                                    In this case, the global minimum is 1.
+                                    | zone1 | zone2 | zone3 |
+                                    |  P P  |  P P  |   P   |
+                                    - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                    scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                    violate MaxSkew(1).
+                                    - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                    When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                    to topologies that satisfy it.
+                                    It's a required field. Default value is 1 and 0 is not allowed.
+                                  format: int32
+                                  type: integer
+                                minDomains:
+                                  description: |-
+                                    MinDomains indicates a minimum number of eligible domains.
+                                    When the number of eligible domains with matching topology keys is less than minDomains,
+                                    Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                    And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                    this value has no effect on scheduling.
+                                    As a result, when the number of eligible domains is less than minDomains,
+                                    scheduler won't schedule more than maxSkew Pods to those domains.
+                                    If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                    Valid values are integers greater than 0.
+                                    When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                    For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                    labelSelector spread as 2/2/2:
+                                    | zone1 | zone2 | zone3 |
+                                    |  P P  |  P P  |  P P  |
+                                    The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                    In this situation, new pod with the same labelSelector cannot be scheduled,
+                                    because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                    it will violate MaxSkew.
+                                  format: int32
+                                  type: integer
+                                nodeAffinityPolicy:
+                                  description: |-
+                                    NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                    when calculating pod topology spread skew. Options are:
+                                    - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                    - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                    If this value is nil, the behavior is equivalent to the Honor policy.
+                                  type: string
+                                nodeTaintsPolicy:
+                                  description: |-
+                                    NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                    pod topology spread skew. Options are:
+                                    - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                    has a toleration, are included.
+                                    - Ignore: node taints are ignored. All nodes are included.
+
+                                    If this value is nil, the behavior is equivalent to the Ignore policy.
+                                  type: string
+                                topologyKey:
+                                  description: |-
+                                    TopologyKey is the key of node labels. Nodes that have a label with this key
+                                    and identical values are considered to be in the same topology.
+                                    We consider each <key, value> as a "bucket", and try to put balanced number
+                                    of pods into each bucket.
+                                    We define a domain as a particular instance of a topology.
+                                    Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                    nodeAffinityPolicy and nodeTaintsPolicy.
+                                    e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                    And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                    It's a required field.
+                                  type: string
+                                whenUnsatisfiable:
+                                  description: |-
+                                    WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                    the spread constraint.
+                                    - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                    - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                      but giving higher precedence to topologies that would help reduce the
+                                      skew.
+                                    A constraint is considered "Unsatisfiable" for an incoming pod
+                                    if and only if every possible node assignment for that pod would violate
+                                    "MaxSkew" on some topology.
+                                    For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                    labelSelector spread as 3/1/1:
+                                    | zone1 | zone2 | zone3 |
+                                    | P P P |   P   |   P   |
+                                    If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                    to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                    MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                    won't make it *more* imbalanced.
+                                    It's a required field.
+                                  type: string
+                              required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                              type: object
+                            type: array
+                        type: object
+                      kine:
+                        description: |-
+                          KineComponent allows the customization for the kine component of the control plane.
+                          Available only if Kamaji is running using Kine as backing storage.
+                        properties:
+                          extraArgs:
+                            items:
+                              type: string
+                            type: array
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                      kubelet:
+                        default:
+                          cgroupfs: systemd
+                          preferredAddressTypes:
+                          - InternalIP
+                          - ExternalIP
+                          - Hostname
+                        description: Configure the Kubelet options, such as the preferred address types, or the expected cgroupfs.
+                        properties:
+                          cgroupfs:
+                            description: |-
+                              CGroupFS defines the  cgroup driver for Kubelet
+                              https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/
+                            enum:
+                            - systemd
+                            - cgroupfs
+                            type: string
+                          preferredAddressTypes:
+                            default:
+                            - Hostname
+                            - InternalIP
+                            - ExternalIP
+                            description: |-
+                              Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
+                              Default to Hostname, InternalIP, ExternalIP.
+                            items:
+                              enum:
+                              - Hostname
+                              - InternalIP
+                              - ExternalIP
+                              - InternalDNS
+                              - ExternalDNS
+                              type: string
+                            minItems: 1
+                            type: array
+                        type: object
+                      network:
+                        default:
+                          serviceType: LoadBalancer
+                        description: Configure how the TenantControlPlane should be exposed.
+                        properties:
+                          certSANs:
+                            description: |-
+                              Configure additional Subject Address Names for the kube-apiserver certificate,
+                              useful if the TenantControlPlane is going to be exposed behind a FQDN with NAT.
+                            items:
+                              type: string
+                            type: array
+                          dnsServiceIPs:
+                            description: |-
+                              DNSServiceIPs contains the DNS Service IPs.
+                              If the CoreDNS addon is specified, its DNSServiceIPs will be used instead.
+                              When set to an empty slice, Kamaji will automatically inflect it from the Service CIDR.
+                            items:
+                              type: string
+                            type: array
+                          ingress:
+                            description: |-
+                              When specified, the KamajiControlPlane will be reachable using an Ingress object
+                              deployed in the management cluster.
+                            properties:
+                              className:
+                                description: Defines the Ingress Class for the Ingress object.
+                                type: string
+                              extraAnnotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  Defines the extra annotations for the Ingress object.
+                                  Useful if you need to define TLS/SSL passthrough, or other Ingress Controller-specific options.
+                                type: object
+                              extraLabels:
+                                additionalProperties:
+                                  type: string
+                                description: Defines the extra labels for the Ingress object.
+                                type: object
+                              hostname:
+                                description: |-
+                                  Defines the hostname for the Ingress object.
+                                  When using an Ingress object the FQDN is automatically added to the Certificate SANs.
+                                minLength: 1
+                                type: string
+                            required:
+                            - hostname
+                            type: object
+                          loadBalancerConfig:
+                            description: Optional configuration for the LoadBalancer service that exposes the Kamaji control plane.
+                            properties:
+                              loadBalancerClass:
+                                description: |-
+                                  Specify the LoadBalancer class in case of multiple load balancer implementations.
+                                  Field supported only for Tenant Control Plane instances exposed using a LoadBalancer Service.
+                                minLength: 1
+                                type: string
+                                x-kubernetes-validations:
+                                - message: LoadBalancerClass is immutable
+                                  rule: self == oldSelf
+                              loadBalancerSourceRanges:
+                                description: |-
+                                  LoadBalancerSourceRanges restricts the IP ranges that can access
+                                  the LoadBalancer type Service. This field defines a list of IP
+                                  address ranges (in CIDR format) that are allowed to access the service.
+                                  If left empty, the service will allow traffic from all IP ranges (0.0.0.0/0).
+                                  This feature is useful for restricting access to API servers or services
+                                  to specific networks for security purposes.
+                                  Example: {"192.168.1.0/24", "10.0.0.0/8"}
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          serviceAddress:
+                            description: |-
+                              This field can be used in case of pre-assigned address, such as a VIP,
+                              helping when serviceType is NodePort.
+                            type: string
+                          serviceAnnotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          serviceLabels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          serviceType:
+                            default: LoadBalancer
+                            description: Service Type string describes ingress methods for a service
+                            enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                            type: string
+                        type: object
+                        x-kubernetes-validations:
+                        - message: LoadBalancerSourceRanges are supported only with LoadBalancer service type
+                          rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerSourceRanges) || (size(self.loadBalancerConfig.loadBalancerSourceRanges) == 0 || self.serviceType == ''LoadBalancer'')'
+                        - message: LoadBalancerClass is supported only with LoadBalancer service type
+                          rule: '!has(self.loadBalancerConfig) || !has(self.loadBalancerConfig.loadBalancerClass) || self.serviceType == ''LoadBalancer'''
+                        - message: LoadBalancerClass cannot be set or unset at runtime
+                          rule: self.serviceType != 'LoadBalancer' || (oldSelf.serviceType != 'LoadBalancer' && self.serviceType == 'LoadBalancer') || !has(self.loadBalancerConfig) || has(self.loadBalancerConfig) && has(self.loadBalancerConfig.loadBalancerClass) == has(oldSelf.loadBalancerConfig.loadBalancerClass)
+                      registry:
+                        default: registry.k8s.io
+                        description: |-
+                          Override the container registry used to pull the components image.
+                          Helpful if running in an air-gapped environment.
+                        type: string
+                      scheduler:
+                        description: ControlPlaneComponent allows the customization for the given component of the control plane.
+                        properties:
+                          containerImageName:
+                            description: |-
+                              In combination with the container registry, it can override the component container image.
+                              With no value, the default images will be used.
+                            minLength: 1
+                            type: string
+                          extraArgs:
+                            items:
+                              type: string
+                            type: array
+                          extraVolumeMounts:
+                            items:
+                              description: VolumeMount describes a mounting of a Volume within a container.
+                              properties:
+                                mountPath:
+                                  description: |-
+                                    Path within the container at which the volume should be mounted.  Must
+                                    not contain ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: |-
+                                    mountPropagation determines how mounts are propagated from the host
+                                    to container and the other way around.
+                                    When not set, MountPropagationNone is used.
+                                    This field is beta in 1.10.
+                                    When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                    (which defaults to None).
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: |-
+                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                    Defaults to false.
+                                  type: boolean
+                                recursiveReadOnly:
+                                  description: |-
+                                    RecursiveReadOnly specifies whether read-only mounts should be handled
+                                    recursively.
+
+                                    If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                    If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                    recursively read-only.  If this field is set to IfPossible, the mount is made
+                                    recursively read-only, if it is supported by the container runtime.  If this
+                                    field is set to Enabled, the mount is made recursively read-only if it is
+                                    supported by the container runtime, otherwise the pod will not be started and
+                                    an error will be generated to indicate the reason.
+
+                                    If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                    None (or be unspecified, which defaults to None).
+
+                                    If this field is not specified, it is treated as an equivalent of Disabled.
+                                  type: string
+                                subPath:
+                                  description: |-
+                                    Path within the volume from which the container's volume should be mounted.
+                                    Defaults to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: |-
+                                    Expanded path within the volume from which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                    Defaults to "" (volume's root).
+                                    SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                          resources:
+                            description: ResourceRequirements describes the compute resource requirements.
+                            properties:
+                              claims:
+                                description: |-
+                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                  that are used by this container.
+
+                                  This is an alpha field and requires enabling the
+                                  DynamicResourceAllocation feature gate.
+
+                                  This field is immutable. It can only be set for containers.
+                                items:
+                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                  properties:
+                                    name:
+                                      description: |-
+                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                        the Pod where this field is used. It makes that resource available
+                                        inside a container.
+                                      type: string
+                                    request:
+                                      description: |-
+                                        Request is the name chosen for a request in the referenced claim.
+                                        If empty, everything from the claim is made available, otherwise
+                                        only the result of this request.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                - name
+                                x-kubernetes-list-type: map
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                type: object
+                            type: object
+                        type: object
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true

--- a/docs/shared/crds/cluster_api/hosted_control_plane/kamaji.clastix.io_datastores.yaml
+++ b/docs/shared/crds/cluster_api/hosted_control_plane/kamaji.clastix.io_datastores.yaml
@@ -1,0 +1,297 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kamaji-system/kamaji-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: datastores.kamaji.clastix.io
+spec:
+  group: kamaji.clastix.io
+  names:
+    kind: DataStore
+    listKind: DataStoreList
+    plural: datastores
+    singular: datastore
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Kamaji data store driver
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Age
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: DataStore is the Schema for the datastores API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: DataStoreSpec defines the desired state of DataStore.
+              properties:
+                basicAuth:
+                  description: |-
+                    In case of authentication enabled for the given data store, specifies the username and password pair.
+                    This value is optional.
+                  properties:
+                    password:
+                      properties:
+                        content:
+                          description: |-
+                            Bare content of the file, base64 encoded.
+                            It has precedence over the SecretReference value.
+                          format: byte
+                          type: string
+                        secretReference:
+                          properties:
+                            keyPath:
+                              description: |-
+                                Name of the key for the given Secret reference where the content is stored.
+                                This value is mandatory.
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name is unique within a namespace to reference a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which the secret name must be unique.
+                              type: string
+                          required:
+                            - keyPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    username:
+                      properties:
+                        content:
+                          description: |-
+                            Bare content of the file, base64 encoded.
+                            It has precedence over the SecretReference value.
+                          format: byte
+                          type: string
+                        secretReference:
+                          properties:
+                            keyPath:
+                              description: |-
+                                Name of the key for the given Secret reference where the content is stored.
+                                This value is mandatory.
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name is unique within a namespace to reference a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which the secret name must be unique.
+                              type: string
+                          required:
+                            - keyPath
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                  required:
+                    - password
+                    - username
+                  type: object
+                driver:
+                  description: The driver to use to connect to the shared datastore.
+                  enum:
+                    - etcd
+                    - MySQL
+                    - PostgreSQL
+                    - NATS
+                  type: string
+                  x-kubernetes-validations:
+                    - message: Datastore driver is immutable
+                      rule: self == oldSelf
+                endpoints:
+                  description: |-
+                    List of the endpoints to connect to the shared datastore.
+                    No need for protocol, just bare IP/FQDN and port.
+                  items:
+                    type: string
+                  minItems: 1
+                  type: array
+                tlsConfig:
+                  description: |-
+                    Defines the TLS/SSL configuration required to connect to the data store in a secure way.
+                    This value is optional.
+                  properties:
+                    certificateAuthority:
+                      description: |-
+                        Retrieve the Certificate Authority certificate and private key, such as bare content of the file, or a SecretReference.
+                        The key reference is required since etcd authentication is based on certificates, and Kamaji is responsible in creating this.
+                      properties:
+                        certificate:
+                          properties:
+                            content:
+                              description: |-
+                                Bare content of the file, base64 encoded.
+                                It has precedence over the SecretReference value.
+                              format: byte
+                              type: string
+                            secretReference:
+                              properties:
+                                keyPath:
+                                  description: |-
+                                    Name of the key for the given Secret reference where the content is stored.
+                                    This value is mandatory.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name is unique within a namespace to reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within which the secret name must be unique.
+                                  type: string
+                              required:
+                                - keyPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        privateKey:
+                          properties:
+                            content:
+                              description: |-
+                                Bare content of the file, base64 encoded.
+                                It has precedence over the SecretReference value.
+                              format: byte
+                              type: string
+                            secretReference:
+                              properties:
+                                keyPath:
+                                  description: |-
+                                    Name of the key for the given Secret reference where the content is stored.
+                                    This value is mandatory.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name is unique within a namespace to reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within which the secret name must be unique.
+                                  type: string
+                              required:
+                                - keyPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                        - certificate
+                      type: object
+                    clientCertificate:
+                      description: Specifies the SSL/TLS key and private key pair used to connect to the data store.
+                      properties:
+                        certificate:
+                          properties:
+                            content:
+                              description: |-
+                                Bare content of the file, base64 encoded.
+                                It has precedence over the SecretReference value.
+                              format: byte
+                              type: string
+                            secretReference:
+                              properties:
+                                keyPath:
+                                  description: |-
+                                    Name of the key for the given Secret reference where the content is stored.
+                                    This value is mandatory.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name is unique within a namespace to reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within which the secret name must be unique.
+                                  type: string
+                              required:
+                                - keyPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        privateKey:
+                          properties:
+                            content:
+                              description: |-
+                                Bare content of the file, base64 encoded.
+                                It has precedence over the SecretReference value.
+                              format: byte
+                              type: string
+                            secretReference:
+                              properties:
+                                keyPath:
+                                  description: |-
+                                    Name of the key for the given Secret reference where the content is stored.
+                                    This value is mandatory.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name is unique within a namespace to reference a secret resource.
+                                  type: string
+                                namespace:
+                                  description: namespace defines the space within which the secret name must be unique.
+                                  type: string
+                              required:
+                                - keyPath
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                      required:
+                        - certificate
+                        - privateKey
+                      type: object
+                  required:
+                    - certificateAuthority
+                  type: object
+              required:
+                - driver
+                - endpoints
+              type: object
+              x-kubernetes-validations:
+                - message: certificateAuthority privateKey must have secretReference or content when driver is etcd
+                  rule: '(self.driver == "etcd") ? (self.tlsConfig != null && (has(self.tlsConfig.certificateAuthority.privateKey.secretReference) || has(self.tlsConfig.certificateAuthority.privateKey.content))) : true'
+                - message: clientCertificate must have secretReference or content when driver is etcd
+                  rule: '(self.driver == "etcd") ? (self.tlsConfig != null && (has(self.tlsConfig.clientCertificate.certificate.secretReference) || has(self.tlsConfig.clientCertificate.certificate.content))) : true'
+                - message: clientCertificate privateKey must have secretReference or content when driver is etcd
+                  rule: '(self.driver == "etcd") ? (self.tlsConfig != null && (has(self.tlsConfig.clientCertificate.privateKey.secretReference) || has(self.tlsConfig.clientCertificate.privateKey.content))) : true'
+                - message: When driver is not etcd and tlsConfig exists, clientCertificate must be null or contain valid content
+                  rule: '(self.driver != "etcd" && has(self.tlsConfig) && has(self.tlsConfig.clientCertificate)) ? (((has(self.tlsConfig.clientCertificate.certificate.secretReference) || has(self.tlsConfig.clientCertificate.certificate.content)))) : true'
+                - message: When driver is not etcd and basicAuth exists, username must have secretReference or content
+                  rule: '(self.driver != "etcd" && has(self.basicAuth)) ? ((has(self.basicAuth.username.secretReference) || has(self.basicAuth.username.content))) : true'
+                - message: When driver is not etcd and basicAuth exists, password must have secretReference or content
+                  rule: '(self.driver != "etcd" && has(self.basicAuth)) ? ((has(self.basicAuth.password.secretReference) || has(self.basicAuth.password.content))) : true'
+                - message: When driver is not etcd, either tlsConfig or basicAuth must be provided
+                  rule: '(self.driver != "etcd") ? (has(self.tlsConfig) || has(self.basicAuth)) : true'
+            status:
+              description: DataStoreStatus defines the observed state of DataStore.
+              properties:
+                usedBy:
+                  description: List of the Tenant Control Planes, namespaced names, using this data store.
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/docs/shared/crds/cluster_api/hosted_control_plane/kamaji.clastix.io_tenantcontrolplanes.yaml
+++ b/docs/shared/crds/cluster_api/hosted_control_plane/kamaji.clastix.io_tenantcontrolplanes.yaml
@@ -1,0 +1,7455 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: kamaji-system/kamaji-serving-cert
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: tenantcontrolplanes.kamaji.clastix.io
+spec:
+  group: kamaji.clastix.io
+  names:
+    categories:
+      - kamaji
+    kind: TenantControlPlane
+    listKind: TenantControlPlaneList
+    plural: tenantcontrolplanes
+    shortNames:
+      - tcp
+    singular: tenantcontrolplane
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Kubernetes version
+          jsonPath: .spec.kubernetes.version
+          name: Version
+          type: string
+        - description: Status
+          jsonPath: .status.kubernetesResources.version.status
+          name: Status
+          type: string
+        - description: Tenant Control Plane Endpoint (API server)
+          jsonPath: .status.controlPlaneEndpoint
+          name: Control-Plane endpoint
+          type: string
+        - description: Secret which contains admin kubeconfig
+          jsonPath: .status.kubeconfig.admin.secretName
+          name: Kubeconfig
+          type: string
+        - description: DataStore actually used
+          jsonPath: .status.storage.dataStoreName
+          name: Datastore
+          type: string
+        - description: Age
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: TenantControlPlane is the Schema for the tenantcontrolplanes API.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                addons:
+                  description: Addons contain which addons are enabled
+                  properties:
+                    coreDNS:
+                      description: |-
+                        Enables the DNS addon in the Tenant Cluster.
+                        The registry and the tag are configurable, the image is hard-coded to `coredns`.
+                      properties:
+                        imageRepository:
+                          description: |-
+                            ImageRepository sets the container registry to pull images from.
+                            if not set, the default ImageRepository will be used instead.
+                          type: string
+                        imageTag:
+                          description: |-
+                            ImageTag allows to specify a tag for the image.
+                            In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                          type: string
+                      type: object
+                    konnectivity:
+                      description: Enables the Konnectivity addon in the Tenant Cluster, required if the worker nodes are in a different network.
+                      properties:
+                        agent:
+                          default:
+                            image: registry.k8s.io/kas-network-proxy/proxy-agent
+                            version: v0.28.6
+                          properties:
+                            extraArgs:
+                              description: |-
+                                ExtraArgs allows adding additional arguments to said component.
+                                WARNING - This option can override existing konnectivity
+                                parameters and cause konnectivity components to misbehave in
+                                unxpected ways. Only modify if you know what you are doing.
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              default: registry.k8s.io/kas-network-proxy/proxy-agent
+                              description: AgentImage defines the container image for Konnectivity's agent.
+                              type: string
+                            tolerations:
+                              default:
+                                - key: CriticalAddonsOnly
+                                  operator: Exists
+                              description: |-
+                                Tolerations for the deployed agent.
+                                Can be customized to start the konnectivity-agent even if the nodes are not ready or tainted.
+                              items:
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                            version:
+                              default: v0.28.6
+                              description: Version for Konnectivity agent.
+                              type: string
+                          type: object
+                        server:
+                          default:
+                            image: registry.k8s.io/kas-network-proxy/proxy-server
+                            port: 8132
+                            version: v0.28.6
+                          properties:
+                            extraArgs:
+                              description: |-
+                                ExtraArgs allows adding additional arguments to said component.
+                                WARNING - This option can override existing konnectivity
+                                parameters and cause konnectivity components to misbehave in
+                                unxpected ways. Only modify if you know what you are doing.
+                              items:
+                                type: string
+                              type: array
+                            image:
+                              default: registry.k8s.io/kas-network-proxy/proxy-server
+                              description: Container image used by the Konnectivity server.
+                              type: string
+                            port:
+                              description: The port which Konnectivity server is listening to.
+                              format: int32
+                              type: integer
+                            resources:
+                              description: Resources define the amount of CPU and memory to allocate to the Konnectivity server.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            version:
+                              default: v0.28.6
+                              description: Container image version of the Konnectivity server.
+                              type: string
+                          required:
+                            - port
+                          type: object
+                      type: object
+                    kubeProxy:
+                      description: |-
+                        Enables the kube-proxy addon in the Tenant Cluster.
+                        The registry and the tag are configurable, the image is hard-coded to `kube-proxy`.
+                      properties:
+                        imageRepository:
+                          description: |-
+                            ImageRepository sets the container registry to pull images from.
+                            if not set, the default ImageRepository will be used instead.
+                          type: string
+                        imageTag:
+                          description: |-
+                            ImageTag allows to specify a tag for the image.
+                            In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                          type: string
+                      type: object
+                  type: object
+                controlPlane:
+                  description: |-
+                    ControlPlane defines how the Tenant Control Plane Kubernetes resources must be created in the Admin Cluster,
+                    such as the number of Pod replicas, the Service resource, or the Ingress.
+                  properties:
+                    deployment:
+                      description: Defining the options for the deployed Tenant Control Plane as Deployment resource.
+                      properties:
+                        additionalContainers:
+                          description: AdditionalContainers allows adding additional containers to the Control Plane deployment.
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              lifecycle:
+                                description: |-
+                                  Actions that the management system should take in response to container lifecycle events.
+                                  Cannot be updated.
+                                properties:
+                                  postStart:
+                                    description: |-
+                                      PostStart is called immediately after a container is created. If the handler fails,
+                                      the container is terminated and restarted according to its restart policy.
+                                      Other management of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    description: |-
+                                      PreStop is called immediately before a container is terminated due to an
+                                      API request or management event such as liveness/startup probe failure,
+                                      preemption, resource contention, etc. The handler is not called if the
+                                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                                      container will eventually terminate within the Pod's termination grace
+                                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                      or until the termination grace period is reached.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
+                                type: object
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external port to.
+                                      type: string
+                                    hostPort:
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                  required:
+                                    - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: |-
+                                        Name of the resource to which this resource resize policy applies.
+                                        Supported values: cpu, memory.
+                                      type: string
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy to apply when specified resource is resized.
+                                        If not specified, it defaults to NotRequired.
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  RestartPolicy defines the restart behavior of individual containers in a pod.
+                                  This field may only be set for init containers, and the only allowed value is "Always".
+                                  For non-init containers or when this field is not specified,
+                                  the restart behavior is defined by the Pod's restart policy and the container type.
+                                  Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                  this init container will be continually restarted on
+                                  exit until all regular containers have terminated. Once all regular
+                                  containers have completed, all init containers with restartPolicy "Always"
+                                  will be shut down. This lifecycle differs from normal init containers and
+                                  is often referred to as a "sidecar" container. Although this init
+                                  container still starts in the init container sequence, it does not wait
+                                  for the container to complete before proceeding to the next init
+                                  container. Instead, the next init container starts immediately after this
+                                  init container is started, or after any startupProbe has successfully
+                                  completed.
+                                type: string
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default value is Default which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      This requires the ProcMountType feature flag to be enabled.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                description: |-
+                                  Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                  is not set, reads from stdin in the container will always result in EOF.
+                                  Default is false.
+                                type: boolean
+                              stdinOnce:
+                                description: |-
+                                  Whether the container runtime should close the stdin channel after it has been opened by
+                                  a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                  sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                  first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                  at which time stdin is closed and remains closed until the container is restarted. If this
+                                  flag is false, a container processes that reads from stdin will never receive an EOF.
+                                  Default is false
+                                type: boolean
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              tty:
+                                description: |-
+                                  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  Default is false.
+                                type: boolean
+                              volumeDevices:
+                                description: volumeDevices is the list of block devices to be used by the container.
+                                items:
+                                  description: volumeDevice describes a mapping of a raw block device within a container.
+                                  properties:
+                                    devicePath:
+                                      description: devicePath is the path inside of the container that the device will be mapped to.
+                                      type: string
+                                    name:
+                                      description: name must match the name of a persistentVolumeClaim in the pod
+                                      type: string
+                                  required:
+                                    - devicePath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        additionalInitContainers:
+                          description: AdditionalInitContainers allows adding additional init containers to the Control Plane deployment.
+                          items:
+                            description: A single application container that you want to run within a pod.
+                            properties:
+                              args:
+                                description: |-
+                                  Arguments to the entrypoint.
+                                  The container image's CMD is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              command:
+                                description: |-
+                                  Entrypoint array. Not executed within a shell.
+                                  The container image's ENTRYPOINT is used if this is not provided.
+                                  Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                  cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                  produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Cannot be updated.
+                                  More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              env:
+                                description: |-
+                                  List of environment variables to set in the container.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvVar represents an environment variable present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to select from.  Must be a valid secret key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          required:
+                                            - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - name
+                                x-kubernetes-list-type: map
+                              envFrom:
+                                description: |-
+                                  List of sources to populate environment variables in the container.
+                                  The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                  will be reported as an event when the container is starting. When a key exists in multiple
+                                  sources, the value associated with the last source will take precedence.
+                                  Values defined by an Env with a duplicate key will take precedence.
+                                  Cannot be updated.
+                                items:
+                                  description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                                  properties:
+                                    configMapRef:
+                                      description: The ConfigMap to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    prefix:
+                                      description: Optional text to prepend to the name of each environment variable. Must be a C_IDENTIFIER.
+                                      type: string
+                                    secretRef:
+                                      description: The Secret to select from
+                                      properties:
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret must be defined
+                                          type: boolean
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              image:
+                                description: |-
+                                  Container image name.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images
+                                  This field is optional to allow higher level config management to default or override
+                                  container images in workload controllers like Deployments and StatefulSets.
+                                type: string
+                              imagePullPolicy:
+                                description: |-
+                                  Image pull policy.
+                                  One of Always, Never, IfNotPresent.
+                                  Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                type: string
+                              lifecycle:
+                                description: |-
+                                  Actions that the management system should take in response to container lifecycle events.
+                                  Cannot be updated.
+                                properties:
+                                  postStart:
+                                    description: |-
+                                      PostStart is called immediately after a container is created. If the handler fails,
+                                      the container is terminated and restarted according to its restart policy.
+                                      Other management of the container blocks until the hook completes.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    description: |-
+                                      PreStop is called immediately before a container is terminated due to an
+                                      API request or management event such as liveness/startup probe failure,
+                                      preemption, resource contention, etc. The handler is not called if the
+                                      container crashes or exits. The Pod's termination grace period countdown begins before the
+                                      PreStop hook is executed. Regardless of the outcome of the handler, the
+                                      container will eventually terminate within the Pod's termination grace
+                                      period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                      or until the termination grace period is reached.
+                                      More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                    properties:
+                                      exec:
+                                        description: Exec specifies a command to execute in the container.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies an HTTP GET request to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                                - name
+                                                - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                          - port
+                                        type: object
+                                      sleep:
+                                        description: Sleep represents a duration that the container should sleep.
+                                        properties:
+                                          seconds:
+                                            description: Seconds is the number of seconds to sleep.
+                                            format: int64
+                                            type: integer
+                                        required:
+                                          - seconds
+                                        type: object
+                                      tcpSocket:
+                                        description: |-
+                                          Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                          for backward compatibility. There is no validation of this field and
+                                          lifecycle hooks will fail at runtime when it is specified.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                          - port
+                                        type: object
+                                    type: object
+                                  stopSignal:
+                                    description: |-
+                                      StopSignal defines which signal will be sent to a container when it is being stopped.
+                                      If not specified, the default is defined by the container runtime in use.
+                                      StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                    type: string
+                                type: object
+                              livenessProbe:
+                                description: |-
+                                  Periodic probe of container liveness.
+                                  Container will be restarted if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                description: |-
+                                  Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
+                                  Cannot be updated.
+                                type: string
+                              ports:
+                                description: |-
+                                  List of ports to expose from the container. Not specifying a port here
+                                  DOES NOT prevent that port from being exposed. Any port which is
+                                  listening on the default "0.0.0.0" address inside a container will be
+                                  accessible from the network.
+                                  Modifying this array with strategic merge patch may corrupt the data.
+                                  For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                  Cannot be updated.
+                                items:
+                                  description: ContainerPort represents a network port in a single container.
+                                  properties:
+                                    containerPort:
+                                      description: |-
+                                        Number of port to expose on the pod's IP address.
+                                        This must be a valid port number, 0 < x < 65536.
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      description: What host IP to bind the external port to.
+                                      type: string
+                                    hostPort:
+                                      description: |-
+                                        Number of port to expose on the host.
+                                        If specified, this must be a valid port number, 0 < x < 65536.
+                                        If HostNetwork is specified, this must match ContainerPort.
+                                        Most containers do not need this.
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      description: |-
+                                        If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                        named port in a pod must have a unique name. Name for the port that can be
+                                        referred to by services.
+                                      type: string
+                                    protocol:
+                                      default: TCP
+                                      description: |-
+                                        Protocol for port. Must be UDP, TCP, or SCTP.
+                                        Defaults to "TCP".
+                                      type: string
+                                  required:
+                                    - containerPort
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - containerPort
+                                  - protocol
+                                x-kubernetes-list-type: map
+                              readinessProbe:
+                                description: |-
+                                  Periodic probe of container service readiness.
+                                  Container will be removed from service endpoints if the probe fails.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resizePolicy:
+                                description: Resources resize policy for the container.
+                                items:
+                                  description: ContainerResizePolicy represents resource resize policy for the container.
+                                  properties:
+                                    resourceName:
+                                      description: |-
+                                        Name of the resource to which this resource resize policy applies.
+                                        Supported values: cpu, memory.
+                                      type: string
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy to apply when specified resource is resized.
+                                        If not specified, it defaults to NotRequired.
+                                      type: string
+                                  required:
+                                    - resourceName
+                                    - restartPolicy
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              resources:
+                                description: |-
+                                  Compute Resources required by this container.
+                                  Cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                properties:
+                                  claims:
+                                    description: |-
+                                      Claims lists the names of resources, defined in spec.resourceClaims,
+                                      that are used by this container.
+
+                                      This is an alpha field and requires enabling the
+                                      DynamicResourceAllocation feature gate.
+
+                                      This field is immutable. It can only be set for containers.
+                                    items:
+                                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name must match the name of one entry in pod.spec.resourceClaims of
+                                            the Pod where this field is used. It makes that resource available
+                                            inside a container.
+                                          type: string
+                                        request:
+                                          description: |-
+                                            Request is the name chosen for a request in the referenced claim.
+                                            If empty, everything from the claim is made available, otherwise
+                                            only the result of this request.
+                                          type: string
+                                      required:
+                                        - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                      - name
+                                    x-kubernetes-list-type: map
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Limits describes the maximum amount of compute resources allowed.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    description: |-
+                                      Requests describes the minimum amount of compute resources required.
+                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    type: object
+                                type: object
+                              restartPolicy:
+                                description: |-
+                                  RestartPolicy defines the restart behavior of individual containers in a pod.
+                                  This field may only be set for init containers, and the only allowed value is "Always".
+                                  For non-init containers or when this field is not specified,
+                                  the restart behavior is defined by the Pod's restart policy and the container type.
+                                  Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                  this init container will be continually restarted on
+                                  exit until all regular containers have terminated. Once all regular
+                                  containers have completed, all init containers with restartPolicy "Always"
+                                  will be shut down. This lifecycle differs from normal init containers and
+                                  is often referred to as a "sidecar" container. Although this init
+                                  container still starts in the init container sequence, it does not wait
+                                  for the container to complete before proceeding to the next init
+                                  container. Instead, the next init container starts immediately after this
+                                  init container is started, or after any startupProbe has successfully
+                                  completed.
+                                type: string
+                              securityContext:
+                                description: |-
+                                  SecurityContext defines the security options the container should be run with.
+                                  If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                  More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    description: |-
+                                      AllowPrivilegeEscalation controls whether a process can gain more
+                                      privileges than its parent process. This bool directly controls if
+                                      the no_new_privs flag will be set on the container process.
+                                      AllowPrivilegeEscalation is true always when the container is:
+                                      1) run as Privileged
+                                      2) has CAP_SYS_ADMIN
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  appArmorProfile:
+                                    description: |-
+                                      appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                      overrides the pod's appArmorProfile.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile loaded on the node that should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must match the loaded name of the profile.
+                                          Must be set if and only if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of AppArmor profile will be applied.
+                                          Valid options are:
+                                            Localhost - a profile pre-loaded on the node.
+                                            RuntimeDefault - the container runtime's default profile.
+                                            Unconfined - no AppArmor enforcement.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  capabilities:
+                                    description: |-
+                                      The capabilities to add/drop when running containers.
+                                      Defaults to the default set of capabilities granted by the container runtime.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      add:
+                                        description: Added capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      drop:
+                                        description: Removed capabilities
+                                        items:
+                                          description: Capability represent POSIX capabilities type
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  privileged:
+                                    description: |-
+                                      Run container in privileged mode.
+                                      Processes in privileged containers are essentially equivalent to root on the host.
+                                      Defaults to false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  procMount:
+                                    description: |-
+                                      procMount denotes the type of proc mount to use for the containers.
+                                      The default value is Default which uses the container runtime defaults for
+                                      readonly paths and masked paths.
+                                      This requires the ProcMountType feature flag to be enabled.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    description: |-
+                                      Whether this container has a read-only root filesystem.
+                                      Default is false.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    type: boolean
+                                  runAsGroup:
+                                    description: |-
+                                      The GID to run the entrypoint of the container process.
+                                      Uses runtime default if unset.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    description: |-
+                                      Indicates that the container must run as a non-root user.
+                                      If true, the Kubelet will validate the image at runtime to ensure that it
+                                      does not run as UID 0 (root) and fail to start the container if it does.
+                                      If unset or false, no such validation will be performed.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    type: boolean
+                                  runAsUser:
+                                    description: |-
+                                      The UID to run the entrypoint of the container process.
+                                      Defaults to user specified in image metadata if unspecified.
+                                      May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    description: |-
+                                      The SELinux context to be applied to the container.
+                                      If unspecified, the container runtime will allocate a random SELinux context for each
+                                      container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      level:
+                                        description: Level is SELinux level label that applies to the container.
+                                        type: string
+                                      role:
+                                        description: Role is a SELinux role label that applies to the container.
+                                        type: string
+                                      type:
+                                        description: Type is a SELinux type label that applies to the container.
+                                        type: string
+                                      user:
+                                        description: User is a SELinux user label that applies to the container.
+                                        type: string
+                                    type: object
+                                  seccompProfile:
+                                    description: |-
+                                      The seccomp options to use by this container. If seccomp options are
+                                      provided at both the pod & container level, the container options
+                                      override the pod options.
+                                      Note that this field cannot be set when spec.os.name is windows.
+                                    properties:
+                                      localhostProfile:
+                                        description: |-
+                                          localhostProfile indicates a profile defined in a file on the node should be used.
+                                          The profile must be preconfigured on the node to work.
+                                          Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                          Must be set if type is "Localhost". Must NOT be set for any other type.
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type indicates which kind of seccomp profile will be applied.
+                                          Valid options are:
+
+                                          Localhost - a profile defined in a file on the node should be used.
+                                          RuntimeDefault - the container runtime default profile should be used.
+                                          Unconfined - no profile should be applied.
+                                        type: string
+                                    required:
+                                      - type
+                                    type: object
+                                  windowsOptions:
+                                    description: |-
+                                      The Windows specific settings applied to all containers.
+                                      If unspecified, the options from the PodSecurityContext will be used.
+                                      If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      Note that this field cannot be set when spec.os.name is linux.
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        description: |-
+                                          GMSACredentialSpec is where the GMSA admission webhook
+                                          (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                          GMSA credential spec named by the GMSACredentialSpecName field.
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                        type: string
+                                      hostProcess:
+                                        description: |-
+                                          HostProcess determines if a container should be run as a 'Host Process' container.
+                                          All of a Pod's containers must have the same effective HostProcess value
+                                          (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                          In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                        type: boolean
+                                      runAsUserName:
+                                        description: |-
+                                          The UserName in Windows to run the entrypoint of the container process.
+                                          Defaults to the user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext. If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                description: |-
+                                  StartupProbe indicates that the Pod has successfully initialized.
+                                  If specified, no other probes are executed until this completes successfully.
+                                  If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                  This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                  when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                  This cannot be updated.
+                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                properties:
+                                  exec:
+                                    description: Exec specifies a command to execute in the container.
+                                    properties:
+                                      command:
+                                        description: |-
+                                          Command is the command line to execute inside the container, the working directory for the
+                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                          a shell, you need to explicitly call out to that shell.
+                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  failureThreshold:
+                                    description: |-
+                                      Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  grpc:
+                                    description: GRPC specifies a GRPC HealthCheckRequest.
+                                    properties:
+                                      port:
+                                        description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                        format: int32
+                                        type: integer
+                                      service:
+                                        default: ""
+                                        description: |-
+                                          Service is the name of the service to place in the gRPC HealthCheckRequest
+                                          (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                          If this is not specified, the default behavior is defined by gRPC.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  httpGet:
+                                    description: HTTPGet specifies an HTTP GET request to perform.
+                                    properties:
+                                      host:
+                                        description: |-
+                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                          "Host" in httpHeaders instead.
+                                        type: string
+                                      httpHeaders:
+                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                        items:
+                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                          properties:
+                                            name:
+                                              description: |-
+                                                The header field name.
+                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                              type: string
+                                            value:
+                                              description: The header field value
+                                              type: string
+                                          required:
+                                            - name
+                                            - value
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: Path to access on the HTTP server.
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Name or number of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        description: |-
+                                          Scheme to use for connecting to the host.
+                                          Defaults to HTTP.
+                                        type: string
+                                    required:
+                                      - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    description: |-
+                                      Number of seconds after the container has started before liveness probes are initiated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    description: |-
+                                      How often (in seconds) to perform the probe.
+                                      Default to 10 seconds. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    description: |-
+                                      Minimum consecutive successes for the probe to be considered successful after having failed.
+                                      Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    description: TCPSocket specifies a connection to a TCP port.
+                                    properties:
+                                      host:
+                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                        type: string
+                                      port:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: |-
+                                          Number or name of the port to access on the container.
+                                          Number must be in the range 1 to 65535.
+                                          Name must be an IANA_SVC_NAME.
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                      - port
+                                    type: object
+                                  terminationGracePeriodSeconds:
+                                    description: |-
+                                      Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                      The grace period is the duration in seconds after the processes running in the pod are sent
+                                      a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                      Set this value longer than the expected cleanup time for your process.
+                                      If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                      value overrides the value provided by the pod spec.
+                                      Value must be non-negative integer. The value zero indicates stop immediately via
+                                      the kill signal (no opportunity to shut down).
+                                      This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                      Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                    format: int64
+                                    type: integer
+                                  timeoutSeconds:
+                                    description: |-
+                                      Number of seconds after which the probe times out.
+                                      Defaults to 1 second. Minimum value is 1.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                description: |-
+                                  Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                  is not set, reads from stdin in the container will always result in EOF.
+                                  Default is false.
+                                type: boolean
+                              stdinOnce:
+                                description: |-
+                                  Whether the container runtime should close the stdin channel after it has been opened by
+                                  a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                  sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                  first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                  at which time stdin is closed and remains closed until the container is restarted. If this
+                                  flag is false, a container processes that reads from stdin will never receive an EOF.
+                                  Default is false
+                                type: boolean
+                              terminationMessagePath:
+                                description: |-
+                                  Optional: Path at which the file to which the container's termination message
+                                  will be written is mounted into the container's filesystem.
+                                  Message written is intended to be brief final status, such as an assertion failure message.
+                                  Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                  all containers will be limited to 12kb.
+                                  Defaults to /dev/termination-log.
+                                  Cannot be updated.
+                                type: string
+                              terminationMessagePolicy:
+                                description: |-
+                                  Indicate how the termination message should be populated. File will use the contents of
+                                  terminationMessagePath to populate the container status message on both success and failure.
+                                  FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                  message file is empty and the container exited with an error.
+                                  The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                  Defaults to File.
+                                  Cannot be updated.
+                                type: string
+                              tty:
+                                description: |-
+                                  Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                  Default is false.
+                                type: boolean
+                              volumeDevices:
+                                description: volumeDevices is the list of block devices to be used by the container.
+                                items:
+                                  description: volumeDevice describes a mapping of a raw block device within a container.
+                                  properties:
+                                    devicePath:
+                                      description: devicePath is the path inside of the container that the device will be mapped to.
+                                      type: string
+                                    name:
+                                      description: name must match the name of a persistentVolumeClaim in the pod
+                                      type: string
+                                  required:
+                                    - devicePath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - devicePath
+                                x-kubernetes-list-type: map
+                              volumeMounts:
+                                description: |-
+                                  Pod volumes to mount into the container's filesystem.
+                                  Cannot be updated.
+                                items:
+                                  description: VolumeMount describes a mounting of a Volume within a container.
+                                  properties:
+                                    mountPath:
+                                      description: |-
+                                        Path within the container at which the volume should be mounted.  Must
+                                        not contain ':'.
+                                      type: string
+                                    mountPropagation:
+                                      description: |-
+                                        mountPropagation determines how mounts are propagated from the host
+                                        to container and the other way around.
+                                        When not set, MountPropagationNone is used.
+                                        This field is beta in 1.10.
+                                        When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                        (which defaults to None).
+                                      type: string
+                                    name:
+                                      description: This must match the Name of a Volume.
+                                      type: string
+                                    readOnly:
+                                      description: |-
+                                        Mounted read-only if true, read-write otherwise (false or unspecified).
+                                        Defaults to false.
+                                      type: boolean
+                                    recursiveReadOnly:
+                                      description: |-
+                                        RecursiveReadOnly specifies whether read-only mounts should be handled
+                                        recursively.
+
+                                        If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                        If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                        recursively read-only.  If this field is set to IfPossible, the mount is made
+                                        recursively read-only, if it is supported by the container runtime.  If this
+                                        field is set to Enabled, the mount is made recursively read-only if it is
+                                        supported by the container runtime, otherwise the pod will not be started and
+                                        an error will be generated to indicate the reason.
+
+                                        If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                        None (or be unspecified, which defaults to None).
+
+                                        If this field is not specified, it is treated as an equivalent of Disabled.
+                                      type: string
+                                    subPath:
+                                      description: |-
+                                        Path within the volume from which the container's volume should be mounted.
+                                        Defaults to "" (volume's root).
+                                      type: string
+                                    subPathExpr:
+                                      description: |-
+                                        Expanded path within the volume from which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                        Defaults to "" (volume's root).
+                                        SubPathExpr and SubPath are mutually exclusive.
+                                      type: string
+                                  required:
+                                    - mountPath
+                                    - name
+                                  type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                  - mountPath
+                                x-kubernetes-list-type: map
+                              workingDir:
+                                description: |-
+                                  Container's working directory.
+                                  If not specified, the container runtime's default will be used, which
+                                  might be configured in the container image.
+                                  Cannot be updated.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        additionalMetadata:
+                          description: AdditionalMetadata defines which additional metadata, such as labels and annotations, must be attached to the created resource.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        additionalVolumeMounts:
+                          description: |-
+                            AdditionalVolumeMounts allows to mount an additional volume into each component of the Control Plane
+                            (kube-apiserver, controller-manager, and scheduler).
+                          properties:
+                            apiServer:
+                              items:
+                                description: VolumeMount describes a mounting of a Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                            controllerManager:
+                              items:
+                                description: VolumeMount describes a mounting of a Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                            scheduler:
+                              items:
+                                description: VolumeMount describes a mounting of a Volume within a container.
+                                properties:
+                                  mountPath:
+                                    description: |-
+                                      Path within the container at which the volume should be mounted.  Must
+                                      not contain ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: |-
+                                      mountPropagation determines how mounts are propagated from the host
+                                      to container and the other way around.
+                                      When not set, MountPropagationNone is used.
+                                      This field is beta in 1.10.
+                                      When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                      (which defaults to None).
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      Mounted read-only if true, read-write otherwise (false or unspecified).
+                                      Defaults to false.
+                                    type: boolean
+                                  recursiveReadOnly:
+                                    description: |-
+                                      RecursiveReadOnly specifies whether read-only mounts should be handled
+                                      recursively.
+
+                                      If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                      If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                      recursively read-only.  If this field is set to IfPossible, the mount is made
+                                      recursively read-only, if it is supported by the container runtime.  If this
+                                      field is set to Enabled, the mount is made recursively read-only if it is
+                                      supported by the container runtime, otherwise the pod will not be started and
+                                      an error will be generated to indicate the reason.
+
+                                      If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                      None (or be unspecified, which defaults to None).
+
+                                      If this field is not specified, it is treated as an equivalent of Disabled.
+                                    type: string
+                                  subPath:
+                                    description: |-
+                                      Path within the volume from which the container's volume should be mounted.
+                                      Defaults to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: |-
+                                      Expanded path within the volume from which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                      Defaults to "" (volume's root).
+                                      SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                          type: object
+                        additionalVolumes:
+                          description: AdditionalVolumes allows to add additional volumes to the Control Plane deployment.
+                          items:
+                            description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                            properties:
+                              awsElasticBlockStore:
+                                description: |-
+                                  awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                                  awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: string
+                                  partition:
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: |-
+                                      readOnly value true will force the readOnly setting in VolumeMounts.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: boolean
+                                  volumeID:
+                                    description: |-
+                                      volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              azureDisk:
+                                description: |-
+                                  azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                  Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                                  are redirected to the disk.csi.azure.com CSI driver.
+                                properties:
+                                  cachingMode:
+                                    description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                    type: string
+                                  diskName:
+                                    description: diskName is the Name of the data disk in the blob storage
+                                    type: string
+                                  diskURI:
+                                    description: diskURI is the URI of data disk in the blob storage
+                                    type: string
+                                  fsType:
+                                    default: ext4
+                                    description: |-
+                                      fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  kind:
+                                    description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                    type: string
+                                  readOnly:
+                                    default: false
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                required:
+                                  - diskName
+                                  - diskURI
+                                type: object
+                              azureFile:
+                                description: |-
+                                  azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                  Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                                  are redirected to the file.csi.azure.com CSI driver.
+                                properties:
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretName:
+                                    description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                    type: string
+                                  shareName:
+                                    description: shareName is the azure share Name
+                                    type: string
+                                required:
+                                  - secretName
+                                  - shareName
+                                type: object
+                              cephfs:
+                                description: |-
+                                  cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                                  Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                                properties:
+                                  monitors:
+                                    description: |-
+                                      monitors is Required: Monitors is a collection of Ceph monitors
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  path:
+                                    description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: boolean
+                                  secretFile:
+                                    description: |-
+                                      secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: string
+                                  secretRef:
+                                    description: |-
+                                      secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    description: |-
+                                      user is optional: User is the rados user name, default is admin
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                    type: string
+                                required:
+                                  - monitors
+                                type: object
+                              cinder:
+                                description: |-
+                                  cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                                  are redirected to the cinder.csi.openstack.org CSI driver.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is optional: points to a secret object containing parameters used to connect
+                                      to OpenStack.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeID:
+                                    description: |-
+                                      volumeID used to identify the volume in cinder.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              configMap:
+                                description: configMap represents a configMap that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  optional:
+                                    description: optional specify whether the ConfigMap or its keys must be defined
+                                    type: boolean
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              csi:
+                                description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
+                                properties:
+                                  driver:
+                                    description: |-
+                                      driver is the name of the CSI driver that handles this volume.
+                                      Consult with your admin for the correct name as registered in the cluster.
+                                    type: string
+                                  fsType:
+                                    description: |-
+                                      fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                      If not provided, the empty value is passed to the associated CSI driver
+                                      which will determine the default filesystem to apply.
+                                    type: string
+                                  nodePublishSecretRef:
+                                    description: |-
+                                      nodePublishSecretRef is a reference to the secret object containing
+                                      sensitive information to pass to the CSI driver to complete the CSI
+                                      NodePublishVolume and NodeUnpublishVolume calls.
+                                      This field is optional, and  may be empty if no secret is required. If the
+                                      secret object contains more than one secret, all secret references are passed.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  readOnly:
+                                    description: |-
+                                      readOnly specifies a read-only configuration for the volume.
+                                      Defaults to false (read/write).
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      volumeAttributes stores driver-specific properties that are passed to the CSI
+                                      driver. Consult your driver's documentation for supported values.
+                                    type: object
+                                required:
+                                  - driver
+                                type: object
+                              downwardAPI:
+                                description: downwardAPI represents downward API about the pod that should populate this volume
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      Optional: mode bits to use on created files by default. Must be a
+                                      Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: Items is a list of downward API volume file
+                                    items:
+                                      description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                      properties:
+                                        fieldRef:
+                                          description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select in the specified API version.
+                                              type: string
+                                          required:
+                                            - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        mode:
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                          type: string
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                                - type: integer
+                                                - type: string
+                                              description: Specifies the output format of the exposed resources, defaults to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to select'
+                                              type: string
+                                          required:
+                                            - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      required:
+                                        - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              emptyDir:
+                                description: |-
+                                  emptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                properties:
+                                  medium:
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    type: string
+                                  sizeLimit:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                type: object
+                              ephemeral:
+                                description: |-
+                                  ephemeral represents a volume that is handled by a cluster storage driver.
+                                  The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                  and deleted when the pod is removed.
+
+                                  Use this if:
+                                  a) the volume is only needed while the pod runs,
+                                  b) features of normal volumes like restoring from snapshot or capacity
+                                     tracking are needed,
+                                  c) the storage driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning through
+                                     a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                     information on the connection between this volume type
+                                     and PersistentVolumeClaim).
+
+                                  Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the lifecycle
+                                  of an individual pod.
+
+                                  Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                  be used that way - see the documentation of the driver for
+                                  more information.
+
+                                  A pod can use both types of ephemeral volumes and
+                                  persistent volumes at the same time.
+                                properties:
+                                  volumeClaimTemplate:
+                                    description: |-
+                                      Will be used to create a stand-alone PVC to provision the volume.
+                                      The pod in which this EphemeralVolumeSource is embedded will be the
+                                      owner of the PVC, i.e. the PVC will be deleted together with the
+                                      pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes` array
+                                      entry. Pod validation will reject the pod if the concatenated name
+                                      is not valid for a PVC (for example, too long).
+
+                                      An existing PVC with that name that is not owned by the pod
+                                      will *not* be used for the pod to avoid using an unrelated
+                                      volume by mistake. Starting the pod is then blocked until
+                                      the unrelated PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to updated with an
+                                      owner reference to the pod once the pod exists. Normally
+                                      this should not be necessary, but it may be useful when
+                                      manually reconstructing a broken cluster.
+
+                                      This field is read-only and no changes will be made by Kubernetes
+                                      to the PVC after it has been created.
+
+                                      Required, must not be nil.
+                                    properties:
+                                      metadata:
+                                        description: |-
+                                          May contain labels and annotations that will be copied into the PVC
+                                          when creating it. No other fields are allowed and will be rejected during
+                                          validation.
+                                        type: object
+                                      spec:
+                                        description: |-
+                                          The specification for the PersistentVolumeClaim. The entire content is
+                                          copied unchanged into the PVC that gets created from this
+                                          template. The same fields as in a PersistentVolumeClaim
+                                          are also valid here.
+                                        properties:
+                                          accessModes:
+                                            description: |-
+                                              accessModes contains the desired access modes the volume should have.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          dataSource:
+                                            description: |-
+                                              dataSource field can be used to specify either:
+                                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                              * An existing PVC (PersistentVolumeClaim)
+                                              If the provisioner or an external controller can support the specified data source,
+                                              it will create a new volume based on the contents of the specified data source.
+                                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                            properties:
+                                              apiGroup:
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource being referenced
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          dataSourceRef:
+                                            description: |-
+                                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                              volume is desired. This may be any object from a non-empty API group (non
+                                              core object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume binding will only succeed if the type of
+                                              the specified object matches some installed volume populator or dynamic
+                                              provisioner.
+                                              This field will replace the functionality of the dataSource field and as such
+                                              if both fields are non-empty, they must have the same value. For backwards
+                                              compatibility, when namespace isn't specified in dataSourceRef,
+                                              both fields (dataSource and dataSourceRef) will be set to the same
+                                              value automatically if one of them is empty and the other is non-empty.
+                                              When namespace is specified in dataSourceRef,
+                                              dataSource isn't set to the same value and must be empty.
+                                              There are three important differences between dataSource and dataSourceRef:
+                                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                preserves all values, and generates an error if a disallowed value is
+                                                specified.
+                                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                                in any namespaces.
+                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            properties:
+                                              apiGroup:
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
+                                                type: string
+                                              kind:
+                                                description: Kind is the type of resource being referenced
+                                                type: string
+                                              name:
+                                                description: Name is the name of resource being referenced
+                                                type: string
+                                              namespace:
+                                                description: |-
+                                                  Namespace is the namespace of resource being referenced
+                                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                type: string
+                                            required:
+                                              - kind
+                                              - name
+                                            type: object
+                                          resources:
+                                            description: |-
+                                              resources represents the minimum resources the volume should have.
+                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              that are lower than previous value but must still be higher than capacity recorded in the
+                                              status field of the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                            properties:
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
+                                          selector:
+                                            description: selector is a label query over volumes to consider for binding.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          storageClassName:
+                                            description: |-
+                                              storageClassName is the name of the StorageClass required by the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                            type: string
+                                          volumeAttributesClassName:
+                                            description: |-
+                                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                              If specified, the CSI driver will create or update the volume with the attributes defined
+                                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                              will be set by the persistentvolume controller if it exists.
+                                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                              exists.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                              (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                            type: string
+                                          volumeMode:
+                                            description: |-
+                                              volumeMode defines what type of volume is required by the claim.
+                                              Value of Filesystem is implied when not included in claim spec.
+                                            type: string
+                                          volumeName:
+                                            description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                            type: string
+                                        type: object
+                                    required:
+                                      - spec
+                                    type: object
+                                type: object
+                              fc:
+                                description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  lun:
+                                    description: 'lun is Optional: FC target lun number'
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  targetWWNs:
+                                    description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  wwids:
+                                    description: |-
+                                      wwids Optional: FC volume world wide identifiers (wwids)
+                                      Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              flexVolume:
+                                description: |-
+                                  flexVolume represents a generic volume resource that is
+                                  provisioned/attached using an exec based plugin.
+                                  Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                                properties:
+                                  driver:
+                                    description: driver is the name of the driver to use for this volume.
+                                    type: string
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'options is Optional: this field holds extra command options if any.'
+                                    type: object
+                                  readOnly:
+                                    description: |-
+                                      readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is Optional: secretRef is reference to the secret object containing
+                                      sensitive information to pass to the plugin scripts. This may be
+                                      empty if no secret object is specified. If the secret object
+                                      contains more than one secret, all secrets are passed to the plugin
+                                      scripts.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                  - driver
+                                type: object
+                              flocker:
+                                description: |-
+                                  flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                                  Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                                properties:
+                                  datasetName:
+                                    description: |-
+                                      datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                      should be considered as deprecated
+                                    type: string
+                                  datasetUUID:
+                                    description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                description: |-
+                                  gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                                  gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: string
+                                  partition:
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    description: |-
+                                      pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    type: boolean
+                                required:
+                                  - pdName
+                                type: object
+                              gitRepo:
+                                description: |-
+                                  gitRepo represents a git repository at a particular revision.
+                                  Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                  EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                  into the Pod's container.
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is the target directory name.
+                                      Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                      git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                      the subdirectory with the given name.
+                                    type: string
+                                  repository:
+                                    description: repository is the URL
+                                    type: string
+                                  revision:
+                                    description: revision is the commit hash for the specified revision.
+                                    type: string
+                                required:
+                                  - repository
+                                type: object
+                              glusterfs:
+                                description: |-
+                                  glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                properties:
+                                  endpoints:
+                                    description: |-
+                                      endpoints is the endpoint name that details Glusterfs topology.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: string
+                                  path:
+                                    description: |-
+                                      path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                    type: boolean
+                                required:
+                                  - endpoints
+                                  - path
+                                type: object
+                              hostPath:
+                                description: |-
+                                  hostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                properties:
+                                  path:
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    type: string
+                                  type:
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                    type: string
+                                required:
+                                  - path
+                                type: object
+                              image:
+                                description: |-
+                                  image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                                  The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                                  - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                  - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                  - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                                  The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                                  A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                                  The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                                  The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                                  The volume will be mounted read-only (ro) and non-executable files (noexec).
+                                  Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
+                                  The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                                properties:
+                                  pullPolicy:
+                                    description: |-
+                                      Policy for pulling OCI objects. Possible values are:
+                                      Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                      Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                      IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                    type: string
+                                  reference:
+                                    description: |-
+                                      Required: Image or artifact reference to be used.
+                                      Behaves in the same way as pod.spec.containers[*].image.
+                                      Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
+                                type: object
+                              iscsi:
+                                description: |-
+                                  iscsi represents an ISCSI Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                properties:
+                                  chapAuthDiscovery:
+                                    description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                    type: boolean
+                                  chapAuthSession:
+                                    description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                    type: boolean
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    type: string
+                                  initiatorName:
+                                    description: |-
+                                      initiatorName is the custom iSCSI Initiator Name.
+                                      If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                      <target portal>:<volume name> will be created for the connection.
+                                    type: string
+                                  iqn:
+                                    description: iqn is the target iSCSI Qualified Name.
+                                    type: string
+                                  iscsiInterface:
+                                    default: default
+                                    description: |-
+                                      iscsiInterface is the interface Name that uses an iSCSI transport.
+                                      Defaults to 'default' (tcp).
+                                    type: string
+                                  lun:
+                                    description: lun represents iSCSI Target Lun number.
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    description: |-
+                                      portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                    type: boolean
+                                  secretRef:
+                                    description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  targetPortal:
+                                    description: |-
+                                      targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
+                                    type: string
+                                required:
+                                  - iqn
+                                  - lun
+                                  - targetPortal
+                                type: object
+                              name:
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              nfs:
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                properties:
+                                  path:
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: boolean
+                                  server:
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    type: string
+                                required:
+                                  - path
+                                  - server
+                                type: object
+                              persistentVolumeClaim:
+                                description: |-
+                                  persistentVolumeClaimVolumeSource represents a reference to a
+                                  PersistentVolumeClaim in the same namespace.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                properties:
+                                  claimName:
+                                    description: |-
+                                      claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly Will force the ReadOnly setting in VolumeMounts.
+                                      Default false.
+                                    type: boolean
+                                required:
+                                  - claimName
+                                type: object
+                              photonPersistentDisk:
+                                description: |-
+                                  photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                                  Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  pdID:
+                                    description: pdID is the ID that identifies Photon Controller persistent disk
+                                    type: string
+                                required:
+                                  - pdID
+                                type: object
+                              portworxVolume:
+                                description: |-
+                                  portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                                  Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                                  are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                                  is on.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fSType represents the filesystem type to mount
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  volumeID:
+                                    description: volumeID uniquely identifies a Portworx volume
+                                    type: string
+                                required:
+                                  - volumeID
+                                type: object
+                              projected:
+                                description: projected items for all in one resources secrets, configmaps, and downward API
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    description: |-
+                                      sources is the list of volume projections. Each entry in this list
+                                      handles one source.
+                                    items:
+                                      description: |-
+                                        Projection that may be projected along with other supported volume types.
+                                        Exactly one of these fields must be set.
+                                      properties:
+                                        clusterTrustBundle:
+                                          description: |-
+                                            ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                            of ClusterTrustBundle objects in an auto-updating file.
+
+                                            Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                            ClusterTrustBundle objects can either be selected by name, or by the
+                                            combination of signer name and a label selector.
+
+                                            Kubelet performs aggressive normalization of the PEM contents written
+                                            into the pod filesystem.  Esoteric PEM features such as inter-block
+                                            comments and block headers are stripped.  Certificates are deduplicated.
+                                            The ordering of certificates within the file is arbitrary, and Kubelet
+                                            may change the order over time.
+                                          properties:
+                                            labelSelector:
+                                              description: |-
+                                                Select all ClusterTrustBundles that match this label selector.  Only has
+                                                effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                everything".
+                                              properties:
+                                                matchExpressions:
+                                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                  items:
+                                                    description: |-
+                                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                                      relates the key and values.
+                                                    properties:
+                                                      key:
+                                                        description: key is the label key that the selector applies to.
+                                                        type: string
+                                                      operator:
+                                                        description: |-
+                                                          operator represents a key's relationship to a set of values.
+                                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                        type: string
+                                                      values:
+                                                        description: |-
+                                                          values is an array of string values. If the operator is In or NotIn,
+                                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                          the values array must be empty. This array is replaced during a strategic
+                                                          merge patch.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    required:
+                                                      - key
+                                                      - operator
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                matchLabels:
+                                                  additionalProperties:
+                                                    type: string
+                                                  description: |-
+                                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                  type: object
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            name:
+                                              description: |-
+                                                Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                with signerName and labelSelector.
+                                              type: string
+                                            optional:
+                                              description: |-
+                                                If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                aren't available.  If using name, then the named ClusterTrustBundle is
+                                                allowed not to exist.  If using signerName, then the combination of
+                                                signerName and labelSelector is allowed to match zero
+                                                ClusterTrustBundles.
+                                              type: boolean
+                                            path:
+                                              description: Relative path from the volume root to write the bundle.
+                                              type: string
+                                            signerName:
+                                              description: |-
+                                                Select all ClusterTrustBundles that match this signer name.
+                                                Mutually-exclusive with name.  The contents of all selected
+                                                ClusterTrustBundles will be unified and deduplicated.
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                        configMap:
+                                          description: configMap information about the configMap data to project
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: optional specify whether the ConfigMap or its keys must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        downwardAPI:
+                                          description: downwardAPI information about the downwardAPI data to project
+                                          properties:
+                                            items:
+                                              description: Items is a list of DownwardAPIVolume file
+                                              items:
+                                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                properties:
+                                                  fieldRef:
+                                                    description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                                    properties:
+                                                      apiVersion:
+                                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                        type: string
+                                                      fieldPath:
+                                                        description: Path of the field to select in the specified API version.
+                                                        type: string
+                                                    required:
+                                                      - fieldPath
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  mode:
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                    properties:
+                                                      containerName:
+                                                        description: 'Container name: required for volumes, optional for env vars'
+                                                        type: string
+                                                      divisor:
+                                                        anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                        x-kubernetes-int-or-string: true
+                                                      resource:
+                                                        description: 'Required: resource to select'
+                                                        type: string
+                                                    required:
+                                                      - resource
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                required:
+                                                  - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          type: object
+                                        secret:
+                                          description: secret information about the secret data to project
+                                          properties:
+                                            items:
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
+                                              items:
+                                                description: Maps a string key to a path within a volume.
+                                                properties:
+                                                  key:
+                                                    description: key is the key to project.
+                                                    type: string
+                                                  mode:
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
+                                                    type: string
+                                                required:
+                                                  - key
+                                                  - path
+                                                type: object
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: optional field specify whether the Secret or its key must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        serviceAccountToken:
+                                          description: serviceAccountToken is information about the serviceAccountToken data to project
+                                          properties:
+                                            audience:
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
+                                              type: string
+                                            expirationSeconds:
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
+                                              type: string
+                                          required:
+                                            - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              quobyte:
+                                description: |-
+                                  quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                                  Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                                properties:
+                                  group:
+                                    description: |-
+                                      group to map volume access to
+                                      Default is no group
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                    type: boolean
+                                  registry:
+                                    description: |-
+                                      registry represents a single or multiple Quobyte Registry services
+                                      specified as a string as host:port pair (multiple entries are separated with commas)
+                                      which acts as the central registry for volumes
+                                    type: string
+                                  tenant:
+                                    description: |-
+                                      tenant owning the given Quobyte volume in the Backend
+                                      Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                    type: string
+                                  user:
+                                    description: |-
+                                      user to map volume access to
+                                      Defaults to serivceaccount user
+                                    type: string
+                                  volume:
+                                    description: volume is a string that references an already created Quobyte volume by name.
+                                    type: string
+                                required:
+                                  - registry
+                                  - volume
+                                type: object
+                              rbd:
+                                description: |-
+                                  rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    type: string
+                                  image:
+                                    description: |-
+                                      image is the rados image name.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  keyring:
+                                    default: /etc/ceph/keyring
+                                    description: |-
+                                      keyring is the path to key ring for RBDUser.
+                                      Default is /etc/ceph/keyring.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  monitors:
+                                    description: |-
+                                      monitors is a collection of Ceph monitors.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  pool:
+                                    default: rbd
+                                    description: |-
+                                      pool is the rados pool name.
+                                      Default is rbd.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef is name of the authentication secret for RBDUser. If provided
+                                      overrides keyring.
+                                      Default is nil.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  user:
+                                    default: admin
+                                    description: |-
+                                      user is the rados user name.
+                                      Default is admin.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                    type: string
+                                required:
+                                  - image
+                                  - monitors
+                                type: object
+                              scaleIO:
+                                description: |-
+                                  scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                                properties:
+                                  fsType:
+                                    default: xfs
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs".
+                                      Default is "xfs".
+                                    type: string
+                                  gateway:
+                                    description: gateway is the host address of the ScaleIO API Gateway.
+                                    type: string
+                                  protectionDomain:
+                                    description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef references to the secret for ScaleIO user and other
+                                      sensitive information. If this is not provided, Login operation will fail.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  sslEnabled:
+                                    description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                    type: boolean
+                                  storageMode:
+                                    default: ThinProvisioned
+                                    description: |-
+                                      storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                      Default is ThinProvisioned.
+                                    type: string
+                                  storagePool:
+                                    description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                    type: string
+                                  system:
+                                    description: system is the name of the storage system as configured in ScaleIO.
+                                    type: string
+                                  volumeName:
+                                    description: |-
+                                      volumeName is the name of a volume already created in the ScaleIO system
+                                      that is associated with this volume source.
+                                    type: string
+                                required:
+                                  - gateway
+                                  - secretRef
+                                  - system
+                                type: object
+                              secret:
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                properties:
+                                  defaultMode:
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
+                                    items:
+                                      description: Maps a string key to a path within a volume.
+                                      properties:
+                                        key:
+                                          description: key is the key to project.
+                                          type: string
+                                        mode:
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
+                                          type: string
+                                      required:
+                                        - key
+                                        - path
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  optional:
+                                    description: optional field specify whether the Secret or its keys must be defined
+                                    type: boolean
+                                  secretName:
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    type: string
+                                type: object
+                              storageos:
+                                description: |-
+                                  storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                  Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  readOnly:
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                    type: boolean
+                                  secretRef:
+                                    description: |-
+                                      secretRef specifies the secret to use for obtaining the StorageOS API
+                                      credentials.  If not specified, default values will be attempted.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  volumeName:
+                                    description: |-
+                                      volumeName is the human-readable name of the StorageOS volume.  Volume
+                                      names are only unique within a namespace.
+                                    type: string
+                                  volumeNamespace:
+                                    description: |-
+                                      volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                      namespace is specified then the Pod's namespace will be used.  This allows the
+                                      Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                      Set VolumeName to any name to override the default behaviour.
+                                      Set to "default" if you are not using namespaces within StorageOS.
+                                      Namespaces that do not pre-exist within StorageOS will be created.
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                description: |-
+                                  vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                                  Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                                  are redirected to the csi.vsphere.vmware.com CSI driver.
+                                properties:
+                                  fsType:
+                                    description: |-
+                                      fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                    type: string
+                                  storagePolicyID:
+                                    description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                    type: string
+                                  storagePolicyName:
+                                    description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                    type: string
+                                  volumePath:
+                                    description: volumePath is the path that identifies vSphere volume vmdk
+                                    type: string
+                                required:
+                                  - volumePath
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        affinity:
+                          description: |-
+                            If specified, the Tenant Control Plane pod's scheduling constraints.
+                            More info: https://kubernetes.io/docs/tasks/configure-pod-container/assign-pods-nodes-using-node-affinity/
+                          properties:
+                            nodeAffinity:
+                              description: Describes node affinity scheduling rules for the pod.
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: |-
+                                      An empty preferred scheduling term matches all objects with implicit weight 0
+                                      (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                    properties:
+                                      preference:
+                                        description: A node selector term, associated with the corresponding weight.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements by node's labels.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchFields:
+                                            description: A list of node selector requirements by node's fields.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      weight:
+                                        description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - preference
+                                      - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to an update), the system
+                                    may or may not try to eventually evict the pod from its node.
+                                  properties:
+                                    nodeSelectorTerms:
+                                      description: Required. A list of node selector terms. The terms are ORed.
+                                      items:
+                                        description: |-
+                                          A null or empty node selector term matches no objects. The requirements of
+                                          them are ANDed.
+                                          The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                        properties:
+                                          matchExpressions:
+                                            description: A list of node selector requirements by node's labels.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchFields:
+                                            description: A list of node selector requirements by node's fields.
+                                            items:
+                                              description: |-
+                                                A node selector requirement is a selector that contains values, a key, and an operator
+                                                that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: The label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    Represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    An array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                    array must have a single element, which will be interpreted as an integer.
+                                                    This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - nodeSelectorTerms
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                            podAffinity:
+                              description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term, associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                          - topologyKey
+                                        type: object
+                                      weight:
+                                        description: |-
+                                          weight associated with matching the corresponding podAffinityTerm,
+                                          in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - podAffinityTerm
+                                      - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes corresponding to each
+                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: |-
+                                      Defines a set of pods (namely those matching the labelSelector
+                                      relative to the given namespace(s)) that this pod should be
+                                      co-located (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node whose value of
+                                      the label with key <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                    the anti-affinity expressions specified by this field, but it may choose
+                                    a node that violates one or more of the expressions. The node that is
+                                    most preferred is the one with the greatest sum of weights, i.e.
+                                    for each node that meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                    compute a sum by iterating through the elements of this field and adding
+                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                    node(s) with the highest sum are the most preferred.
+                                  items:
+                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                    properties:
+                                      podAffinityTerm:
+                                        description: Required. A pod affinity term, associated with the corresponding weight.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                    - key
+                                                    - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                          - topologyKey
+                                        type: object
+                                      weight:
+                                        description: |-
+                                          weight associated with matching the corresponding podAffinityTerm,
+                                          in the range 1-100.
+                                        format: int32
+                                        type: integer
+                                    required:
+                                      - podAffinityTerm
+                                      - weight
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: |-
+                                    If the anti-affinity requirements specified by this field are not met at
+                                    scheduling time, the pod will not be scheduled onto the node.
+                                    If the anti-affinity requirements specified by this field cease to be met
+                                    at some point during pod execution (e.g. due to a pod label update), the
+                                    system may or may not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes corresponding to each
+                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                  items:
+                                    description: |-
+                                      Defines a set of pods (namely those matching the labelSelector
+                                      relative to the given namespace(s)) that this pod should be
+                                      co-located (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node whose value of
+                                      the label with key <topologyKey> matches that of any node on which
+                                      a pod of the set of pods is running
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                          Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                          Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                          type: object
+                        extraArgs:
+                          description: |-
+                            ExtraArgs allows adding additional arguments to the Control Plane components,
+                            such as kube-apiserver, controller-manager, and scheduler. WARNING - This option
+                            can override existing parameters and cause components to misbehave in unxpected ways.
+                            Only modify if you know what you are doing.
+                          properties:
+                            apiServer:
+                              items:
+                                type: string
+                              type: array
+                            controllerManager:
+                              items:
+                                type: string
+                              type: array
+                            kine:
+                              description: Available only if Kamaji is running using Kine as backing storage.
+                              items:
+                                type: string
+                              type: array
+                            scheduler:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            NodeSelector is a selector which must be true for the pod to fit on a node.
+                            Selector which must match a node's labels for the pod to be scheduled on that node.
+                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                          type: object
+                        podAdditionalMetadata:
+                          description: AdditionalMetadata defines which additional metadata, such as labels and annotations, must be attached to the created resource.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        registrySettings:
+                          default:
+                            apiServerImage: kube-apiserver
+                            controllerManagerImage: kube-controller-manager
+                            registry: registry.k8s.io
+                            schedulerImage: kube-scheduler
+                          description: |-
+                            RegistrySettings allows to override the default images for the given Tenant Control Plane instance.
+                            It could be used to point to a different container registry rather than the public one.
+                          properties:
+                            apiServerImage:
+                              default: kube-apiserver
+                              type: string
+                            controllerManagerImage:
+                              default: kube-controller-manager
+                              type: string
+                            registry:
+                              default: registry.k8s.io
+                              type: string
+                            schedulerImage:
+                              default: kube-scheduler
+                              type: string
+                            tagSuffix:
+                              description: |-
+                                The tag to append to all the Control Plane container images.
+                                Optional.
+                              type: string
+                          type: object
+                        replicas:
+                          default: 2
+                          format: int32
+                          type: integer
+                        resources:
+                          description: |-
+                            Resources defines the amount of memory and CPU to allocate to each component of the Control Plane
+                            (kube-apiserver, controller-manager, and scheduler).
+                          properties:
+                            apiServer:
+                              description: ResourceRequirements describes the compute resource requirements.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            controllerManager:
+                              description: ResourceRequirements describes the compute resource requirements.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            kine:
+                              description: |-
+                                Define the kine container resources.
+                                Available only if Kamaji is running using Kine as backing storage.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                            scheduler:
+                              description: ResourceRequirements describes the compute resource requirements.
+                              properties:
+                                claims:
+                                  description: |-
+                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                    that are used by this container.
+
+                                    This is an alpha field and requires enabling the
+                                    DynamicResourceAllocation feature gate.
+
+                                    This field is immutable. It can only be set for containers.
+                                  items:
+                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                    properties:
+                                      name:
+                                        description: |-
+                                          Name must match the name of one entry in pod.spec.resourceClaims of
+                                          the Pod where this field is used. It makes that resource available
+                                          inside a container.
+                                        type: string
+                                      request:
+                                        description: |-
+                                          Request is the name chosen for a request in the referenced claim.
+                                          If empty, everything from the claim is made available, otherwise
+                                          only the result of this request.
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-map-keys:
+                                    - name
+                                  x-kubernetes-list-type: map
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Limits describes the maximum amount of compute resources allowed.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: |-
+                                    Requests describes the minimum amount of compute resources required.
+                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                  type: object
+                              type: object
+                          type: object
+                        runtimeClassName:
+                          description: |-
+                            RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                            to run the Tenant Control Plane pod. If no RuntimeClass resource matches the named class, the pod will not be run.
+                            If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                            empty definition that uses the default runtime handler.
+                            More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                          type: string
+                        serviceAccountName:
+                          default: default
+                          description: ServiceAccountName allows to specify the service account to be mounted to the pods of the Control plane deployment
+                          type: string
+                        strategy:
+                          default:
+                            rollingUpdate:
+                              maxSurge: 100%
+                              maxUnavailable: 0
+                            type: RollingUpdate
+                          description: |-
+                            Strategy describes how to replace existing pods with new ones for the given Tenant Control Plane.
+                            Default value is set to Rolling Update, with a blue/green strategy.
+                          properties:
+                            rollingUpdate:
+                              description: |-
+                                Rolling update config params. Present only if DeploymentStrategyType =
+                                RollingUpdate.
+                              properties:
+                                maxSurge:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: |-
+                                    The maximum number of pods that can be scheduled above the desired number of
+                                    pods.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                    This can not be 0 if MaxUnavailable is 0.
+                                    Absolute number is calculated from percentage by rounding up.
+                                    Defaults to 25%.
+                                    Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when
+                                    the rolling update starts, such that the total number of old and new pods do not exceed
+                                    130% of desired pods. Once old pods have been killed,
+                                    new ReplicaSet can be scaled up further, ensuring that total number of pods running
+                                    at any time during the update is at most 130% of desired pods.
+                                  x-kubernetes-int-or-string: true
+                                maxUnavailable:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: |-
+                                    The maximum number of pods that can be unavailable during the update.
+                                    Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                                    Absolute number is calculated from percentage by rounding down.
+                                    This can not be 0 if MaxSurge is 0.
+                                    Defaults to 25%.
+                                    Example: when this is set to 30%, the old ReplicaSet can be scaled down to 70% of desired pods
+                                    immediately when the rolling update starts. Once new pods are ready, old ReplicaSet
+                                    can be scaled down further, followed by scaling up the new ReplicaSet, ensuring
+                                    that the total number of pods available at all times during the update is at
+                                    least 70% of desired pods.
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            type:
+                              description: Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
+                              type: string
+                          type: object
+                        tolerations:
+                          description: |-
+                            If specified, the Tenant Control Plane pod's tolerations.
+                            More info: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+                          items:
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                        topologySpreadConstraints:
+                          description: |-
+                            TopologySpreadConstraints describes how the Tenant Control Plane pods ought to spread across topology
+                            domains. Scheduler will schedule pods in a way which abides by the constraints.
+                            In case of nil underlying LabelSelector, the Kamaji one for the given Tenant Control Plane will be used.
+                            All topologySpreadConstraints are ANDed.
+                          items:
+                            description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                            properties:
+                              labelSelector:
+                                description: |-
+                                  LabelSelector is used to find matching pods.
+                                  Pods that match this label selector are counted to determine the number of pods
+                                  in their corresponding topology domain.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                    items:
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the selector applies to.
+                                          type: string
+                                        operator:
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                        - key
+                                        - operator
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                    type: object
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              matchLabelKeys:
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select the pods over which
+                                  spreading will be calculated. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are ANDed with labelSelector
+                                  to select the group of existing pods over which spreading will be calculated
+                                  for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  Keys that don't exist in the incoming pod labels will
+                                  be ignored. A null or empty list means only match against labelSelector.
+
+                                  This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              maxSkew:
+                                description: |-
+                                  MaxSkew describes the degree to which pods may be unevenly distributed.
+                                  When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                  between the number of matching pods in the target topology and the global minimum.
+                                  The global minimum is the minimum number of matching pods in an eligible domain
+                                  or zero if the number of eligible domains is less than MinDomains.
+                                  For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                  labelSelector spread as 2/2/1:
+                                  In this case, the global minimum is 1.
+                                  | zone1 | zone2 | zone3 |
+                                  |  P P  |  P P  |   P   |
+                                  - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                  scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                  violate MaxSkew(1).
+                                  - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                  When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                  to topologies that satisfy it.
+                                  It's a required field. Default value is 1 and 0 is not allowed.
+                                format: int32
+                                type: integer
+                              minDomains:
+                                description: |-
+                                  MinDomains indicates a minimum number of eligible domains.
+                                  When the number of eligible domains with matching topology keys is less than minDomains,
+                                  Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                  And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                  this value has no effect on scheduling.
+                                  As a result, when the number of eligible domains is less than minDomains,
+                                  scheduler won't schedule more than maxSkew Pods to those domains.
+                                  If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                  Valid values are integers greater than 0.
+                                  When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+                                  For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                  labelSelector spread as 2/2/2:
+                                  | zone1 | zone2 | zone3 |
+                                  |  P P  |  P P  |  P P  |
+                                  The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                  In this situation, new pod with the same labelSelector cannot be scheduled,
+                                  because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                  it will violate MaxSkew.
+                                format: int32
+                                type: integer
+                              nodeAffinityPolicy:
+                                description: |-
+                                  NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                  when calculating pod topology spread skew. Options are:
+                                  - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                  - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+                                  If this value is nil, the behavior is equivalent to the Honor policy.
+                                type: string
+                              nodeTaintsPolicy:
+                                description: |-
+                                  NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                  pod topology spread skew. Options are:
+                                  - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                  has a toleration, are included.
+                                  - Ignore: node taints are ignored. All nodes are included.
+
+                                  If this value is nil, the behavior is equivalent to the Ignore policy.
+                                type: string
+                              topologyKey:
+                                description: |-
+                                  TopologyKey is the key of node labels. Nodes that have a label with this key
+                                  and identical values are considered to be in the same topology.
+                                  We consider each <key, value> as a "bucket", and try to put balanced number
+                                  of pods into each bucket.
+                                  We define a domain as a particular instance of a topology.
+                                  Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                  nodeAffinityPolicy and nodeTaintsPolicy.
+                                  e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                  And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                  It's a required field.
+                                type: string
+                              whenUnsatisfiable:
+                                description: |-
+                                  WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                  the spread constraint.
+                                  - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                  - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                    but giving higher precedence to topologies that would help reduce the
+                                    skew.
+                                  A constraint is considered "Unsatisfiable" for an incoming pod
+                                  if and only if every possible node assignment for that pod would violate
+                                  "MaxSkew" on some topology.
+                                  For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                  labelSelector spread as 3/1/1:
+                                  | zone1 | zone2 | zone3 |
+                                  | P P P |   P   |   P   |
+                                  If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                  to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                  MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                  won't make it *more* imbalanced.
+                                  It's a required field.
+                                type: string
+                            required:
+                              - maxSkew
+                              - topologyKey
+                              - whenUnsatisfiable
+                            type: object
+                          type: array
+                      type: object
+                    ingress:
+                      description: Defining the options for an Optional Ingress which will expose API Server of the Tenant Control Plane
+                      properties:
+                        additionalMetadata:
+                          description: AdditionalMetadata defines which additional metadata, such as labels and annotations, must be attached to the created resource.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        hostname:
+                          description: |-
+                            Hostname is an optional field which will be used as Ingress's Host. If it is not defined,
+                            Ingress's host will be "<tenant>.<namespace>.<domain>", where domain is specified under NetworkProfileSpec
+                          type: string
+                        ingressClassName:
+                          type: string
+                      type: object
+                    service:
+                      description: Defining the options for the Tenant Control Plane Service resource.
+                      properties:
+                        additionalMetadata:
+                          description: AdditionalMetadata defines which additional metadata, such as labels and annotations, must be attached to the created resource.
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        serviceType:
+                          description: ServiceType allows specifying how to expose the Tenant Control Plane.
+                          enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                          type: string
+                      required:
+                        - serviceType
+                      type: object
+                  required:
+                    - service
+                  type: object
+                dataStore:
+                  description: |-
+                    DataStore specifies the DataStore that should be used to store the Kubernetes data for the given Tenant Control Plane.
+                    When Kamaji runs with the default DataStore flag, all empty values will inherit the default value.
+                    By leaving it empty and running Kamaji with no default DataStore flag, it is possible to achieve automatic assignment to a specific DataStore object.
+
+                    Migration from one DataStore to another backed by the same Driver is possible. See: https://kamaji.clastix.io/guides/datastore-migration/
+                    Migration from one DataStore to another backed by a different Driver is not supported.
+                  type: string
+                dataStoreSchema:
+                  description: |-
+                    DataStoreSchema allows to specify the name of the database (for relational DataStores) or the key prefix (for etcd). This
+                    value is optional and immutable. Note that Kamaji currently doesn't ensure that DataStoreSchema values are unique. It's up
+                    to the user to avoid clashes between different TenantControlPlanes. If not set upon creation, Kamaji will default the
+                    DataStoreSchema by concatenating the namespace and name of the TenantControlPlane.
+                  type: string
+                  x-kubernetes-validations:
+                    - message: changing the dataStoreSchema is not supported
+                      rule: self == oldSelf
+                kubernetes:
+                  description: Kubernetes specification for tenant control plane
+                  properties:
+                    admissionControllers:
+                      default:
+                        - CertificateApproval
+                        - CertificateSigning
+                        - CertificateSubjectRestriction
+                        - DefaultIngressClass
+                        - DefaultStorageClass
+                        - DefaultTolerationSeconds
+                        - LimitRanger
+                        - MutatingAdmissionWebhook
+                        - NamespaceLifecycle
+                        - PersistentVolumeClaimResize
+                        - Priority
+                        - ResourceQuota
+                        - RuntimeClass
+                        - ServiceAccount
+                        - StorageObjectInUseProtection
+                        - TaintNodesByCondition
+                        - ValidatingAdmissionWebhook
+                      description: |-
+                        List of enabled Admission Controllers for the Tenant cluster.
+                        Full reference available here: https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers
+                      items:
+                        enum:
+                          - AlwaysAdmit
+                          - AlwaysDeny
+                          - AlwaysPullImages
+                          - CertificateApproval
+                          - CertificateSigning
+                          - CertificateSubjectRestriction
+                          - DefaultIngressClass
+                          - DefaultStorageClass
+                          - DefaultTolerationSeconds
+                          - DenyEscalatingExec
+                          - DenyExecOnPrivileged
+                          - DenyServiceExternalIPs
+                          - EventRateLimit
+                          - ExtendedResourceToleration
+                          - ImagePolicyWebhook
+                          - LimitPodHardAntiAffinityTopology
+                          - LimitRanger
+                          - MutatingAdmissionWebhook
+                          - NamespaceAutoProvision
+                          - NamespaceExists
+                          - NamespaceLifecycle
+                          - NodeRestriction
+                          - OwnerReferencesPermissionEnforcement
+                          - PersistentVolumeClaimResize
+                          - PersistentVolumeLabel
+                          - PodNodeSelector
+                          - PodSecurity
+                          - PodSecurityPolicy
+                          - PodTolerationRestriction
+                          - Priority
+                          - ResourceQuota
+                          - RuntimeClass
+                          - SecurityContextDeny
+                          - ServiceAccount
+                          - StorageObjectInUseProtection
+                          - TaintNodesByCondition
+                          - ValidatingAdmissionWebhook
+                        type: string
+                      type: array
+                    kubelet:
+                      properties:
+                        cgroupfs:
+                          description: |-
+                            CGroupFS defines the  cgroup driver for Kubelet
+                            https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/configure-cgroup-driver/
+                          enum:
+                            - systemd
+                            - cgroupfs
+                          type: string
+                        preferredAddressTypes:
+                          default:
+                            - Hostname
+                            - InternalIP
+                            - ExternalIP
+                          description: |-
+                            Ordered list of the preferred NodeAddressTypes to use for kubelet connections.
+                            Default to Hostname, InternalIP, ExternalIP.
+                          items:
+                            enum:
+                              - Hostname
+                              - InternalIP
+                              - ExternalIP
+                              - InternalDNS
+                              - ExternalDNS
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
+                    version:
+                      description: Kubernetes Version for the tenant control plane
+                      type: string
+                  required:
+                    - kubelet
+                    - version
+                  type: object
+                networkProfile:
+                  description: NetworkProfile specifies how the network is
+                  properties:
+                    address:
+                      description: |-
+                        Address where API server of will be exposed.
+                        In case of LoadBalancer Service, this can be empty in order to use the exposed IP provided by the cloud controller manager.
+                      type: string
+                    allowAddressAsExternalIP:
+                      description: |-
+                        AllowAddressAsExternalIP will include tenantControlPlane.Spec.NetworkProfile.Address in the section of
+                        ExternalIPs of the Kubernetes Service (only ClusterIP or NodePort)
+                      type: boolean
+                    certSANs:
+                      description: |-
+                        CertSANs sets extra Subject Alternative Names (SANs) for the API Server signing certificate.
+                        Use this field to add additional hostnames when exposing the Tenant Control Plane with third solutions.
+                      items:
+                        type: string
+                      type: array
+                    clusterDomain:
+                      default: cluster.local
+                      description: The default domain name used for DNS resolution within the cluster.
+                      pattern: .*\..*
+                      type: string
+                      x-kubernetes-validations:
+                        - message: changing the cluster domain is not supported
+                          rule: self == oldSelf
+                    dnsServiceIPs:
+                      description: |-
+                        The DNS Service for internal resolution, it must match the Service CIDR.
+                        In case of an empty value, it is automatically computed according to the Service CIDR, e.g.:
+                        Service CIDR 10.96.0.0/16, the resulting DNS Service IP will be 10.96.0.10 for IPv4,
+                        for IPv6 from the CIDR 2001:db8:abcd::/64 the resulting DNS Service IP will be 2001:db8:abcd::10.
+                      items:
+                        type: string
+                      type: array
+                    loadBalancerClass:
+                      description: |-
+                        Specify the LoadBalancer class in case of multiple load balancer implementations.
+                        Field supported only for Tenant Control Plane instances exposed using a LoadBalancer Service.
+                      minLength: 1
+                      type: string
+                      x-kubernetes-validations:
+                        - message: LoadBalancerClass is immutable
+                          rule: self == oldSelf
+                    loadBalancerSourceRanges:
+                      description: |-
+                        LoadBalancerSourceRanges restricts the IP ranges that can access
+                        the LoadBalancer type Service. This field defines a list of IP
+                        address ranges (in CIDR format) that are allowed to access the service.
+                        If left empty, the service will allow traffic from all IP ranges (0.0.0.0/0).
+                        This feature is useful for restricting access to API servers or services
+                        to specific networks for security purposes.
+                        Example: {"192.168.1.0/24", "10.0.0.0/8"}
+                      items:
+                        type: string
+                      type: array
+                    podCidr:
+                      default: 10.244.0.0/16
+                      description: 'CIDR for Kubernetes Pods: if empty, defaulted to 10.244.0.0/16.'
+                      type: string
+                    port:
+                      default: 6443
+                      description: Port where API server of will be exposed
+                      format: int32
+                      type: integer
+                    serviceCidr:
+                      default: 10.96.0.0/16
+                      description: 'CIDR for Kubernetes Services: if empty, defaulted to 10.96.0.0/16.'
+                      type: string
+                  type: object
+              required:
+                - controlPlane
+                - kubernetes
+              type: object
+              x-kubernetes-validations:
+                - message: unsetting the dataStore is not supported
+                  rule: '!has(oldSelf.dataStore) || has(self.dataStore)'
+                - message: unsetting the dataStoreSchema is not supported
+                  rule: '!has(oldSelf.dataStoreSchema) || has(self.dataStoreSchema)'
+                - message: LoadBalancer source ranges are supported only with LoadBalancer service type
+                  rule: '!has(self.networkProfile.loadBalancerSourceRanges) || (size(self.networkProfile.loadBalancerSourceRanges) == 0 || self.controlPlane.service.serviceType == ''LoadBalancer'')'
+                - message: LoadBalancerClass is supported only with LoadBalancer service type
+                  rule: '!has(self.networkProfile.loadBalancerClass) || self.controlPlane.service.serviceType == ''LoadBalancer'''
+                - message: LoadBalancerClass cannot be set or unset at runtime
+                  rule: self.controlPlane.service.serviceType != 'LoadBalancer' || (oldSelf.controlPlane.service.serviceType != 'LoadBalancer' && self.controlPlane.service.serviceType == 'LoadBalancer') || has(self.networkProfile.loadBalancerClass) == has(oldSelf.networkProfile.loadBalancerClass)
+            status:
+              description: TenantControlPlaneStatus defines the observed state of TenantControlPlane.
+              properties:
+                addons:
+                  description: Addons contains the status of the different Addons
+                  properties:
+                    coreDNS:
+                      description: AddonStatus defines the observed state of an Addon.
+                      properties:
+                        enabled:
+                          type: boolean
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                      required:
+                        - enabled
+                      type: object
+                    konnectivity:
+                      description: KonnectivityStatus defines the status of Konnectivity as Addon.
+                      properties:
+                        agent:
+                          properties:
+                            lastUpdate:
+                              description: Last time when k8s object was updated
+                              format: date-time
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        certificate:
+                          description: CertificatePrivateKeyPairStatus defines the status.
+                          properties:
+                            checksum:
+                              type: string
+                            lastUpdate:
+                              format: date-time
+                              type: string
+                            secretName:
+                              type: string
+                          type: object
+                        clusterrolebinding:
+                          properties:
+                            lastUpdate:
+                              description: Last time when k8s object was updated
+                              format: date-time
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        configMap:
+                          properties:
+                            checksum:
+                              type: string
+                            name:
+                              type: string
+                          type: object
+                        enabled:
+                          type: boolean
+                        kubeconfig:
+                          description: KubeconfigStatus contains information about the generated kubeconfig.
+                          properties:
+                            checksum:
+                              type: string
+                            lastUpdate:
+                              format: date-time
+                              type: string
+                            secretName:
+                              type: string
+                          type: object
+                        sa:
+                          properties:
+                            lastUpdate:
+                              description: Last time when k8s object was updated
+                              format: date-time
+                              type: string
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        service:
+                          description: KubernetesServiceStatus defines the status for the Tenant Control Plane Service in the management cluster.
+                          properties:
+                            conditions:
+                              description: Current service state
+                              items:
+                                description: Condition contains details for one aspect of the current state of this API Resource.
+                                properties:
+                                  lastTransitionTime:
+                                    description: |-
+                                      lastTransitionTime is the last time the condition transitioned from one status to another.
+                                      This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: |-
+                                      message is a human readable message indicating details about the transition.
+                                      This may be an empty string.
+                                    maxLength: 32768
+                                    type: string
+                                  observedGeneration:
+                                    description: |-
+                                      observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                      For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                      with respect to the current state of the instance.
+                                    format: int64
+                                    minimum: 0
+                                    type: integer
+                                  reason:
+                                    description: |-
+                                      reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                      Producers of specific condition types may define expected values and meanings for this field,
+                                      and whether the values are considered a guaranteed API.
+                                      The value should be a CamelCase string.
+                                      This field may not be empty.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                    type: string
+                                  status:
+                                    description: status of the condition, one of True, False, Unknown.
+                                    enum:
+                                      - "True"
+                                      - "False"
+                                      - Unknown
+                                    type: string
+                                  type:
+                                    description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                    maxLength: 316
+                                    pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                    type: string
+                                required:
+                                  - lastTransitionTime
+                                  - message
+                                  - reason
+                                  - status
+                                  - type
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - type
+                              x-kubernetes-list-type: map
+                            loadBalancer:
+                              description: |-
+                                LoadBalancer contains the current status of the load-balancer,
+                                if one is present.
+                              properties:
+                                ingress:
+                                  description: |-
+                                    Ingress is a list containing ingress points for the load-balancer.
+                                    Traffic intended for the service should be sent to these ingress points.
+                                  items:
+                                    description: |-
+                                      LoadBalancerIngress represents the status of a load-balancer ingress point:
+                                      traffic intended for the service should be sent to an ingress point.
+                                    properties:
+                                      hostname:
+                                        description: |-
+                                          Hostname is set for load-balancer ingress points that are DNS based
+                                          (typically AWS load-balancers)
+                                        type: string
+                                      ip:
+                                        description: |-
+                                          IP is set for load-balancer ingress points that are IP based
+                                          (typically GCE or OpenStack load-balancers)
+                                        type: string
+                                      ipMode:
+                                        description: |-
+                                          IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                                          Setting this to "VIP" indicates that traffic is delivered to the node with
+                                          the destination set to the load-balancer's IP and port.
+                                          Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                                          the destination set to the node's IP and node port or the pod's IP and port.
+                                          Service implementations may use this information to adjust traffic routing.
+                                        type: string
+                                      ports:
+                                        description: |-
+                                          Ports is a list of records of service ports
+                                          If used, every port defined in the service should have an entry in it
+                                        items:
+                                          description: PortStatus represents the error condition of a service port
+                                          properties:
+                                            error:
+                                              description: |-
+                                                Error is to record the problem with the service port
+                                                The format of the error shall comply with the following rules:
+                                                - built-in error values shall be specified in this file and those shall use
+                                                  CamelCase names
+                                                - cloud provider specific error values must have names that comply with the
+                                                  format foo.example.com/CamelCase.
+                                              maxLength: 316
+                                              pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                              type: string
+                                            port:
+                                              description: Port is the port number of the service port of which status is recorded here
+                                              format: int32
+                                              type: integer
+                                            protocol:
+                                              description: |-
+                                                Protocol is the protocol of the service port of which status is recorded here
+                                                The supported values are: "TCP", "UDP", "SCTP"
+                                              type: string
+                                          required:
+                                            - error
+                                            - port
+                                            - protocol
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            name:
+                              description: The name of the Service for the given cluster.
+                              type: string
+                            namespace:
+                              description: The namespace which the Service for the given cluster is deployed.
+                              type: string
+                            port:
+                              description: The port where the service is running
+                              format: int32
+                              type: integer
+                          required:
+                            - name
+                            - namespace
+                            - port
+                          type: object
+                      required:
+                        - enabled
+                      type: object
+                    kubeProxy:
+                      description: AddonStatus defines the observed state of an Addon.
+                      properties:
+                        enabled:
+                          type: boolean
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                      required:
+                        - enabled
+                      type: object
+                  type: object
+                certificates:
+                  description: |-
+                    Certificates contains information about the different certificates
+                    that are necessary to run a kubernetes control plane
+                  properties:
+                    apiServer:
+                      description: CertificatePrivateKeyPairStatus defines the status.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    apiServerKubeletClient:
+                      description: CertificatePrivateKeyPairStatus defines the status.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    ca:
+                      description: CertificatePrivateKeyPairStatus defines the status.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    etcd:
+                      description: ETCDCertificatesStatus defines the observed state of ETCD Certificate for API server.
+                      properties:
+                        apiServer:
+                          description: APIServerCertificatesStatus defines the observed state of ETCD Certificate for API server.
+                          properties:
+                            checksum:
+                              type: string
+                            lastUpdate:
+                              format: date-time
+                              type: string
+                            secretName:
+                              type: string
+                          type: object
+                        ca:
+                          description: ETCDCertificateStatus defines the observed state of ETCD Certificate for API server.
+                          properties:
+                            checksum:
+                              type: string
+                            lastUpdate:
+                              format: date-time
+                              type: string
+                            secretName:
+                              type: string
+                          type: object
+                      type: object
+                    frontProxyCA:
+                      description: CertificatePrivateKeyPairStatus defines the status.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    frontProxyClient:
+                      description: CertificatePrivateKeyPairStatus defines the status.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    sa:
+                      description: PublicKeyPrivateKeyPairStatus defines the status.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                  type: object
+                controlPlaneEndpoint:
+                  description: ControlPlaneEndpoint contains the status of the kubernetes control plane
+                  type: string
+                kubeadmPhase:
+                  description: KubeadmPhase contains the status of the kubeadm phases action
+                  properties:
+                    bootstrapToken:
+                      description: KubeadmPhaseStatus contains the status of a kubeadm phase action.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                      type: object
+                  required:
+                    - bootstrapToken
+                  type: object
+                kubeadmconfig:
+                  description: KubeadmConfig contains the status of the configuration required by kubeadm
+                  properties:
+                    checksum:
+                      description: Checksum of the kubeadm configuration to detect changes
+                      type: string
+                    configmapName:
+                      type: string
+                    lastUpdate:
+                      format: date-time
+                      type: string
+                  type: object
+                kubeconfig:
+                  description: KubeConfig contains information about the kubenconfigs that control plane pieces need
+                  properties:
+                    admin:
+                      description: KubeconfigStatus contains information about the generated kubeconfig.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    controllerManager:
+                      description: KubeconfigStatus contains information about the generated kubeconfig.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    scheduler:
+                      description: KubeconfigStatus contains information about the generated kubeconfig.
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                  type: object
+                kubernetesResources:
+                  description: Kubernetes contains information about the reconciliation of the required Kubernetes resources deployed in the admin cluster
+                  properties:
+                    deployment:
+                      description: KubernetesDeploymentStatus defines the status for the Tenant Control Plane Deployment in the management cluster.
+                      properties:
+                        availableReplicas:
+                          description: Total number of available non-terminating pods (ready for at least minReadySeconds) targeted by this deployment.
+                          format: int32
+                          type: integer
+                        collisionCount:
+                          description: |-
+                            Count of hash collisions for the Deployment. The Deployment controller uses this
+                            field as a collision avoidance mechanism when it needs to create the name for the
+                            newest ReplicaSet.
+                          format: int32
+                          type: integer
+                        conditions:
+                          description: Represents the latest available observations of a deployment's current state.
+                          items:
+                            description: DeploymentCondition describes the state of a deployment at a certain point.
+                            properties:
+                              lastTransitionTime:
+                                description: Last time the condition transitioned from one status to another.
+                                format: date-time
+                                type: string
+                              lastUpdateTime:
+                                description: The last time this condition was updated.
+                                format: date-time
+                                type: string
+                              message:
+                                description: A human readable message indicating details about the transition.
+                                type: string
+                              reason:
+                                description: The reason for the condition's last transition.
+                                type: string
+                              status:
+                                description: Status of the condition, one of True, False, Unknown.
+                                type: string
+                              type:
+                                description: Type of deployment condition.
+                                type: string
+                            required:
+                              - status
+                              - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - type
+                          x-kubernetes-list-type: map
+                        lastUpdate:
+                          description: Last time when deployment was updated
+                          format: date-time
+                          type: string
+                        name:
+                          description: The name of the Deployment for the given cluster.
+                          type: string
+                        namespace:
+                          description: The namespace which the Deployment for the given cluster is deployed.
+                          type: string
+                        observedGeneration:
+                          description: The generation observed by the deployment controller.
+                          format: int64
+                          type: integer
+                        readyReplicas:
+                          description: Total number of non-terminating pods targeted by this Deployment with a Ready Condition.
+                          format: int32
+                          type: integer
+                        replicas:
+                          description: Total number of non-terminating pods targeted by this deployment (their labels match the selector).
+                          format: int32
+                          type: integer
+                        selector:
+                          description: Selector is the label selector used to group the Tenant Control Plane Pods used by the scale subresource.
+                          type: string
+                        terminatingReplicas:
+                          description: |-
+                            Total number of terminating pods targeted by this deployment. Terminating pods have a non-null
+                            .metadata.deletionTimestamp and have not yet reached the Failed or Succeeded .status.phase.
+
+                            This is an alpha field. Enable DeploymentReplicaSetTerminatingReplicas to be able to use this field.
+                          format: int32
+                          type: integer
+                        unavailableReplicas:
+                          description: |-
+                            Total number of unavailable pods targeted by this deployment. This is the total number of
+                            pods that are still required for the deployment to have 100% available capacity. They may
+                            either be pods that are running but not yet available or pods that still have not been created.
+                          format: int32
+                          type: integer
+                        updatedReplicas:
+                          description: Total number of non-terminating pods targeted by this deployment that have the desired template spec.
+                          format: int32
+                          type: integer
+                      required:
+                        - name
+                        - namespace
+                        - selector
+                      type: object
+                    ingress:
+                      description: KubernetesIngressStatus defines the status for the Tenant Control Plane Ingress in the management cluster.
+                      properties:
+                        loadBalancer:
+                          description: loadBalancer contains the current status of the load-balancer.
+                          properties:
+                            ingress:
+                              description: ingress is a list containing ingress points for the load-balancer.
+                              items:
+                                description: IngressLoadBalancerIngress represents the status of a load-balancer ingress point.
+                                properties:
+                                  hostname:
+                                    description: hostname is set for load-balancer ingress points that are DNS based.
+                                    type: string
+                                  ip:
+                                    description: ip is set for load-balancer ingress points that are IP based.
+                                    type: string
+                                  ports:
+                                    description: ports provides information about the ports exposed by this LoadBalancer.
+                                    items:
+                                      description: IngressPortStatus represents the error condition of a service port
+                                      properties:
+                                        error:
+                                          description: |-
+                                            error is to record the problem with the service port
+                                            The format of the error shall comply with the following rules:
+                                            - built-in error values shall be specified in this file and those shall use
+                                              CamelCase names
+                                            - cloud provider specific error values must have names that comply with the
+                                              format foo.example.com/CamelCase.
+                                          maxLength: 316
+                                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                          type: string
+                                        port:
+                                          description: port is the port number of the ingress port.
+                                          format: int32
+                                          type: integer
+                                        protocol:
+                                          description: |-
+                                            protocol is the protocol of the ingress port.
+                                            The supported values are: "TCP", "UDP", "SCTP"
+                                          type: string
+                                      required:
+                                        - error
+                                        - port
+                                        - protocol
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        name:
+                          description: The name of the Ingress for the given cluster.
+                          type: string
+                        namespace:
+                          description: The namespace which the Ingress for the given cluster is deployed.
+                          type: string
+                      required:
+                        - name
+                        - namespace
+                      type: object
+                    service:
+                      description: KubernetesServiceStatus defines the status for the Tenant Control Plane Service in the management cluster.
+                      properties:
+                        conditions:
+                          description: Current service state
+                          items:
+                            description: Condition contains details for one aspect of the current state of this API Resource.
+                            properties:
+                              lastTransitionTime:
+                                description: |-
+                                  lastTransitionTime is the last time the condition transitioned from one status to another.
+                                  This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                format: date-time
+                                type: string
+                              message:
+                                description: |-
+                                  message is a human readable message indicating details about the transition.
+                                  This may be an empty string.
+                                maxLength: 32768
+                                type: string
+                              observedGeneration:
+                                description: |-
+                                  observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                  For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                  with respect to the current state of the instance.
+                                format: int64
+                                minimum: 0
+                                type: integer
+                              reason:
+                                description: |-
+                                  reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                  Producers of specific condition types may define expected values and meanings for this field,
+                                  and whether the values are considered a guaranteed API.
+                                  The value should be a CamelCase string.
+                                  This field may not be empty.
+                                maxLength: 1024
+                                minLength: 1
+                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                type: string
+                              status:
+                                description: status of the condition, one of True, False, Unknown.
+                                enum:
+                                  - "True"
+                                  - "False"
+                                  - Unknown
+                                type: string
+                              type:
+                                description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                maxLength: 316
+                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                type: string
+                            required:
+                              - lastTransitionTime
+                              - message
+                              - reason
+                              - status
+                              - type
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - type
+                          x-kubernetes-list-type: map
+                        loadBalancer:
+                          description: |-
+                            LoadBalancer contains the current status of the load-balancer,
+                            if one is present.
+                          properties:
+                            ingress:
+                              description: |-
+                                Ingress is a list containing ingress points for the load-balancer.
+                                Traffic intended for the service should be sent to these ingress points.
+                              items:
+                                description: |-
+                                  LoadBalancerIngress represents the status of a load-balancer ingress point:
+                                  traffic intended for the service should be sent to an ingress point.
+                                properties:
+                                  hostname:
+                                    description: |-
+                                      Hostname is set for load-balancer ingress points that are DNS based
+                                      (typically AWS load-balancers)
+                                    type: string
+                                  ip:
+                                    description: |-
+                                      IP is set for load-balancer ingress points that are IP based
+                                      (typically GCE or OpenStack load-balancers)
+                                    type: string
+                                  ipMode:
+                                    description: |-
+                                      IPMode specifies how the load-balancer IP behaves, and may only be specified when the ip field is specified.
+                                      Setting this to "VIP" indicates that traffic is delivered to the node with
+                                      the destination set to the load-balancer's IP and port.
+                                      Setting this to "Proxy" indicates that traffic is delivered to the node or pod with
+                                      the destination set to the node's IP and node port or the pod's IP and port.
+                                      Service implementations may use this information to adjust traffic routing.
+                                    type: string
+                                  ports:
+                                    description: |-
+                                      Ports is a list of records of service ports
+                                      If used, every port defined in the service should have an entry in it
+                                    items:
+                                      description: PortStatus represents the error condition of a service port
+                                      properties:
+                                        error:
+                                          description: |-
+                                            Error is to record the problem with the service port
+                                            The format of the error shall comply with the following rules:
+                                            - built-in error values shall be specified in this file and those shall use
+                                              CamelCase names
+                                            - cloud provider specific error values must have names that comply with the
+                                              format foo.example.com/CamelCase.
+                                          maxLength: 316
+                                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                          type: string
+                                        port:
+                                          description: Port is the port number of the service port of which status is recorded here
+                                          format: int32
+                                          type: integer
+                                        protocol:
+                                          description: |-
+                                            Protocol is the protocol of the service port of which status is recorded here
+                                            The supported values are: "TCP", "UDP", "SCTP"
+                                          type: string
+                                      required:
+                                        - error
+                                        - port
+                                        - protocol
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        name:
+                          description: The name of the Service for the given cluster.
+                          type: string
+                        namespace:
+                          description: The namespace which the Service for the given cluster is deployed.
+                          type: string
+                        port:
+                          description: The port where the service is running
+                          format: int32
+                          type: integer
+                      required:
+                        - name
+                        - namespace
+                        - port
+                      type: object
+                    version:
+                      description: KubernetesVersion contains the information regarding the running Kubernetes version, and its upgrade status.
+                      properties:
+                        status:
+                          default: Provisioning
+                          description: Status returns the current status of the Kubernetes version, such as its provisioning state, or completed upgrade.
+                          enum:
+                            - Provisioning
+                            - CertificateAuthorityRotating
+                            - Upgrading
+                            - Migrating
+                            - Ready
+                            - NotReady
+                            - Sleeping
+                          type: string
+                        version:
+                          description: Version is the running Kubernetes version of the Tenant Control Plane.
+                          type: string
+                      type: object
+                  type: object
+                storage:
+                  description: Storage Status contains information about Kubernetes storage system
+                  properties:
+                    certificate:
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    config:
+                      properties:
+                        checksum:
+                          type: string
+                        secretName:
+                          type: string
+                      type: object
+                    dataStoreName:
+                      type: string
+                    driver:
+                      type: string
+                    setup:
+                      properties:
+                        checksum:
+                          type: string
+                        lastUpdate:
+                          format: date-time
+                          type: string
+                        schema:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          labelSelectorPath: .status.kubernetesResources.deployment.selector
+          specReplicasPath: .spec.controlPlane.deployment.replicas
+          statusReplicasPath: .status.kubernetesResources.deployment.replicas
+        status: {}
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: kamaji-webhook-service
+          namespace: kamaji-system
+          path: /convert
+      conversionReviewVersions:
+        - v1

--- a/docs/shared/crds/cluster_api/ipam/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
+++ b/docs/shared/crds/cluster_api/ipam/ipam.cluster.x-k8s.io_ipaddressclaims.yaml
@@ -1,0 +1,368 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ipaddressclaims.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddressClaim
+    listKind: IPAddressClaimList
+    plural: ipaddressclaims
+    singular: ipaddressclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAddressClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddressClaim.
+            properties:
+              clusterName:
+                description: clusterName is the name of the Cluster this object belongs
+                  to.
+                maxLength: 63
+                minLength: 1
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - poolRef
+            type: object
+          status:
+            description: status is the observed state of IPAddressClaim.
+            properties:
+              addressRef:
+                description: addressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in IPAddressClaim's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: conditions represents the observations of a IPAddressClaim's
+                      current state.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: Name of the pool to allocate an address from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool to allocate an address from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAddressClaim
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddressClaim is the Schema for the ipaddressclaim API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddressClaim.
+            properties:
+              poolRef:
+                description: poolRef is a reference to the pool from which an IP address
+                  should be created.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+            required:
+            - poolRef
+            type: object
+          status:
+            description: status is the observed state of IPAddressClaim.
+            properties:
+              addressRef:
+                description: addressRef is a reference to the address that was created
+                  for this claim.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              conditions:
+                description: conditions summarises the current state of the IPAddressClaim
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/ipam/ipam.cluster.x-k8s.io_ipaddresses.yaml
+++ b/docs/shared/crds/cluster_api/ipam/ipam.cluster.x-k8s.io_ipaddresses.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: ipaddresses.ipam.cluster.x-k8s.io
+spec:
+  group: ipam.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: IPAddress
+    listKind: IPAddressList
+    plural: ipaddresses
+    singular: ipaddress
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAddress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddress.
+            properties:
+              address:
+                description: address is the IP address.
+                maxLength: 39
+                minLength: 1
+                type: string
+              claimRef:
+                description: claimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              gateway:
+                description: gateway is the network gateway of the network the address
+                  is from.
+                maxLength: 39
+                minLength: 1
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+  - additionalPrinterColumns:
+    - description: Address
+      jsonPath: .spec.address
+      name: Address
+      type: string
+    - description: Name of the pool the address is from
+      jsonPath: .spec.poolRef.name
+      name: Pool Name
+      type: string
+    - description: Kind of the pool the address is from
+      jsonPath: .spec.poolRef.kind
+      name: Pool Kind
+      type: string
+    - description: Time duration since creation of IPAddress
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IPAddress is the Schema for the ipaddress API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of IPAddress.
+            properties:
+              address:
+                description: address is the IP address.
+                maxLength: 39
+                minLength: 1
+                type: string
+              claimRef:
+                description: claimRef is a reference to the claim this IPAddress was
+                  created for.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              gateway:
+                description: gateway is the network gateway of the network the address
+                  is from.
+                maxLength: 39
+                minLength: 1
+                type: string
+              poolRef:
+                description: poolRef is a reference to the pool that this IPAddress
+                  was created from.
+                properties:
+                  apiGroup:
+                    description: |-
+                      APIGroup is the group for the resource being referenced.
+                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                      For any other third-party types, APIGroup is required.
+                    type: string
+                  kind:
+                    description: Kind is the type of resource being referenced
+                    type: string
+                  name:
+                    description: Name is the name of resource being referenced
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              prefix:
+                description: prefix is the prefix of the address.
+                type: integer
+            required:
+            - address
+            - claimRef
+            - poolRef
+            - prefix
+            type: object
+        type: object
+    served: true
+    storage: false
+    subresources: {}

--- a/docs/shared/crds/cluster_api/kubeadm_bootstrap/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+++ b/docs/shared/crds/cluster_api/kubeadm_bootstrap/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
@@ -1,0 +1,2096 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: kubeadmconfigs.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfig
+    listKind: KubeadmConfigList
+    plural: kubeadmconfigs
+    singular: kubeadmconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: Time duration since creation of KubeadmConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfig is the Schema for the kubeadmconfigs API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of KubeadmConfig.
+            properties:
+              bootCommands:
+                description: |-
+                  bootCommands specifies extra commands to run very early in the boot process via the cloud-init bootcmd
+                  module. bootcmd will run on every boot, 'cloud-init-per' command can be used to make bootcmd run exactly
+                  once. This is typically run in the cloud-init.service systemd unit. This has no effect in Ignition.
+                items:
+                  maxLength: 10240
+                  minLength: 1
+                  type: string
+                maxItems: 1000
+                type: array
+              clusterConfiguration:
+                description: clusterConfiguration along with InitConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiServer:
+                    description: apiServer contains extra settings for the API server
+                      control plane component
+                    properties:
+                      certSANs:
+                        description: certSANs sets extra Subject Alternative Names
+                          for the API Server signing cert.
+                        items:
+                          maxLength: 253
+                          minLength: 1
+                          type: string
+                        maxItems: 100
+                        type: array
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraEnvs:
+                        description: |-
+                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                      timeoutForControlPlane:
+                        description: timeoutForControlPlane controls the timeout that
+                          we use for API server to appear
+                        type: string
+                    type: object
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  certificatesDir:
+                    description: |-
+                      certificatesDir specifies where to store or look for all required certificates.
+                      NB: if not provided, this will default to `/etc/kubernetes/pki`
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  clusterName:
+                    description: clusterName is the cluster name
+                    maxLength: 63
+                    minLength: 1
+                    type: string
+                  controlPlaneEndpoint:
+                    description: |-
+                      controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                      can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                      In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                      are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                      the BindPort is used.
+                      Possible usages are:
+                      e.g. In a cluster with more than one control plane instances, this field should be
+                      assigned the address of the external load balancer in front of the
+                      control plane instances.
+                      e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                      could be used for assigning a stable DNS to the control plane.
+                      NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  controllerManager:
+                    description: controllerManager contains extra settings for the
+                      controller manager control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraEnvs:
+                        description: |-
+                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                    type: object
+                  dns:
+                    description: dns defines the options for the DNS add-on installed
+                      in the cluster.
+                    properties:
+                      imageRepository:
+                        description: |-
+                          imageRepository sets the container registry to pull images from.
+                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      imageTag:
+                        description: |-
+                          imageTag allows to specify a tag for the image.
+                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                    type: object
+                  etcd:
+                    description: |-
+                      etcd holds configuration for etcd.
+                      NB: This value defaults to a Local (stacked) etcd
+                    properties:
+                      external:
+                        description: |-
+                          external describes how to connect to an external etcd cluster
+                          Local and External are mutually exclusive
+                        properties:
+                          caFile:
+                            description: |-
+                              caFile is an SSL Certificate Authority file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          certFile:
+                            description: |-
+                              certFile is an SSL certification file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          endpoints:
+                            description: endpoints of etcd members. Required for ExternalEtcd.
+                            items:
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            maxItems: 50
+                            type: array
+                          keyFile:
+                            description: |-
+                              keyFile is an SSL key file used to secure etcd communication.
+                              Required if using a TLS connection.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                        required:
+                        - caFile
+                        - certFile
+                        - endpoints
+                        - keyFile
+                        type: object
+                      local:
+                        description: |-
+                          local provides configuration knobs for configuring the local etcd instance
+                          Local and External are mutually exclusive
+                        properties:
+                          dataDir:
+                            description: |-
+                              dataDir is the directory etcd will place its data.
+                              Defaults to "/var/lib/etcd".
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              extraArgs are extra arguments provided to the etcd binary
+                              when run inside a static pod.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          imageTag:
+                            description: |-
+                              imageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          peerCertSANs:
+                            description: peerCertSANs sets extra Subject Alternative
+                              Names for the etcd peer signing cert.
+                            items:
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            maxItems: 100
+                            type: array
+                          serverCertSANs:
+                            description: serverCertSANs sets extra Subject Alternative
+                              Names for the etcd server signing cert.
+                            items:
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            maxItems: 100
+                            type: array
+                        type: object
+                    type: object
+                  featureGates:
+                    additionalProperties:
+                      type: boolean
+                    description: featureGates enabled by the user.
+                    type: object
+                  imageRepository:
+                    description: |-
+                      imageRepository sets the container registry to pull images from.
+                      * If not set, the default registry of kubeadm will be used, i.e.
+                        * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                        * k8s.gcr.io (old registry): all older versions
+                        Please note that when imageRepository is not set we don't allow upgrades to
+                        versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                        a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                        >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                      * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                       `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                        and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  kubernetesVersion:
+                    description: |-
+                      kubernetesVersion is the target version of the control plane.
+                      NB: This value defaults to the Machine object spec.version
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                  networking:
+                    description: |-
+                      networking holds configuration for the networking topology of the cluster.
+                      NB: This value defaults to the Cluster object spec.clusterNetwork.
+                    properties:
+                      dnsDomain:
+                        description: dnsDomain is the dns domain used by k8s services.
+                          Defaults to "cluster.local".
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      podSubnet:
+                        description: |-
+                          podSubnet is the subnet used by pods.
+                          If unset, the API server will not allocate CIDR ranges for every node.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                      serviceSubnet:
+                        description: |-
+                          serviceSubnet is the subnet used by k8s services.
+                          Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                          to "10.96.0.0/12" if that's unset.
+                        maxLength: 1024
+                        minLength: 1
+                        type: string
+                    type: object
+                  scheduler:
+                    description: scheduler contains extra settings for the scheduler
+                      control plane component
+                    properties:
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: extraArgs is an extra set of flags to pass to
+                          the control plane component.
+                        type: object
+                      extraEnvs:
+                        description: |-
+                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                      extraVolumes:
+                        description: extraVolumes is an extra set of host volumes,
+                          mounted to the control plane component.
+                        items:
+                          description: |-
+                            HostPathMount contains elements describing volumes that are mounted from the
+                            host.
+                          properties:
+                            hostPath:
+                              description: |-
+                                hostPath is the path in the host that will be mounted inside
+                                the pod.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            mountPath:
+                              description: mountPath is the path inside the pod where
+                                hostPath will be mounted.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name of the volume inside the pod template.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            pathType:
+                              description: pathType is the type of the HostPath.
+                              type: string
+                            readOnly:
+                              description: readOnly controls write access to the volume
+                              type: boolean
+                          required:
+                          - hostPath
+                          - mountPath
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                    type: object
+                type: object
+              diskSetup:
+                description: diskSetup specifies options for the creation of partition
+                  tables and file systems on devices.
+                properties:
+                  filesystems:
+                    description: filesystems specifies the list of file systems to
+                      setup.
+                    items:
+                      description: Filesystem defines the file systems to be created.
+                      properties:
+                        device:
+                          description: device specifies the device name
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        extraOpts:
+                          description: extraOpts defined extra options to add to the
+                            command for creating the file system.
+                          items:
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          maxItems: 100
+                          type: array
+                        filesystem:
+                          description: filesystem specifies the file system type.
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        label:
+                          description: label specifies the file system label to be
+                            used. If set to None, no label is used.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        overwrite:
+                          description: |-
+                            overwrite defines whether or not to overwrite any existing filesystem.
+                            If true, any pre-existing file system will be destroyed. Use with Caution.
+                          type: boolean
+                        partition:
+                          description: 'partition specifies the partition to use.
+                            The valid options are: "auto|any", "auto", "any", "none",
+                            and <NUM>, where NUM is the actual partition number.'
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                        replaceFS:
+                          description: |-
+                            replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                            NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                          maxLength: 128
+                          minLength: 1
+                          type: string
+                      required:
+                      - device
+                      - filesystem
+                      type: object
+                    maxItems: 100
+                    type: array
+                  partitions:
+                    description: partitions specifies the list of the partitions to
+                      setup.
+                    items:
+                      description: Partition defines how to create and layout a partition.
+                      properties:
+                        device:
+                          description: device is the name of the device.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        layout:
+                          description: |-
+                            layout specifies the device layout.
+                            If it is true, a single partition will be created for the entire device.
+                            When layout is false, it means don't partition or ignore existing partitioning.
+                          type: boolean
+                        overwrite:
+                          description: |-
+                            overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                            Use with caution. Default is 'false'.
+                          type: boolean
+                        tableType:
+                          description: |-
+                            tableType specifies the tupe of partition table. The following are supported:
+                            'mbr': default and setups a MS-DOS partition table
+                            'gpt': setups a GPT partition table
+                          enum:
+                          - mbr
+                          - gpt
+                          type: string
+                      required:
+                      - device
+                      - layout
+                      type: object
+                    maxItems: 100
+                    type: array
+                type: object
+              files:
+                description: files specifies extra files to be passed to user_data
+                  upon creation.
+                items:
+                  description: File defines the input for generating write_files in
+                    cloud-init.
+                  properties:
+                    append:
+                      description: append specifies whether to append Content to existing
+                        file if Path exists.
+                      type: boolean
+                    content:
+                      description: content is the actual content of the file.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    contentFrom:
+                      description: contentFrom is a referenced source of content to
+                        populate the file.
+                      properties:
+                        secret:
+                          description: secret represents a secret that should populate
+                            this file.
+                          properties:
+                            key:
+                              description: key is the key in the secret's data map
+                                for this value.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    encoding:
+                      description: encoding specifies the encoding of the file contents.
+                      enum:
+                      - base64
+                      - gzip
+                      - gzip+base64
+                      type: string
+                    owner:
+                      description: owner specifies the ownership of the file, e.g.
+                        "root:root".
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    path:
+                      description: path specifies the full path on disk where to store
+                        the file.
+                      maxLength: 512
+                      minLength: 1
+                      type: string
+                    permissions:
+                      description: permissions specifies the permissions to assign
+                        to the file, e.g. "0640".
+                      maxLength: 16
+                      minLength: 1
+                      type: string
+                  required:
+                  - path
+                  type: object
+                maxItems: 200
+                type: array
+              format:
+                description: format specifies the output format of the bootstrap data
+                enum:
+                - cloud-config
+                - ignition
+                type: string
+              ignition:
+                description: ignition contains Ignition specific configuration.
+                properties:
+                  containerLinuxConfig:
+                    description: containerLinuxConfig contains CLC specific configuration.
+                    properties:
+                      additionalConfig:
+                        description: |-
+                          additionalConfig contains additional configuration to be merged with the Ignition
+                          configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                          The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                        maxLength: 32768
+                        minLength: 1
+                        type: string
+                      strict:
+                        description: strict controls if AdditionalConfig should be
+                          strictly parsed. If so, warnings are treated as errors.
+                        type: boolean
+                    type: object
+                type: object
+              initConfiguration:
+                description: initConfiguration along with ClusterConfiguration are
+                  the configurations necessary for the init command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  bootstrapTokens:
+                    description: |-
+                      bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                      This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                    items:
+                      description: BootstrapToken describes one bootstrap token, stored
+                        as a Secret in the cluster.
+                      properties:
+                        description:
+                          description: |-
+                            description sets a human-friendly message why this token exists and what it's used
+                            for, so other administrators can know its purpose.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        expires:
+                          description: |-
+                            expires specifies the timestamp when this token expires. Defaults to being set
+                            dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                          format: date-time
+                          type: string
+                        groups:
+                          description: |-
+                            groups specifies the extra groups that this token will authenticate as when/if
+                            used for authentication
+                          items:
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          maxItems: 100
+                          type: array
+                        token:
+                          description: |-
+                            token is used for establishing bidirectional trust between nodes and control-planes.
+                            Used for joining nodes in the cluster.
+                          type: string
+                        ttl:
+                          description: |-
+                            ttl defines the time to live for this token. Defaults to 24h.
+                            Expires and TTL are mutually exclusive.
+                          type: string
+                        usages:
+                          description: |-
+                            usages describes the ways in which this token can be used. Can by default be used
+                            for establishing bidirectional trust, but that can be changed here.
+                          items:
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          maxItems: 100
+                          type: array
+                      required:
+                      - token
+                      type: object
+                    maxItems: 100
+                    type: array
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  localAPIEndpoint:
+                    description: |-
+                      localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                      In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                      is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                      configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                      on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                      fails you may set the desired value here.
+                    properties:
+                      advertiseAddress:
+                        description: advertiseAddress sets the IP address for the
+                          API server to advertise.
+                        maxLength: 39
+                        minLength: 1
+                        type: string
+                      bindPort:
+                        description: |-
+                          bindPort sets the secure port for the API Server to bind to.
+                          Defaults to 6443.
+                        format: int32
+                        type: integer
+                    type: object
+                  nodeRegistration:
+                    description: |-
+                      nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: criSocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      ignorePreflightErrors:
+                        description: ignorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        maxItems: 50
+                        type: array
+                      imagePullPolicy:
+                        description: |-
+                          imagePullPolicy specifies the policy for image pulling
+                          during kubeadm "init" and "join" operations. The value of
+                          this field must be one of "Always", "IfNotPresent" or
+                          "Never". Defaults to "IfNotPresent". This can be used only
+                          with Kubernetes version equal to 1.22 and later.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSerial:
+                        description: |-
+                          imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                          Default: true (defaulted in kubeadm)
+                        type: boolean
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      taints:
+                        description: |-
+                          taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        maxItems: 100
+                        type: array
+                    type: object
+                  patches:
+                    description: |-
+                      patches contains options related to applying patches to components deployed by kubeadm during
+                      "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: |-
+                          directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                          "suffix" is an optional string that can be used to determine which patches are applied
+                          first alpha-numerically.
+                          These files can be written into the target directory via KubeadmConfig.Files which
+                          specifies additional files to be created on the machine, either with content inline or
+                          by referencing a secret.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                    type: object
+                  skipPhases:
+                    description: |-
+                      skipPhases is a list of phases to skip during command execution.
+                      The list of phases can be obtained with the "kubeadm init --help" command.
+                      This option takes effect only on Kubernetes >=1.22.0.
+                    items:
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    maxItems: 50
+                    type: array
+                type: object
+              joinConfiguration:
+                description: joinConfiguration is the kubeadm configuration for the
+                  join command
+                properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion defines the versioned schema of this representation of an object.
+                      Servers should convert recognized schemas to the latest internal value, and
+                      may reject unrecognized values.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                    type: string
+                  caCertPath:
+                    description: |-
+                      caCertPath is the path to the SSL certificate authority used to
+                      secure comunications between node and control-plane.
+                      Defaults to "/etc/kubernetes/pki/ca.crt".
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  controlPlane:
+                    description: |-
+                      controlPlane defines the additional control plane instance to be deployed on the joining node.
+                      If nil, no additional control plane instance will be deployed.
+                    properties:
+                      localAPIEndpoint:
+                        description: localAPIEndpoint represents the endpoint of the
+                          API server instance to be deployed on this node.
+                        properties:
+                          advertiseAddress:
+                            description: advertiseAddress sets the IP address for
+                              the API server to advertise.
+                            maxLength: 39
+                            minLength: 1
+                            type: string
+                          bindPort:
+                            description: |-
+                              bindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                    type: object
+                  discovery:
+                    description: discovery specifies the options for the kubelet to
+                      use during the TLS Bootstrap process
+                    properties:
+                      bootstrapToken:
+                        description: |-
+                          bootstrapToken is used to set the options for bootstrap token based discovery
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          apiServerEndpoint:
+                            description: apiServerEndpoint is an IP or domain name
+                              to the API server from which info will be fetched.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          caCertHashes:
+                            description: |-
+                              caCertHashes specifies a set of public key pins to verify
+                              when token-based discovery is used. The root CA found during discovery
+                              must match one of these values. Specifying an empty set disables root CA
+                              pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                              where the only currently supported type is "sha256". This is a hex-encoded
+                              SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                              ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                              openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                            items:
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            maxItems: 100
+                            type: array
+                          token:
+                            description: |-
+                              token is a token used to validate cluster information
+                              fetched from the control-plane.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          unsafeSkipCAVerification:
+                            description: |-
+                              unsafeSkipCAVerification allows token-based discovery
+                              without CA verification via CACertHashes. This can weaken
+                              the security of kubeadm since other nodes can impersonate the control-plane.
+                            type: boolean
+                        type: object
+                      file:
+                        description: |-
+                          file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                          BootstrapToken and File are mutually exclusive
+                        properties:
+                          kubeConfig:
+                            description: |-
+                              kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                              The file is generated at the path specified in KubeConfigPath.
+
+                              Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                              Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                            properties:
+                              cluster:
+                                description: |-
+                                  cluster contains information about how to communicate with the kubernetes cluster.
+
+                                  By default the following fields are automatically populated:
+                                  - Server with the Cluster's ControlPlaneEndpoint.
+                                  - CertificateAuthorityData with the Cluster's CA certificate.
+                                properties:
+                                  certificateAuthorityData:
+                                    description: |-
+                                      certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                      Defaults to the Cluster's CA certificate if empty.
+                                    format: byte
+                                    maxLength: 51200
+                                    minLength: 1
+                                    type: string
+                                  insecureSkipTLSVerify:
+                                    description: insecureSkipTLSVerify skips the validity
+                                      check for the server's certificate. This will
+                                      make your HTTPS connections insecure.
+                                    type: boolean
+                                  proxyURL:
+                                    description: |-
+                                      proxyURL is the URL to the proxy to be used for all requests made by this
+                                      client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                      this configuration is not provided or the empty string, the client
+                                      attempts to construct a proxy configuration from http_proxy and
+                                      https_proxy environment variables. If these environment variables are not
+                                      set, the client does not attempt to proxy requests.
+
+                                      socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                      attach, port forward).
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  server:
+                                    description: |-
+                                      server is the address of the kubernetes cluster (https://hostname:port).
+
+                                      Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  tlsServerName:
+                                    description: tlsServerName is used to check server
+                                      certificate. If TLSServerName is empty, the
+                                      hostname used to contact the server is used.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              user:
+                                description: |-
+                                  user contains information that describes identity information.
+                                  This is used to tell the kubernetes cluster who you are.
+                                properties:
+                                  authProvider:
+                                    description: authProvider specifies a custom authentication
+                                      plugin for the kubernetes cluster.
+                                    properties:
+                                      config:
+                                        additionalProperties:
+                                          type: string
+                                        description: config holds the parameters for
+                                          the authentication plugin.
+                                        type: object
+                                      name:
+                                        description: name is the name of the authentication
+                                          plugin.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - name
+                                    type: object
+                                  exec:
+                                    description: exec specifies a custom exec-based
+                                      authentication plugin for the kubernetes cluster.
+                                    properties:
+                                      apiVersion:
+                                        description: |-
+                                          apiVersion is preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                          the same encoding version as the input.
+                                          Defaults to client.authentication.k8s.io/v1 if not set.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      args:
+                                        description: args is the arguments to pass
+                                          to the command when executing it.
+                                        items:
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                      command:
+                                        description: command to execute.
+                                        maxLength: 1024
+                                        minLength: 1
+                                        type: string
+                                      env:
+                                        description: |-
+                                          env defines additional environment variables to expose to the process. These
+                                          are unioned with the host's environment, as well as variables client-go uses
+                                          to pass argument to the plugin.
+                                        items:
+                                          description: |-
+                                            KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                            credential plugin.
+                                          properties:
+                                            name:
+                                              description: name of the environment
+                                                variable
+                                              maxLength: 512
+                                              minLength: 1
+                                              type: string
+                                            value:
+                                              description: value of the environment
+                                                variable
+                                              maxLength: 512
+                                              minLength: 1
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        maxItems: 100
+                                        type: array
+                                      provideClusterInfo:
+                                        description: |-
+                                          provideClusterInfo determines whether or not to provide cluster information,
+                                          which could potentially contain very large CA data, to this exec plugin as a
+                                          part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                          to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                          reading this environment variable.
+                                        type: boolean
+                                    required:
+                                    - command
+                                    type: object
+                                type: object
+                            required:
+                            - user
+                            type: object
+                          kubeConfigPath:
+                            description: kubeConfigPath is used to specify the actual
+                              file path or URL to the kubeconfig file from which to
+                              load cluster information
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                        required:
+                        - kubeConfigPath
+                        type: object
+                      timeout:
+                        description: timeout modifies the discovery timeout
+                        type: string
+                      tlsBootstrapToken:
+                        description: |-
+                          tlsBootstrapToken is a token used for TLS bootstrapping.
+                          If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                          If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                    type: object
+                  kind:
+                    description: |-
+                      Kind is a string value representing the REST resource this object represents.
+                      Servers may infer this from the endpoint the client submits requests to.
+                      Cannot be updated.
+                      In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  nodeRegistration:
+                    description: |-
+                      nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                      When used in the context of control plane nodes, NodeRegistration should remain consistent
+                      across both InitConfiguration and JoinConfiguration
+                    properties:
+                      criSocket:
+                        description: criSocket is used to retrieve container runtime
+                          info. This information will be annotated to the Node API
+                          object, for later re-use
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      ignorePreflightErrors:
+                        description: ignorePreflightErrors provides a slice of pre-flight
+                          errors to be ignored when the current node is registered.
+                        items:
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        maxItems: 50
+                        type: array
+                      imagePullPolicy:
+                        description: |-
+                          imagePullPolicy specifies the policy for image pulling
+                          during kubeadm "init" and "join" operations. The value of
+                          this field must be one of "Always", "IfNotPresent" or
+                          "Never". Defaults to "IfNotPresent". This can be used only
+                          with Kubernetes version equal to 1.22 and later.
+                        enum:
+                        - Always
+                        - IfNotPresent
+                        - Never
+                        type: string
+                      imagePullSerial:
+                        description: |-
+                          imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                          This option takes effect only on Kubernetes >=1.31.0.
+                          Default: true (defaulted in kubeadm)
+                        type: boolean
+                      kubeletExtraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                          kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                          Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                        type: object
+                      name:
+                        description: |-
+                          name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                          This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                          Defaults to the hostname of the node if not provided.
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      taints:
+                        description: |-
+                          taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                          it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                          empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                        items:
+                          description: |-
+                            The node this Taint is attached to has the "effect" on
+                            any pod that does not tolerate the Taint.
+                          properties:
+                            effect:
+                              description: |-
+                                Required. The effect of the taint on pods
+                                that do not tolerate the taint.
+                                Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: Required. The taint key to be applied to
+                                a node.
+                              type: string
+                            timeAdded:
+                              description: |-
+                                TimeAdded represents the time at which the taint was added.
+                                It is only written for NoExecute taints.
+                              format: date-time
+                              type: string
+                            value:
+                              description: The taint value corresponding to the taint
+                                key.
+                              type: string
+                          required:
+                          - effect
+                          - key
+                          type: object
+                        maxItems: 100
+                        type: array
+                    type: object
+                  patches:
+                    description: |-
+                      patches contains options related to applying patches to components deployed by kubeadm during
+                      "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                    properties:
+                      directory:
+                        description: |-
+                          directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                          For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                          "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                          of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                          The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                          "suffix" is an optional string that can be used to determine which patches are applied
+                          first alpha-numerically.
+                          These files can be written into the target directory via KubeadmConfig.Files which
+                          specifies additional files to be created on the machine, either with content inline or
+                          by referencing a secret.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                    type: object
+                  skipPhases:
+                    description: |-
+                      skipPhases is a list of phases to skip during command execution.
+                      The list of phases can be obtained with the "kubeadm init --help" command.
+                      This option takes effect only on Kubernetes >=1.22.0.
+                    items:
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    maxItems: 50
+                    type: array
+                type: object
+              mounts:
+                description: mounts specifies a list of mount points to be setup.
+                items:
+                  description: MountPoints defines input for generated mounts in cloud-init.
+                  items:
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                  type: array
+                maxItems: 100
+                type: array
+              ntp:
+                description: ntp specifies NTP configuration
+                properties:
+                  enabled:
+                    description: enabled specifies whether NTP should be enabled
+                    type: boolean
+                  servers:
+                    description: servers specifies which NTP servers to use
+                    items:
+                      maxLength: 512
+                      minLength: 1
+                      type: string
+                    maxItems: 100
+                    type: array
+                type: object
+              postKubeadmCommands:
+                description: |-
+                  postKubeadmCommands specifies extra commands to run after kubeadm runs.
+                  With cloud-init, this is appended to the runcmd module configuration, and is typically executed in
+                  the cloud-final.service systemd unit. In Ignition, this is appended to /etc/kubeadm.sh.
+                items:
+                  maxLength: 10240
+                  minLength: 1
+                  type: string
+                maxItems: 1000
+                type: array
+              preKubeadmCommands:
+                description: |-
+                  preKubeadmCommands specifies extra commands to run before kubeadm runs.
+                  With cloud-init, this is prepended to the runcmd module configuration, and is typically executed in
+                  the cloud-final.service systemd unit. In Ignition, this is prepended to /etc/kubeadm.sh.
+                items:
+                  maxLength: 10240
+                  minLength: 1
+                  type: string
+                maxItems: 1000
+                type: array
+              useExperimentalRetryJoin:
+                description: |-
+                  useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                  script with retries for joins.
+
+                  This is meant to be an experimental temporary workaround on some environments
+                  where joins fail due to timing (and other issues). The long term goal is to add retries to
+                  kubeadm proper and use that functionality.
+
+                  This will add about 40KB to userdata
+
+                  For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                  Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                  When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                type: boolean
+              users:
+                description: users specifies extra users to add
+                items:
+                  description: User defines the input for a generated user in cloud-init.
+                  properties:
+                    gecos:
+                      description: gecos specifies the gecos to use for the user
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    groups:
+                      description: groups specifies the additional groups for the
+                        user
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    homeDir:
+                      description: homeDir specifies the home directory to use for
+                        the user
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    inactive:
+                      description: inactive specifies whether to mark the user as
+                        inactive
+                      type: boolean
+                    lockPassword:
+                      description: lockPassword specifies if password login should
+                        be disabled
+                      type: boolean
+                    name:
+                      description: name specifies the user name
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    passwd:
+                      description: passwd specifies a hashed password for the user
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    passwdFrom:
+                      description: passwdFrom is a referenced source of passwd to
+                        populate the passwd.
+                      properties:
+                        secret:
+                          description: secret represents a secret that should populate
+                            this password.
+                          properties:
+                            key:
+                              description: key is the key in the secret's data map
+                                for this value.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            name:
+                              description: name of the secret in the KubeadmBootstrapConfig's
+                                namespace to use.
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                          required:
+                          - key
+                          - name
+                          type: object
+                      required:
+                      - secret
+                      type: object
+                    primaryGroup:
+                      description: primaryGroup specifies the primary group for the
+                        user
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    shell:
+                      description: shell specifies the user's shell
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    sshAuthorizedKeys:
+                      description: sshAuthorizedKeys specifies a list of ssh authorized
+                        keys for the user
+                      items:
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      maxItems: 100
+                      type: array
+                    sudo:
+                      description: sudo specifies a sudo role for the user
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - name
+                  type: object
+                maxItems: 100
+                type: array
+              verbosity:
+                description: |-
+                  verbosity is the number for the kubeadm log level verbosity.
+                  It overrides the `--v` flag in kubeadm commands.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: status is the observed state of KubeadmConfig.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dataSecretName:
+                description: dataSecretName is the name of the secret that stores
+                  the bootstrap data script.
+                maxLength: 253
+                minLength: 1
+                type: string
+              failureMessage:
+                description: |-
+                  failureMessage will be set on non-retryable errors
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason will be set on non-retryable errors
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 256
+                minLength: 1
+                type: string
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: ready indicates the BootstrapData field is ready to be
+                  consumed
+                type: boolean
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in KubeadmConfig's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a KubeadmConfig's current state.
+                      Known condition types are Ready, DataSecretAvailable, CertificatesAvailable.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/cluster_api/kubeadm_bootstrap/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+++ b/docs/shared/crds/cluster_api/kubeadm_bootstrap/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
@@ -1,0 +1,2017 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: kubeadmconfigtemplates.bootstrap.cluster.x-k8s.io
+spec:
+  group: bootstrap.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmConfigTemplate
+    listKind: KubeadmConfigTemplateList
+    plural: kubeadmconfigtemplates
+    singular: kubeadmconfigtemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmConfigTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmConfigTemplate is the Schema for the kubeadmconfigtemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of KubeadmConfigTemplate.
+            properties:
+              template:
+                description: template defines the desired state of KubeadmConfigTemplate.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: spec is the desired state of KubeadmConfig.
+                    properties:
+                      bootCommands:
+                        description: |-
+                          bootCommands specifies extra commands to run very early in the boot process via the cloud-init bootcmd
+                          module. bootcmd will run on every boot, 'cloud-init-per' command can be used to make bootcmd run exactly
+                          once. This is typically run in the cloud-init.service systemd unit. This has no effect in Ignition.
+                        items:
+                          maxLength: 10240
+                          minLength: 1
+                          type: string
+                        maxItems: 1000
+                        type: array
+                      clusterConfiguration:
+                        description: clusterConfiguration along with InitConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiServer:
+                            description: apiServer contains extra settings for the
+                              API server control plane component
+                            properties:
+                              certSANs:
+                                description: certSANs sets extra Subject Alternative
+                                  Names for the API Server signing cert.
+                                items:
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                maxItems: 100
+                                type: array
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              timeoutForControlPlane:
+                                description: timeoutForControlPlane controls the timeout
+                                  that we use for API server to appear
+                                type: string
+                            type: object
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          certificatesDir:
+                            description: |-
+                              certificatesDir specifies where to store or look for all required certificates.
+                              NB: if not provided, this will default to `/etc/kubernetes/pki`
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          clusterName:
+                            description: clusterName is the cluster name
+                            maxLength: 63
+                            minLength: 1
+                            type: string
+                          controlPlaneEndpoint:
+                            description: |-
+                              controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                              can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                              In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                              are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                              the BindPort is used.
+                              Possible usages are:
+                              e.g. In a cluster with more than one control plane instances, this field should be
+                              assigned the address of the external load balancer in front of the
+                              control plane instances.
+                              e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                              could be used for assigning a stable DNS to the control plane.
+                              NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          controllerManager:
+                            description: controllerManager contains extra settings
+                              for the controller manager control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                            type: object
+                          dns:
+                            description: dns defines the options for the DNS add-on
+                              installed in the cluster.
+                            properties:
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              imageTag:
+                                description: |-
+                                  imageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                            type: object
+                          etcd:
+                            description: |-
+                              etcd holds configuration for etcd.
+                              NB: This value defaults to a Local (stacked) etcd
+                            properties:
+                              external:
+                                description: |-
+                                  external describes how to connect to an external etcd cluster
+                                  Local and External are mutually exclusive
+                                properties:
+                                  caFile:
+                                    description: |-
+                                      caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  certFile:
+                                    description: |-
+                                      certFile is an SSL certification file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  endpoints:
+                                    description: endpoints of etcd members. Required
+                                      for ExternalEtcd.
+                                    items:
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 50
+                                    type: array
+                                  keyFile:
+                                    description: |-
+                                      keyFile is an SSL key file used to secure etcd communication.
+                                      Required if using a TLS connection.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - caFile
+                                - certFile
+                                - endpoints
+                                - keyFile
+                                type: object
+                              local:
+                                description: |-
+                                  local provides configuration knobs for configuring the local etcd instance
+                                  Local and External are mutually exclusive
+                                properties:
+                                  dataDir:
+                                    description: |-
+                                      dataDir is the directory etcd will place its data.
+                                      Defaults to "/var/lib/etcd".
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      extraArgs are extra arguments provided to the etcd binary
+                                      when run inside a static pod.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                  imageRepository:
+                                    description: |-
+                                      imageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      imageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                  peerCertSANs:
+                                    description: peerCertSANs sets extra Subject Alternative
+                                      Names for the etcd peer signing cert.
+                                    items:
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 100
+                                    type: array
+                                  serverCertSANs:
+                                    description: serverCertSANs sets extra Subject
+                                      Alternative Names for the etcd server signing
+                                      cert.
+                                    items:
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 100
+                                    type: array
+                                type: object
+                            type: object
+                          featureGates:
+                            additionalProperties:
+                              type: boolean
+                            description: featureGates enabled by the user.
+                            type: object
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              * If not set, the default registry of kubeadm will be used, i.e.
+                                * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                * k8s.gcr.io (old registry): all older versions
+                                Please note that when imageRepository is not set we don't allow upgrades to
+                                versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                              * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                               `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          kubernetesVersion:
+                            description: |-
+                              kubernetesVersion is the target version of the control plane.
+                              NB: This value defaults to the Machine object spec.version
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                          networking:
+                            description: |-
+                              networking holds configuration for the networking topology of the cluster.
+                              NB: This value defaults to the Cluster object spec.clusterNetwork.
+                            properties:
+                              dnsDomain:
+                                description: dnsDomain is the dns domain used by k8s
+                                  services. Defaults to "cluster.local".
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              podSubnet:
+                                description: |-
+                                  podSubnet is the subnet used by pods.
+                                  If unset, the API server will not allocate CIDR ranges for every node.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                maxLength: 1024
+                                minLength: 1
+                                type: string
+                              serviceSubnet:
+                                description: |-
+                                  serviceSubnet is the subnet used by k8s services.
+                                  Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                  to "10.96.0.0/12" if that's unset.
+                                maxLength: 1024
+                                minLength: 1
+                                type: string
+                            type: object
+                          scheduler:
+                            description: scheduler contains extra settings for the
+                              scheduler control plane component
+                            properties:
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: extraArgs is an extra set of flags to
+                                  pass to the control plane component.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              extraVolumes:
+                                description: extraVolumes is an extra set of host
+                                  volumes, mounted to the control plane component.
+                                items:
+                                  description: |-
+                                    HostPathMount contains elements describing volumes that are mounted from the
+                                    host.
+                                  properties:
+                                    hostPath:
+                                      description: |-
+                                        hostPath is the path in the host that will be mounted inside
+                                        the pod.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    mountPath:
+                                      description: mountPath is the path inside the
+                                        pod where hostPath will be mounted.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      description: name of the volume inside the pod
+                                        template.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    pathType:
+                                      description: pathType is the type of the HostPath.
+                                      type: string
+                                    readOnly:
+                                      description: readOnly controls write access
+                                        to the volume
+                                      type: boolean
+                                  required:
+                                  - hostPath
+                                  - mountPath
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                            type: object
+                        type: object
+                      diskSetup:
+                        description: diskSetup specifies options for the creation
+                          of partition tables and file systems on devices.
+                        properties:
+                          filesystems:
+                            description: filesystems specifies the list of file systems
+                              to setup.
+                            items:
+                              description: Filesystem defines the file systems to
+                                be created.
+                              properties:
+                                device:
+                                  description: device specifies the device name
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                extraOpts:
+                                  description: extraOpts defined extra options to
+                                    add to the command for creating the file system.
+                                  items:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                  maxItems: 100
+                                  type: array
+                                filesystem:
+                                  description: filesystem specifies the file system
+                                    type.
+                                  maxLength: 128
+                                  minLength: 1
+                                  type: string
+                                label:
+                                  description: label specifies the file system label
+                                    to be used. If set to None, no label is used.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                overwrite:
+                                  description: |-
+                                    overwrite defines whether or not to overwrite any existing filesystem.
+                                    If true, any pre-existing file system will be destroyed. Use with Caution.
+                                  type: boolean
+                                partition:
+                                  description: 'partition specifies the partition
+                                    to use. The valid options are: "auto|any", "auto",
+                                    "any", "none", and <NUM>, where NUM is the actual
+                                    partition number.'
+                                  maxLength: 128
+                                  minLength: 1
+                                  type: string
+                                replaceFS:
+                                  description: |-
+                                    replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                    NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                  maxLength: 128
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - device
+                              - filesystem
+                              type: object
+                            maxItems: 100
+                            type: array
+                          partitions:
+                            description: partitions specifies the list of the partitions
+                              to setup.
+                            items:
+                              description: Partition defines how to create and layout
+                                a partition.
+                              properties:
+                                device:
+                                  description: device is the name of the device.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                layout:
+                                  description: |-
+                                    layout specifies the device layout.
+                                    If it is true, a single partition will be created for the entire device.
+                                    When layout is false, it means don't partition or ignore existing partitioning.
+                                  type: boolean
+                                overwrite:
+                                  description: |-
+                                    overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                    Use with caution. Default is 'false'.
+                                  type: boolean
+                                tableType:
+                                  description: |-
+                                    tableType specifies the tupe of partition table. The following are supported:
+                                    'mbr': default and setups a MS-DOS partition table
+                                    'gpt': setups a GPT partition table
+                                  enum:
+                                  - mbr
+                                  - gpt
+                                  type: string
+                              required:
+                              - device
+                              - layout
+                              type: object
+                            maxItems: 100
+                            type: array
+                        type: object
+                      files:
+                        description: files specifies extra files to be passed to user_data
+                          upon creation.
+                        items:
+                          description: File defines the input for generating write_files
+                            in cloud-init.
+                          properties:
+                            append:
+                              description: append specifies whether to append Content
+                                to existing file if Path exists.
+                              type: boolean
+                            content:
+                              description: content is the actual content of the file.
+                              maxLength: 10240
+                              minLength: 1
+                              type: string
+                            contentFrom:
+                              description: contentFrom is a referenced source of content
+                                to populate the file.
+                              properties:
+                                secret:
+                                  description: secret represents a secret that should
+                                    populate this file.
+                                  properties:
+                                    key:
+                                      description: key is the key in the secret's
+                                        data map for this value.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      description: name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            encoding:
+                              description: encoding specifies the encoding of the
+                                file contents.
+                              enum:
+                              - base64
+                              - gzip
+                              - gzip+base64
+                              type: string
+                            owner:
+                              description: owner specifies the ownership of the file,
+                                e.g. "root:root".
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            path:
+                              description: path specifies the full path on disk where
+                                to store the file.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            permissions:
+                              description: permissions specifies the permissions to
+                                assign to the file, e.g. "0640".
+                              maxLength: 16
+                              minLength: 1
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        maxItems: 200
+                        type: array
+                      format:
+                        description: format specifies the output format of the bootstrap
+                          data
+                        enum:
+                        - cloud-config
+                        - ignition
+                        type: string
+                      ignition:
+                        description: ignition contains Ignition specific configuration.
+                        properties:
+                          containerLinuxConfig:
+                            description: containerLinuxConfig contains CLC specific
+                              configuration.
+                            properties:
+                              additionalConfig:
+                                description: |-
+                                  additionalConfig contains additional configuration to be merged with the Ignition
+                                  configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                                  The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                maxLength: 32768
+                                minLength: 1
+                                type: string
+                              strict:
+                                description: strict controls if AdditionalConfig should
+                                  be strictly parsed. If so, warnings are treated
+                                  as errors.
+                                type: boolean
+                            type: object
+                        type: object
+                      initConfiguration:
+                        description: initConfiguration along with ClusterConfiguration
+                          are the configurations necessary for the init command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          bootstrapTokens:
+                            description: |-
+                              bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                              This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                            items:
+                              description: BootstrapToken describes one bootstrap
+                                token, stored as a Secret in the cluster.
+                              properties:
+                                description:
+                                  description: |-
+                                    description sets a human-friendly message why this token exists and what it's used
+                                    for, so other administrators can know its purpose.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                expires:
+                                  description: |-
+                                    expires specifies the timestamp when this token expires. Defaults to being set
+                                    dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                  format: date-time
+                                  type: string
+                                groups:
+                                  description: |-
+                                    groups specifies the extra groups that this token will authenticate as when/if
+                                    used for authentication
+                                  items:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                  maxItems: 100
+                                  type: array
+                                token:
+                                  description: |-
+                                    token is used for establishing bidirectional trust between nodes and control-planes.
+                                    Used for joining nodes in the cluster.
+                                  type: string
+                                ttl:
+                                  description: |-
+                                    ttl defines the time to live for this token. Defaults to 24h.
+                                    Expires and TTL are mutually exclusive.
+                                  type: string
+                                usages:
+                                  description: |-
+                                    usages describes the ways in which this token can be used. Can by default be used
+                                    for establishing bidirectional trust, but that can be changed here.
+                                  items:
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                  maxItems: 100
+                                  type: array
+                              required:
+                              - token
+                              type: object
+                            maxItems: 100
+                            type: array
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          localAPIEndpoint:
+                            description: |-
+                              localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                              In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                              is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                              configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                              on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                              fails you may set the desired value here.
+                            properties:
+                              advertiseAddress:
+                                description: advertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                maxLength: 39
+                                minLength: 1
+                                type: string
+                              bindPort:
+                                description: |-
+                                  bindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                          nodeRegistration:
+                            description: |-
+                              nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: criSocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              ignorePreflightErrors:
+                                description: ignorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                maxItems: 50
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  imagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              imagePullSerial:
+                                description: |-
+                                  imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                  Default: true (defaulted in kubeadm)
+                                type: boolean
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              taints:
+                                description: |-
+                                  taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                maxItems: 100
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              skipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            maxItems: 50
+                            type: array
+                        type: object
+                      joinConfiguration:
+                        description: joinConfiguration is the kubeadm configuration
+                          for the join command
+                        properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion defines the versioned schema of this representation of an object.
+                              Servers should convert recognized schemas to the latest internal value, and
+                              may reject unrecognized values.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                            type: string
+                          caCertPath:
+                            description: |-
+                              caCertPath is the path to the SSL certificate authority used to
+                              secure comunications between node and control-plane.
+                              Defaults to "/etc/kubernetes/pki/ca.crt".
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          controlPlane:
+                            description: |-
+                              controlPlane defines the additional control plane instance to be deployed on the joining node.
+                              If nil, no additional control plane instance will be deployed.
+                            properties:
+                              localAPIEndpoint:
+                                description: localAPIEndpoint represents the endpoint
+                                  of the API server instance to be deployed on this
+                                  node.
+                                properties:
+                                  advertiseAddress:
+                                    description: advertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    maxLength: 39
+                                    minLength: 1
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      bindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                            type: object
+                          discovery:
+                            description: discovery specifies the options for the kubelet
+                              to use during the TLS Bootstrap process
+                            properties:
+                              bootstrapToken:
+                                description: |-
+                                  bootstrapToken is used to set the options for bootstrap token based discovery
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  apiServerEndpoint:
+                                    description: apiServerEndpoint is an IP or domain
+                                      name to the API server from which info will
+                                      be fetched.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  caCertHashes:
+                                    description: |-
+                                      caCertHashes specifies a set of public key pins to verify
+                                      when token-based discovery is used. The root CA found during discovery
+                                      must match one of these values. Specifying an empty set disables root CA
+                                      pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                      where the only currently supported type is "sha256". This is a hex-encoded
+                                      SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                      ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                      openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                    items:
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 100
+                                    type: array
+                                  token:
+                                    description: |-
+                                      token is a token used to validate cluster information
+                                      fetched from the control-plane.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  unsafeSkipCAVerification:
+                                    description: |-
+                                      unsafeSkipCAVerification allows token-based discovery
+                                      without CA verification via CACertHashes. This can weaken
+                                      the security of kubeadm since other nodes can impersonate the control-plane.
+                                    type: boolean
+                                type: object
+                              file:
+                                description: |-
+                                  file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                  BootstrapToken and File are mutually exclusive
+                                properties:
+                                  kubeConfig:
+                                    description: |-
+                                      kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                      The file is generated at the path specified in KubeConfigPath.
+
+                                      Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                      Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                    properties:
+                                      cluster:
+                                        description: |-
+                                          cluster contains information about how to communicate with the kubernetes cluster.
+
+                                          By default the following fields are automatically populated:
+                                          - Server with the Cluster's ControlPlaneEndpoint.
+                                          - CertificateAuthorityData with the Cluster's CA certificate.
+                                        properties:
+                                          certificateAuthorityData:
+                                            description: |-
+                                              certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                              Defaults to the Cluster's CA certificate if empty.
+                                            format: byte
+                                            maxLength: 51200
+                                            minLength: 1
+                                            type: string
+                                          insecureSkipTLSVerify:
+                                            description: insecureSkipTLSVerify skips
+                                              the validity check for the server's
+                                              certificate. This will make your HTTPS
+                                              connections insecure.
+                                            type: boolean
+                                          proxyURL:
+                                            description: |-
+                                              proxyURL is the URL to the proxy to be used for all requests made by this
+                                              client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                              this configuration is not provided or the empty string, the client
+                                              attempts to construct a proxy configuration from http_proxy and
+                                              https_proxy environment variables. If these environment variables are not
+                                              set, the client does not attempt to proxy requests.
+
+                                              socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                              attach, port forward).
+                                            maxLength: 512
+                                            minLength: 1
+                                            type: string
+                                          server:
+                                            description: |-
+                                              server is the address of the kubernetes cluster (https://hostname:port).
+
+                                              Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                            maxLength: 512
+                                            minLength: 1
+                                            type: string
+                                          tlsServerName:
+                                            description: tlsServerName is used to
+                                              check server certificate. If TLSServerName
+                                              is empty, the hostname used to contact
+                                              the server is used.
+                                            maxLength: 512
+                                            minLength: 1
+                                            type: string
+                                        type: object
+                                      user:
+                                        description: |-
+                                          user contains information that describes identity information.
+                                          This is used to tell the kubernetes cluster who you are.
+                                        properties:
+                                          authProvider:
+                                            description: authProvider specifies a
+                                              custom authentication plugin for the
+                                              kubernetes cluster.
+                                            properties:
+                                              config:
+                                                additionalProperties:
+                                                  type: string
+                                                description: config holds the parameters
+                                                  for the authentication plugin.
+                                                type: object
+                                              name:
+                                                description: name is the name of the
+                                                  authentication plugin.
+                                                maxLength: 256
+                                                minLength: 1
+                                                type: string
+                                            required:
+                                            - name
+                                            type: object
+                                          exec:
+                                            description: exec specifies a custom exec-based
+                                              authentication plugin for the kubernetes
+                                              cluster.
+                                            properties:
+                                              apiVersion:
+                                                description: |-
+                                                  apiVersion is preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                  the same encoding version as the input.
+                                                  Defaults to client.authentication.k8s.io/v1 if not set.
+                                                maxLength: 512
+                                                minLength: 1
+                                                type: string
+                                              args:
+                                                description: args is the arguments
+                                                  to pass to the command when executing
+                                                  it.
+                                                items:
+                                                  maxLength: 512
+                                                  minLength: 1
+                                                  type: string
+                                                maxItems: 100
+                                                type: array
+                                              command:
+                                                description: command to execute.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                type: string
+                                              env:
+                                                description: |-
+                                                  env defines additional environment variables to expose to the process. These
+                                                  are unioned with the host's environment, as well as variables client-go uses
+                                                  to pass argument to the plugin.
+                                                items:
+                                                  description: |-
+                                                    KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                    credential plugin.
+                                                  properties:
+                                                    name:
+                                                      description: name of the environment
+                                                        variable
+                                                      maxLength: 512
+                                                      minLength: 1
+                                                      type: string
+                                                    value:
+                                                      description: value of the environment
+                                                        variable
+                                                      maxLength: 512
+                                                      minLength: 1
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                maxItems: 100
+                                                type: array
+                                              provideClusterInfo:
+                                                description: |-
+                                                  provideClusterInfo determines whether or not to provide cluster information,
+                                                  which could potentially contain very large CA data, to this exec plugin as a
+                                                  part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                  to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                  reading this environment variable.
+                                                type: boolean
+                                            required:
+                                            - command
+                                            type: object
+                                        type: object
+                                    required:
+                                    - user
+                                    type: object
+                                  kubeConfigPath:
+                                    description: kubeConfigPath is used to specify
+                                      the actual file path or URL to the kubeconfig
+                                      file from which to load cluster information
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                required:
+                                - kubeConfigPath
+                                type: object
+                              timeout:
+                                description: timeout modifies the discovery timeout
+                                type: string
+                              tlsBootstrapToken:
+                                description: |-
+                                  tlsBootstrapToken is a token used for TLS bootstrapping.
+                                  If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                  If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                            type: object
+                          kind:
+                            description: |-
+                              Kind is a string value representing the REST resource this object represents.
+                              Servers may infer this from the endpoint the client submits requests to.
+                              Cannot be updated.
+                              In CamelCase.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                            type: string
+                          nodeRegistration:
+                            description: |-
+                              nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                              When used in the context of control plane nodes, NodeRegistration should remain consistent
+                              across both InitConfiguration and JoinConfiguration
+                            properties:
+                              criSocket:
+                                description: criSocket is used to retrieve container
+                                  runtime info. This information will be annotated
+                                  to the Node API object, for later re-use
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              ignorePreflightErrors:
+                                description: ignorePreflightErrors provides a slice
+                                  of pre-flight errors to be ignored when the current
+                                  node is registered.
+                                items:
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                maxItems: 50
+                                type: array
+                              imagePullPolicy:
+                                description: |-
+                                  imagePullPolicy specifies the policy for image pulling
+                                  during kubeadm "init" and "join" operations. The value of
+                                  this field must be one of "Always", "IfNotPresent" or
+                                  "Never". Defaults to "IfNotPresent". This can be used only
+                                  with Kubernetes version equal to 1.22 and later.
+                                enum:
+                                - Always
+                                - IfNotPresent
+                                - Never
+                                type: string
+                              imagePullSerial:
+                                description: |-
+                                  imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                  Default: true (defaulted in kubeadm)
+                                type: boolean
+                              kubeletExtraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                  kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                  Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                type: object
+                              name:
+                                description: |-
+                                  name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                  This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                  Defaults to the hostname of the node if not provided.
+                                maxLength: 253
+                                minLength: 1
+                                type: string
+                              taints:
+                                description: |-
+                                  taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                  it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                  empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                items:
+                                  description: |-
+                                    The node this Taint is attached to has the "effect" on
+                                    any pod that does not tolerate the Taint.
+                                  properties:
+                                    effect:
+                                      description: |-
+                                        Required. The effect of the taint on pods
+                                        that do not tolerate the taint.
+                                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                      type: string
+                                    key:
+                                      description: Required. The taint key to be applied
+                                        to a node.
+                                      type: string
+                                    timeAdded:
+                                      description: |-
+                                        TimeAdded represents the time at which the taint was added.
+                                        It is only written for NoExecute taints.
+                                      format: date-time
+                                      type: string
+                                    value:
+                                      description: The taint value corresponding to
+                                        the taint key.
+                                      type: string
+                                  required:
+                                  - effect
+                                  - key
+                                  type: object
+                                maxItems: 100
+                                type: array
+                            type: object
+                          patches:
+                            description: |-
+                              patches contains options related to applying patches to components deployed by kubeadm during
+                              "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                            properties:
+                              directory:
+                                description: |-
+                                  directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                  For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                  "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                  of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                  The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                  "suffix" is an optional string that can be used to determine which patches are applied
+                                  first alpha-numerically.
+                                  These files can be written into the target directory via KubeadmConfig.Files which
+                                  specifies additional files to be created on the machine, either with content inline or
+                                  by referencing a secret.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                            type: object
+                          skipPhases:
+                            description: |-
+                              skipPhases is a list of phases to skip during command execution.
+                              The list of phases can be obtained with the "kubeadm init --help" command.
+                              This option takes effect only on Kubernetes >=1.22.0.
+                            items:
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            maxItems: 50
+                            type: array
+                        type: object
+                      mounts:
+                        description: mounts specifies a list of mount points to be
+                          setup.
+                        items:
+                          description: MountPoints defines input for generated mounts
+                            in cloud-init.
+                          items:
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          type: array
+                        maxItems: 100
+                        type: array
+                      ntp:
+                        description: ntp specifies NTP configuration
+                        properties:
+                          enabled:
+                            description: enabled specifies whether NTP should be enabled
+                            type: boolean
+                          servers:
+                            description: servers specifies which NTP servers to use
+                            items:
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            maxItems: 100
+                            type: array
+                        type: object
+                      postKubeadmCommands:
+                        description: |-
+                          postKubeadmCommands specifies extra commands to run after kubeadm runs.
+                          With cloud-init, this is appended to the runcmd module configuration, and is typically executed in
+                          the cloud-final.service systemd unit. In Ignition, this is appended to /etc/kubeadm.sh.
+                        items:
+                          maxLength: 10240
+                          minLength: 1
+                          type: string
+                        maxItems: 1000
+                        type: array
+                      preKubeadmCommands:
+                        description: |-
+                          preKubeadmCommands specifies extra commands to run before kubeadm runs.
+                          With cloud-init, this is prepended to the runcmd module configuration, and is typically executed in
+                          the cloud-final.service systemd unit. In Ignition, this is prepended to /etc/kubeadm.sh.
+                        items:
+                          maxLength: 10240
+                          minLength: 1
+                          type: string
+                        maxItems: 1000
+                        type: array
+                      useExperimentalRetryJoin:
+                        description: |-
+                          useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                          script with retries for joins.
+
+                          This is meant to be an experimental temporary workaround on some environments
+                          where joins fail due to timing (and other issues). The long term goal is to add retries to
+                          kubeadm proper and use that functionality.
+
+                          This will add about 40KB to userdata
+
+                          For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                          Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                          When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                        type: boolean
+                      users:
+                        description: users specifies extra users to add
+                        items:
+                          description: User defines the input for a generated user
+                            in cloud-init.
+                          properties:
+                            gecos:
+                              description: gecos specifies the gecos to use for the
+                                user
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            groups:
+                              description: groups specifies the additional groups
+                                for the user
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            homeDir:
+                              description: homeDir specifies the home directory to
+                                use for the user
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            inactive:
+                              description: inactive specifies whether to mark the
+                                user as inactive
+                              type: boolean
+                            lockPassword:
+                              description: lockPassword specifies if password login
+                                should be disabled
+                              type: boolean
+                            name:
+                              description: name specifies the user name
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            passwd:
+                              description: passwd specifies a hashed password for
+                                the user
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            passwdFrom:
+                              description: passwdFrom is a referenced source of passwd
+                                to populate the passwd.
+                              properties:
+                                secret:
+                                  description: secret represents a secret that should
+                                    populate this password.
+                                  properties:
+                                    key:
+                                      description: key is the key in the secret's
+                                        data map for this value.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    name:
+                                      description: name of the secret in the KubeadmBootstrapConfig's
+                                        namespace to use.
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - key
+                                  - name
+                                  type: object
+                              required:
+                              - secret
+                              type: object
+                            primaryGroup:
+                              description: primaryGroup specifies the primary group
+                                for the user
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            shell:
+                              description: shell specifies the user's shell
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            sshAuthorizedKeys:
+                              description: sshAuthorizedKeys specifies a list of ssh
+                                authorized keys for the user
+                              items:
+                                maxLength: 2048
+                                minLength: 1
+                                type: string
+                              maxItems: 100
+                              type: array
+                            sudo:
+                              description: sudo specifies a sudo role for the user
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                      verbosity:
+                        description: |-
+                          verbosity is the number for the kubeadm log level verbosity.
+                          It overrides the `--v` flag in kubeadm commands.
+                        format: int32
+                        type: integer
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/cluster_api/kubeadm_control_plane/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+++ b/docs/shared/crds/cluster_api/kubeadm_control_plane/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
@@ -1,0 +1,2587 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: kubeadmcontrolplanes.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlane
+    listKind: KubeadmControlPlaneList
+    plural: kubeadmcontrolplanes
+    shortNames:
+    - kcp
+    singular: kubeadmcontrolplane
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Cluster
+      jsonPath: .metadata.labels['cluster\.x-k8s\.io/cluster-name']
+      name: Cluster
+      type: string
+    - description: This denotes whether or not the control plane has the uploaded
+        kubeadm-config configmap
+      jsonPath: .status.initialized
+      name: Initialized
+      type: boolean
+    - description: KubeadmControlPlane API Server is ready to receive requests
+      jsonPath: .status.ready
+      name: API Server Available
+      type: boolean
+    - description: Total number of machines desired by this control plane
+      jsonPath: .spec.replicas
+      name: Desired
+      priority: 10
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane
+      jsonPath: .status.replicas
+      name: Replicas
+      type: integer
+    - description: Total number of fully running and ready control plane machines
+      jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - description: Total number of non-terminated machines targeted by this control
+        plane that have the desired template spec
+      jsonPath: .status.updatedReplicas
+      name: Updated
+      type: integer
+    - description: Total number of unavailable machines targeted by this control plane
+      jsonPath: .status.unavailableReplicas
+      name: Unavailable
+      type: integer
+    - description: Time duration since creation of KubeadmControlPlane
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Kubernetes version associated with this control plane
+      jsonPath: .spec.version
+      name: Version
+      type: string
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlane is the Schema for the KubeadmControlPlane
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of KubeadmControlPlane.
+            properties:
+              kubeadmConfigSpec:
+                description: |-
+                  kubeadmConfigSpec is a KubeadmConfigSpec
+                  to use for initializing and joining machines to the control plane.
+                properties:
+                  bootCommands:
+                    description: |-
+                      bootCommands specifies extra commands to run very early in the boot process via the cloud-init bootcmd
+                      module. bootcmd will run on every boot, 'cloud-init-per' command can be used to make bootcmd run exactly
+                      once. This is typically run in the cloud-init.service systemd unit. This has no effect in Ignition.
+                    items:
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    maxItems: 1000
+                    type: array
+                  clusterConfiguration:
+                    description: clusterConfiguration along with InitConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiServer:
+                        description: apiServer contains extra settings for the API
+                          server control plane component
+                        properties:
+                          certSANs:
+                            description: certSANs sets extra Subject Alternative Names
+                              for the API Server signing cert.
+                            items:
+                              maxLength: 253
+                              minLength: 1
+                              type: string
+                            maxItems: 100
+                            type: array
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                          timeoutForControlPlane:
+                            description: timeoutForControlPlane controls the timeout
+                              that we use for API server to appear
+                            type: string
+                        type: object
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      certificatesDir:
+                        description: |-
+                          certificatesDir specifies where to store or look for all required certificates.
+                          NB: if not provided, this will default to `/etc/kubernetes/pki`
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      clusterName:
+                        description: clusterName is the cluster name
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      controlPlaneEndpoint:
+                        description: |-
+                          controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                          can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                          In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                          are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                          the BindPort is used.
+                          Possible usages are:
+                          e.g. In a cluster with more than one control plane instances, this field should be
+                          assigned the address of the external load balancer in front of the
+                          control plane instances.
+                          e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                          could be used for assigning a stable DNS to the control plane.
+                          NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      controllerManager:
+                        description: controllerManager contains extra settings for
+                          the controller manager control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                        type: object
+                      dns:
+                        description: dns defines the options for the DNS add-on installed
+                          in the cluster.
+                        properties:
+                          imageRepository:
+                            description: |-
+                              imageRepository sets the container registry to pull images from.
+                              if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          imageTag:
+                            description: |-
+                              imageTag allows to specify a tag for the image.
+                              In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                        type: object
+                      etcd:
+                        description: |-
+                          etcd holds configuration for etcd.
+                          NB: This value defaults to a Local (stacked) etcd
+                        properties:
+                          external:
+                            description: |-
+                              external describes how to connect to an external etcd cluster
+                              Local and External are mutually exclusive
+                            properties:
+                              caFile:
+                                description: |-
+                                  caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              certFile:
+                                description: |-
+                                  certFile is an SSL certification file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              endpoints:
+                                description: endpoints of etcd members. Required for
+                                  ExternalEtcd.
+                                items:
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                maxItems: 50
+                                type: array
+                              keyFile:
+                                description: |-
+                                  keyFile is an SSL key file used to secure etcd communication.
+                                  Required if using a TLS connection.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                            required:
+                            - caFile
+                            - certFile
+                            - endpoints
+                            - keyFile
+                            type: object
+                          local:
+                            description: |-
+                              local provides configuration knobs for configuring the local etcd instance
+                              Local and External are mutually exclusive
+                            properties:
+                              dataDir:
+                                description: |-
+                                  dataDir is the directory etcd will place its data.
+                                  Defaults to "/var/lib/etcd".
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              extraArgs:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  extraArgs are extra arguments provided to the etcd binary
+                                  when run inside a static pod.
+                                type: object
+                              extraEnvs:
+                                description: |-
+                                  extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                  Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                  This option takes effect only on Kubernetes >=1.31.0.
+                                items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
+                                  properties:
+                                    name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        Variable references $(VAR_NAME) are expanded
+                                        using the previously defined environment variables in the container and
+                                        any service environment variables. If a variable cannot be resolved,
+                                        the reference in the input string will be unchanged. Double $$ are reduced
+                                        to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                        "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                        Escaped references will never be expanded, regardless of whether the variable
+                                        exists or not.
+                                        Defaults to "".
+                                      type: string
+                                    valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
+                                      properties:
+                                        configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
+                                          properties:
+                                            key:
+                                              description: The key to select.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        fieldRef:
+                                          description: |-
+                                            Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                            spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                          properties:
+                                            apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of,
+                                                defaults to "v1".
+                                              type: string
+                                            fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resourceFieldRef:
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                          properties:
+                                            containerName:
+                                              description: 'Container name: required
+                                                for volumes, optional for env vars'
+                                              type: string
+                                            divisor:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults
+                                                to "1"
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            resource:
+                                              description: 'Required: resource to
+                                                select'
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
+                                          properties:
+                                            key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
+                                              type: string
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              imageTag:
+                                description: |-
+                                  imageTag allows to specify a tag for the image.
+                                  In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              peerCertSANs:
+                                description: peerCertSANs sets extra Subject Alternative
+                                  Names for the etcd peer signing cert.
+                                items:
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                maxItems: 100
+                                type: array
+                              serverCertSANs:
+                                description: serverCertSANs sets extra Subject Alternative
+                                  Names for the etcd server signing cert.
+                                items:
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                                maxItems: 100
+                                type: array
+                            type: object
+                        type: object
+                      featureGates:
+                        additionalProperties:
+                          type: boolean
+                        description: featureGates enabled by the user.
+                        type: object
+                      imageRepository:
+                        description: |-
+                          imageRepository sets the container registry to pull images from.
+                          * If not set, the default registry of kubeadm will be used, i.e.
+                            * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                            * k8s.gcr.io (old registry): all older versions
+                            Please note that when imageRepository is not set we don't allow upgrades to
+                            versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                            a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                            >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                          * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                           `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                            and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      kubernetesVersion:
+                        description: |-
+                          kubernetesVersion is the target version of the control plane.
+                          NB: This value defaults to the Machine object spec.version
+                        maxLength: 256
+                        minLength: 1
+                        type: string
+                      networking:
+                        description: |-
+                          networking holds configuration for the networking topology of the cluster.
+                          NB: This value defaults to the Cluster object spec.clusterNetwork.
+                        properties:
+                          dnsDomain:
+                            description: dnsDomain is the dns domain used by k8s services.
+                              Defaults to "cluster.local".
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          podSubnet:
+                            description: |-
+                              podSubnet is the subnet used by pods.
+                              If unset, the API server will not allocate CIDR ranges for every node.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                            maxLength: 1024
+                            minLength: 1
+                            type: string
+                          serviceSubnet:
+                            description: |-
+                              serviceSubnet is the subnet used by k8s services.
+                              Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                              to "10.96.0.0/12" if that's unset.
+                            maxLength: 1024
+                            minLength: 1
+                            type: string
+                        type: object
+                      scheduler:
+                        description: scheduler contains extra settings for the scheduler
+                          control plane component
+                        properties:
+                          extraArgs:
+                            additionalProperties:
+                              type: string
+                            description: extraArgs is an extra set of flags to pass
+                              to the control plane component.
+                            type: object
+                          extraEnvs:
+                            description: |-
+                              extraEnvs is an extra set of environment variables to pass to the control plane component.
+                              Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: |-
+                                    Variable references $(VAR_NAME) are expanded
+                                    using the previously defined environment variables in the container and
+                                    any service environment variables. If a variable cannot be resolved,
+                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless of whether the variable
+                                    exists or not.
+                                    Defaults to "".
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: |-
+                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: |-
+                                        Selects a resource of the container: only resources limits and requests
+                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          default: ""
+                                          description: |-
+                                            Name of the referent.
+                                            This field is effectively required, but due to backwards compatibility is
+                                            allowed to be empty. Instances of this type with an empty value here are
+                                            almost certainly wrong.
+                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                          extraVolumes:
+                            description: extraVolumes is an extra set of host volumes,
+                              mounted to the control plane component.
+                            items:
+                              description: |-
+                                HostPathMount contains elements describing volumes that are mounted from the
+                                host.
+                              properties:
+                                hostPath:
+                                  description: |-
+                                    hostPath is the path in the host that will be mounted inside
+                                    the pod.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                mountPath:
+                                  description: mountPath is the path inside the pod
+                                    where hostPath will be mounted.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name of the volume inside the pod template.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                pathType:
+                                  description: pathType is the type of the HostPath.
+                                  type: string
+                                readOnly:
+                                  description: readOnly controls write access to the
+                                    volume
+                                  type: boolean
+                              required:
+                              - hostPath
+                              - mountPath
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                        type: object
+                    type: object
+                  diskSetup:
+                    description: diskSetup specifies options for the creation of partition
+                      tables and file systems on devices.
+                    properties:
+                      filesystems:
+                        description: filesystems specifies the list of file systems
+                          to setup.
+                        items:
+                          description: Filesystem defines the file systems to be created.
+                          properties:
+                            device:
+                              description: device specifies the device name
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            extraOpts:
+                              description: extraOpts defined extra options to add
+                                to the command for creating the file system.
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 100
+                              type: array
+                            filesystem:
+                              description: filesystem specifies the file system type.
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                            label:
+                              description: label specifies the file system label to
+                                be used. If set to None, no label is used.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            overwrite:
+                              description: |-
+                                overwrite defines whether or not to overwrite any existing filesystem.
+                                If true, any pre-existing file system will be destroyed. Use with Caution.
+                              type: boolean
+                            partition:
+                              description: 'partition specifies the partition to use.
+                                The valid options are: "auto|any", "auto", "any",
+                                "none", and <NUM>, where NUM is the actual partition
+                                number.'
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                            replaceFS:
+                              description: |-
+                                replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                          - device
+                          - filesystem
+                          type: object
+                        maxItems: 100
+                        type: array
+                      partitions:
+                        description: partitions specifies the list of the partitions
+                          to setup.
+                        items:
+                          description: Partition defines how to create and layout
+                            a partition.
+                          properties:
+                            device:
+                              description: device is the name of the device.
+                              maxLength: 256
+                              minLength: 1
+                              type: string
+                            layout:
+                              description: |-
+                                layout specifies the device layout.
+                                If it is true, a single partition will be created for the entire device.
+                                When layout is false, it means don't partition or ignore existing partitioning.
+                              type: boolean
+                            overwrite:
+                              description: |-
+                                overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                Use with caution. Default is 'false'.
+                              type: boolean
+                            tableType:
+                              description: |-
+                                tableType specifies the tupe of partition table. The following are supported:
+                                'mbr': default and setups a MS-DOS partition table
+                                'gpt': setups a GPT partition table
+                              enum:
+                              - mbr
+                              - gpt
+                              type: string
+                          required:
+                          - device
+                          - layout
+                          type: object
+                        maxItems: 100
+                        type: array
+                    type: object
+                  files:
+                    description: files specifies extra files to be passed to user_data
+                      upon creation.
+                    items:
+                      description: File defines the input for generating write_files
+                        in cloud-init.
+                      properties:
+                        append:
+                          description: append specifies whether to append Content
+                            to existing file if Path exists.
+                          type: boolean
+                        content:
+                          description: content is the actual content of the file.
+                          maxLength: 10240
+                          minLength: 1
+                          type: string
+                        contentFrom:
+                          description: contentFrom is a referenced source of content
+                            to populate the file.
+                          properties:
+                            secret:
+                              description: secret represents a secret that should
+                                populate this file.
+                              properties:
+                                key:
+                                  description: key is the key in the secret's data
+                                    map for this value.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        encoding:
+                          description: encoding specifies the encoding of the file
+                            contents.
+                          enum:
+                          - base64
+                          - gzip
+                          - gzip+base64
+                          type: string
+                        owner:
+                          description: owner specifies the ownership of the file,
+                            e.g. "root:root".
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        path:
+                          description: path specifies the full path on disk where
+                            to store the file.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        permissions:
+                          description: permissions specifies the permissions to assign
+                            to the file, e.g. "0640".
+                          maxLength: 16
+                          minLength: 1
+                          type: string
+                      required:
+                      - path
+                      type: object
+                    maxItems: 200
+                    type: array
+                  format:
+                    description: format specifies the output format of the bootstrap
+                      data
+                    enum:
+                    - cloud-config
+                    - ignition
+                    type: string
+                  ignition:
+                    description: ignition contains Ignition specific configuration.
+                    properties:
+                      containerLinuxConfig:
+                        description: containerLinuxConfig contains CLC specific configuration.
+                        properties:
+                          additionalConfig:
+                            description: |-
+                              additionalConfig contains additional configuration to be merged with the Ignition
+                              configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                              The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                            maxLength: 32768
+                            minLength: 1
+                            type: string
+                          strict:
+                            description: strict controls if AdditionalConfig should
+                              be strictly parsed. If so, warnings are treated as errors.
+                            type: boolean
+                        type: object
+                    type: object
+                  initConfiguration:
+                    description: initConfiguration along with ClusterConfiguration
+                      are the configurations necessary for the init command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      bootstrapTokens:
+                        description: |-
+                          bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                          This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                        items:
+                          description: BootstrapToken describes one bootstrap token,
+                            stored as a Secret in the cluster.
+                          properties:
+                            description:
+                              description: |-
+                                description sets a human-friendly message why this token exists and what it's used
+                                for, so other administrators can know its purpose.
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            expires:
+                              description: |-
+                                expires specifies the timestamp when this token expires. Defaults to being set
+                                dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                              format: date-time
+                              type: string
+                            groups:
+                              description: |-
+                                groups specifies the extra groups that this token will authenticate as when/if
+                                used for authentication
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 100
+                              type: array
+                            token:
+                              description: |-
+                                token is used for establishing bidirectional trust between nodes and control-planes.
+                                Used for joining nodes in the cluster.
+                              type: string
+                            ttl:
+                              description: |-
+                                ttl defines the time to live for this token. Defaults to 24h.
+                                Expires and TTL are mutually exclusive.
+                              type: string
+                            usages:
+                              description: |-
+                                usages describes the ways in which this token can be used. Can by default be used
+                                for establishing bidirectional trust, but that can be changed here.
+                              items:
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              maxItems: 100
+                              type: array
+                          required:
+                          - token
+                          type: object
+                        maxItems: 100
+                        type: array
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      localAPIEndpoint:
+                        description: |-
+                          localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                          In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                          is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                          configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                          on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                          fails you may set the desired value here.
+                        properties:
+                          advertiseAddress:
+                            description: advertiseAddress sets the IP address for
+                              the API server to advertise.
+                            maxLength: 39
+                            minLength: 1
+                            type: string
+                          bindPort:
+                            description: |-
+                              bindPort sets the secure port for the API Server to bind to.
+                              Defaults to 6443.
+                            format: int32
+                            type: integer
+                        type: object
+                      nodeRegistration:
+                        description: |-
+                          nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: criSocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          ignorePreflightErrors:
+                            description: ignorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            maxItems: 50
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              imagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          imagePullSerial:
+                            description: |-
+                              imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                              Default: true (defaulted in kubeadm)
+                            type: boolean
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          taints:
+                            description: |-
+                              taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            maxItems: 100
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          skipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        maxItems: 50
+                        type: array
+                    type: object
+                  joinConfiguration:
+                    description: joinConfiguration is the kubeadm configuration for
+                      the join command
+                    properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                      caCertPath:
+                        description: |-
+                          caCertPath is the path to the SSL certificate authority used to
+                          secure comunications between node and control-plane.
+                          Defaults to "/etc/kubernetes/pki/ca.crt".
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      controlPlane:
+                        description: |-
+                          controlPlane defines the additional control plane instance to be deployed on the joining node.
+                          If nil, no additional control plane instance will be deployed.
+                        properties:
+                          localAPIEndpoint:
+                            description: localAPIEndpoint represents the endpoint
+                              of the API server instance to be deployed on this node.
+                            properties:
+                              advertiseAddress:
+                                description: advertiseAddress sets the IP address
+                                  for the API server to advertise.
+                                maxLength: 39
+                                minLength: 1
+                                type: string
+                              bindPort:
+                                description: |-
+                                  bindPort sets the secure port for the API Server to bind to.
+                                  Defaults to 6443.
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      discovery:
+                        description: discovery specifies the options for the kubelet
+                          to use during the TLS Bootstrap process
+                        properties:
+                          bootstrapToken:
+                            description: |-
+                              bootstrapToken is used to set the options for bootstrap token based discovery
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              apiServerEndpoint:
+                                description: apiServerEndpoint is an IP or domain
+                                  name to the API server from which info will be fetched.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              caCertHashes:
+                                description: |-
+                                  caCertHashes specifies a set of public key pins to verify
+                                  when token-based discovery is used. The root CA found during discovery
+                                  must match one of these values. Specifying an empty set disables root CA
+                                  pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                  where the only currently supported type is "sha256". This is a hex-encoded
+                                  SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                  ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                  openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                items:
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                maxItems: 100
+                                type: array
+                              token:
+                                description: |-
+                                  token is a token used to validate cluster information
+                                  fetched from the control-plane.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              unsafeSkipCAVerification:
+                                description: |-
+                                  unsafeSkipCAVerification allows token-based discovery
+                                  without CA verification via CACertHashes. This can weaken
+                                  the security of kubeadm since other nodes can impersonate the control-plane.
+                                type: boolean
+                            type: object
+                          file:
+                            description: |-
+                              file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                              BootstrapToken and File are mutually exclusive
+                            properties:
+                              kubeConfig:
+                                description: |-
+                                  kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                  The file is generated at the path specified in KubeConfigPath.
+
+                                  Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                  Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                properties:
+                                  cluster:
+                                    description: |-
+                                      cluster contains information about how to communicate with the kubernetes cluster.
+
+                                      By default the following fields are automatically populated:
+                                      - Server with the Cluster's ControlPlaneEndpoint.
+                                      - CertificateAuthorityData with the Cluster's CA certificate.
+                                    properties:
+                                      certificateAuthorityData:
+                                        description: |-
+                                          certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                          Defaults to the Cluster's CA certificate if empty.
+                                        format: byte
+                                        maxLength: 51200
+                                        minLength: 1
+                                        type: string
+                                      insecureSkipTLSVerify:
+                                        description: insecureSkipTLSVerify skips the
+                                          validity check for the server's certificate.
+                                          This will make your HTTPS connections insecure.
+                                        type: boolean
+                                      proxyURL:
+                                        description: |-
+                                          proxyURL is the URL to the proxy to be used for all requests made by this
+                                          client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                          this configuration is not provided or the empty string, the client
+                                          attempts to construct a proxy configuration from http_proxy and
+                                          https_proxy environment variables. If these environment variables are not
+                                          set, the client does not attempt to proxy requests.
+
+                                          socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                          attach, port forward).
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      server:
+                                        description: |-
+                                          server is the address of the kubernetes cluster (https://hostname:port).
+
+                                          Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      tlsServerName:
+                                        description: tlsServerName is used to check
+                                          server certificate. If TLSServerName is
+                                          empty, the hostname used to contact the
+                                          server is used.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                    type: object
+                                  user:
+                                    description: |-
+                                      user contains information that describes identity information.
+                                      This is used to tell the kubernetes cluster who you are.
+                                    properties:
+                                      authProvider:
+                                        description: authProvider specifies a custom
+                                          authentication plugin for the kubernetes
+                                          cluster.
+                                        properties:
+                                          config:
+                                            additionalProperties:
+                                              type: string
+                                            description: config holds the parameters
+                                              for the authentication plugin.
+                                            type: object
+                                          name:
+                                            description: name is the name of the authentication
+                                              plugin.
+                                            maxLength: 256
+                                            minLength: 1
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      exec:
+                                        description: exec specifies a custom exec-based
+                                          authentication plugin for the kubernetes
+                                          cluster.
+                                        properties:
+                                          apiVersion:
+                                            description: |-
+                                              apiVersion is preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                              the same encoding version as the input.
+                                              Defaults to client.authentication.k8s.io/v1 if not set.
+                                            maxLength: 512
+                                            minLength: 1
+                                            type: string
+                                          args:
+                                            description: args is the arguments to
+                                              pass to the command when executing it.
+                                            items:
+                                              maxLength: 512
+                                              minLength: 1
+                                              type: string
+                                            maxItems: 100
+                                            type: array
+                                          command:
+                                            description: command to execute.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            type: string
+                                          env:
+                                            description: |-
+                                              env defines additional environment variables to expose to the process. These
+                                              are unioned with the host's environment, as well as variables client-go uses
+                                              to pass argument to the plugin.
+                                            items:
+                                              description: |-
+                                                KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                credential plugin.
+                                              properties:
+                                                name:
+                                                  description: name of the environment
+                                                    variable
+                                                  maxLength: 512
+                                                  minLength: 1
+                                                  type: string
+                                                value:
+                                                  description: value of the environment
+                                                    variable
+                                                  maxLength: 512
+                                                  minLength: 1
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            maxItems: 100
+                                            type: array
+                                          provideClusterInfo:
+                                            description: |-
+                                              provideClusterInfo determines whether or not to provide cluster information,
+                                              which could potentially contain very large CA data, to this exec plugin as a
+                                              part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                              to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                              reading this environment variable.
+                                            type: boolean
+                                        required:
+                                        - command
+                                        type: object
+                                    type: object
+                                required:
+                                - user
+                                type: object
+                              kubeConfigPath:
+                                description: kubeConfigPath is used to specify the
+                                  actual file path or URL to the kubeconfig file from
+                                  which to load cluster information
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                            required:
+                            - kubeConfigPath
+                            type: object
+                          timeout:
+                            description: timeout modifies the discovery timeout
+                            type: string
+                          tlsBootstrapToken:
+                            description: |-
+                              tlsBootstrapToken is a token used for TLS bootstrapping.
+                              If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                              If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                        type: object
+                      kind:
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      nodeRegistration:
+                        description: |-
+                          nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                          When used in the context of control plane nodes, NodeRegistration should remain consistent
+                          across both InitConfiguration and JoinConfiguration
+                        properties:
+                          criSocket:
+                            description: criSocket is used to retrieve container runtime
+                              info. This information will be annotated to the Node
+                              API object, for later re-use
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                          ignorePreflightErrors:
+                            description: ignorePreflightErrors provides a slice of
+                              pre-flight errors to be ignored when the current node
+                              is registered.
+                            items:
+                              maxLength: 512
+                              minLength: 1
+                              type: string
+                            maxItems: 50
+                            type: array
+                          imagePullPolicy:
+                            description: |-
+                              imagePullPolicy specifies the policy for image pulling
+                              during kubeadm "init" and "join" operations. The value of
+                              this field must be one of "Always", "IfNotPresent" or
+                              "Never". Defaults to "IfNotPresent". This can be used only
+                              with Kubernetes version equal to 1.22 and later.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            - Never
+                            type: string
+                          imagePullSerial:
+                            description: |-
+                              imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                              This option takes effect only on Kubernetes >=1.31.0.
+                              Default: true (defaulted in kubeadm)
+                            type: boolean
+                          kubeletExtraArgs:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                              kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                              Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                            type: object
+                          name:
+                            description: |-
+                              name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                              This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                              Defaults to the hostname of the node if not provided.
+                            maxLength: 253
+                            minLength: 1
+                            type: string
+                          taints:
+                            description: |-
+                              taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                              it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                              empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                            items:
+                              description: |-
+                                The node this Taint is attached to has the "effect" on
+                                any pod that does not tolerate the Taint.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Required. The effect of the taint on pods
+                                    that do not tolerate the taint.
+                                    Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: Required. The taint key to be applied
+                                    to a node.
+                                  type: string
+                                timeAdded:
+                                  description: |-
+                                    TimeAdded represents the time at which the taint was added.
+                                    It is only written for NoExecute taints.
+                                  format: date-time
+                                  type: string
+                                value:
+                                  description: The taint value corresponding to the
+                                    taint key.
+                                  type: string
+                              required:
+                              - effect
+                              - key
+                              type: object
+                            maxItems: 100
+                            type: array
+                        type: object
+                      patches:
+                        description: |-
+                          patches contains options related to applying patches to components deployed by kubeadm during
+                          "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                        properties:
+                          directory:
+                            description: |-
+                              directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                              For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                              "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                              of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                              The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                              "suffix" is an optional string that can be used to determine which patches are applied
+                              first alpha-numerically.
+                              These files can be written into the target directory via KubeadmConfig.Files which
+                              specifies additional files to be created on the machine, either with content inline or
+                              by referencing a secret.
+                            maxLength: 512
+                            minLength: 1
+                            type: string
+                        type: object
+                      skipPhases:
+                        description: |-
+                          skipPhases is a list of phases to skip during command execution.
+                          The list of phases can be obtained with the "kubeadm init --help" command.
+                          This option takes effect only on Kubernetes >=1.22.0.
+                        items:
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        maxItems: 50
+                        type: array
+                    type: object
+                  mounts:
+                    description: mounts specifies a list of mount points to be setup.
+                    items:
+                      description: MountPoints defines input for generated mounts
+                        in cloud-init.
+                      items:
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      type: array
+                    maxItems: 100
+                    type: array
+                  ntp:
+                    description: ntp specifies NTP configuration
+                    properties:
+                      enabled:
+                        description: enabled specifies whether NTP should be enabled
+                        type: boolean
+                      servers:
+                        description: servers specifies which NTP servers to use
+                        items:
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        maxItems: 100
+                        type: array
+                    type: object
+                  postKubeadmCommands:
+                    description: |-
+                      postKubeadmCommands specifies extra commands to run after kubeadm runs.
+                      With cloud-init, this is appended to the runcmd module configuration, and is typically executed in
+                      the cloud-final.service systemd unit. In Ignition, this is appended to /etc/kubeadm.sh.
+                    items:
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    maxItems: 1000
+                    type: array
+                  preKubeadmCommands:
+                    description: |-
+                      preKubeadmCommands specifies extra commands to run before kubeadm runs.
+                      With cloud-init, this is prepended to the runcmd module configuration, and is typically executed in
+                      the cloud-final.service systemd unit. In Ignition, this is prepended to /etc/kubeadm.sh.
+                    items:
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    maxItems: 1000
+                    type: array
+                  useExperimentalRetryJoin:
+                    description: |-
+                      useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                      script with retries for joins.
+
+                      This is meant to be an experimental temporary workaround on some environments
+                      where joins fail due to timing (and other issues). The long term goal is to add retries to
+                      kubeadm proper and use that functionality.
+
+                      This will add about 40KB to userdata
+
+                      For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                      Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                      When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                    type: boolean
+                  users:
+                    description: users specifies extra users to add
+                    items:
+                      description: User defines the input for a generated user in
+                        cloud-init.
+                      properties:
+                        gecos:
+                          description: gecos specifies the gecos to use for the user
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        groups:
+                          description: groups specifies the additional groups for
+                            the user
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        homeDir:
+                          description: homeDir specifies the home directory to use
+                            for the user
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        inactive:
+                          description: inactive specifies whether to mark the user
+                            as inactive
+                          type: boolean
+                        lockPassword:
+                          description: lockPassword specifies if password login should
+                            be disabled
+                          type: boolean
+                        name:
+                          description: name specifies the user name
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        passwd:
+                          description: passwd specifies a hashed password for the
+                            user
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        passwdFrom:
+                          description: passwdFrom is a referenced source of passwd
+                            to populate the passwd.
+                          properties:
+                            secret:
+                              description: secret represents a secret that should
+                                populate this password.
+                              properties:
+                                key:
+                                  description: key is the key in the secret's data
+                                    map for this value.
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: name of the secret in the KubeadmBootstrapConfig's
+                                    namespace to use.
+                                  maxLength: 253
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                          required:
+                          - secret
+                          type: object
+                        primaryGroup:
+                          description: primaryGroup specifies the primary group for
+                            the user
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        shell:
+                          description: shell specifies the user's shell
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                        sshAuthorizedKeys:
+                          description: sshAuthorizedKeys specifies a list of ssh authorized
+                            keys for the user
+                          items:
+                            maxLength: 2048
+                            minLength: 1
+                            type: string
+                          maxItems: 100
+                          type: array
+                        sudo:
+                          description: sudo specifies a sudo role for the user
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    maxItems: 100
+                    type: array
+                  verbosity:
+                    description: |-
+                      verbosity is the number for the kubeadm log level verbosity.
+                      It overrides the `--v` flag in kubeadm commands.
+                    format: int32
+                    type: integer
+                type: object
+              machineNamingStrategy:
+                description: |-
+                  machineNamingStrategy allows changing the naming pattern used when creating Machines.
+                  InfraMachines & KubeadmConfigs will use the same name as the corresponding Machines.
+                properties:
+                  template:
+                    description: |-
+                      template defines the template to use for generating the names of the Machine objects.
+                      If not defined, it will fallback to `{{ .kubeadmControlPlane.name }}-{{ .random }}`.
+                      If the generated name string exceeds 63 characters, it will be trimmed to 58 characters and will
+                      get concatenated with a random suffix of length 5.
+                      Length of the template string must not exceed 256 characters.
+                      The template allows the following variables `.cluster.name`, `.kubeadmControlPlane.name` and `.random`.
+                      The variable `.cluster.name` retrieves the name of the cluster object that owns the Machines being created.
+                      The variable `.kubeadmControlPlane.name` retrieves the name of the KubeadmControlPlane object that owns the Machines being created.
+                      The variable `.random` is substituted with random alphanumeric string, without vowels, of length 5. This variable is required
+                      part of the template. If not provided, validation will fail.
+                    maxLength: 256
+                    minLength: 1
+                    type: string
+                type: object
+              machineTemplate:
+                description: |-
+                  machineTemplate contains information about how machines
+                  should be shaped when creating or updating a control plane.
+                properties:
+                  infrastructureRef:
+                    description: |-
+                      infrastructureRef is a required reference to a custom resource
+                      offered by an infrastructure provider.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent.
+                        type: string
+                      fieldPath:
+                        description: |-
+                          If referring to a piece of an object instead of an entire object, this string
+                          should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                          For example, if the object reference is to a container within a pod, this would take on a value like:
+                          "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                          the event) or if no container name is specified "spec.containers[2]" (container with
+                          index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                          referencing a part of an object.
+                        type: string
+                      kind:
+                        description: |-
+                          Kind of the referent.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                      name:
+                        description: |-
+                          Name of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                      namespace:
+                        description: |-
+                          Namespace of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                        type: string
+                      resourceVersion:
+                        description: |-
+                          Specific resourceVersion to which this reference is made, if any.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                        type: string
+                      uid:
+                        description: |-
+                          UID of the referent.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  nodeDeletionTimeout:
+                    description: |-
+                      nodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                      hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                      If no value is provided, the default value for this property of the Machine resource will be used.
+                    type: string
+                  nodeDrainTimeout:
+                    description: |-
+                      nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                      The default value is 0, meaning that the node can be drained without any time limitations.
+                      NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                    type: string
+                  nodeVolumeDetachTimeout:
+                    description: |-
+                      nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                      to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                    type: string
+                  readinessGates:
+                    description: |-
+                      readinessGates specifies additional conditions to include when evaluating Machine Ready condition;
+                      KubeadmControlPlane will always add readinessGates for the condition it is setting on the Machine:
+                      APIServerPodHealthy, SchedulerPodHealthy, ControllerManagerPodHealthy, and if etcd is managed by CKP also
+                      EtcdPodHealthy, EtcdMemberHealthy.
+
+                      This field can be used e.g. to instruct the machine controller to include in the computation for Machine's ready
+                      computation a condition, managed by an external controllers, reporting the status of special software/hardware installed on the Machine.
+
+                      NOTE: This field is considered only for computing v1beta2 conditions.
+                    items:
+                      description: MachineReadinessGate contains the type of a Machine
+                        condition to be used as a readiness gate.
+                      properties:
+                        conditionType:
+                          description: |-
+                            conditionType refers to a condition with matching type in the Machine's condition list.
+                            If the conditions doesn't exist, it will be treated as unknown.
+                            Note: Both Cluster API conditions or conditions added by 3rd party controllers can be used as readiness gates.
+                          maxLength: 316
+                          minLength: 1
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                        polarity:
+                          description: |-
+                            polarity of the conditionType specified in this readinessGate.
+                            Valid values are Positive, Negative and omitted.
+                            When omitted, the default behaviour will be Positive.
+                            A positive polarity means that the condition should report a true status under normal conditions.
+                            A negative polarity means that the condition should report a false status under normal conditions.
+                          enum:
+                          - Positive
+                          - Negative
+                          type: string
+                      required:
+                      - conditionType
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - conditionType
+                    x-kubernetes-list-type: map
+                  taints:
+                    description: |-
+                      The list of the taints to be applied to the corresponding Node in additive
+                      manner. This list will not overwrite any other taints added to the Node on
+                      an ongoing basis by other entities. These taints should be actively reconciled
+                      e.g. if you ask the machine controller to apply a taint and then manually remove
+                      the taint the machine controller will put it back) but not have the machine controller
+                      remove any taints
+                    items:
+                      description: |-
+                        The node this Taint is attached to has the "effect" on
+                        any pod that does not tolerate the Taint.
+                      properties:
+                        effect:
+                          description: |-
+                            Required. The effect of the taint on pods
+                            that do not tolerate the taint.
+                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Required. The taint key to be applied to a
+                            node.
+                          type: string
+                        timeAdded:
+                          description: |-
+                            TimeAdded represents the time at which the taint was added.
+                            It is only written for NoExecute taints.
+                          format: date-time
+                          type: string
+                        value:
+                          description: The taint value corresponding to the taint
+                            key.
+                          type: string
+                      required:
+                      - effect
+                      - key
+                      type: object
+                    type: array
+                required:
+                - infrastructureRef
+                type: object
+              remediationStrategy:
+                description: remediationStrategy is the RemediationStrategy that controls
+                  how control plane machine remediation happens.
+                properties:
+                  maxRetry:
+                    description: "maxRetry is the Max number of retries while attempting
+                      to remediate an unhealthy machine.\nA retry happens when a machine
+                      that was created as a replacement for an unhealthy machine also
+                      fails.\nFor example, given a control plane with three machines
+                      M1, M2, M3:\n\n\tM1 become unhealthy; remediation happens, and
+                      M1-1 is created as a replacement.\n\tIf M1-1 (replacement of
+                      M1) has problems while bootstrapping it will become unhealthy,
+                      and then be\n\tremediated; such operation is considered a retry,
+                      remediation-retry #1.\n\tIf M1-2 (replacement of M1-1) becomes
+                      unhealthy, remediation-retry #2 will happen, etc.\n\nA retry
+                      could happen only after RetryPeriod from the previous retry.\nIf
+                      a machine is marked as unhealthy after MinHealthyPeriod from
+                      the previous remediation expired,\nthis is not considered a
+                      retry anymore because the new issue is assumed unrelated from
+                      the previous one.\n\nIf not set, the remedation will be retried
+                      infinitely."
+                    format: int32
+                    type: integer
+                  minHealthyPeriod:
+                    description: "minHealthyPeriod defines the duration after which
+                      KCP will consider any failure to a machine unrelated\nfrom the
+                      previous one. In this case the remediation is not considered
+                      a retry anymore, and thus the retry\ncounter restarts from 0.
+                      For example, assuming MinHealthyPeriod is set to 1h (default)\n\n\tM1
+                      become unhealthy; remediation happens, and M1-1 is created as
+                      a replacement.\n\tIf M1-1 (replacement of M1) has problems within
+                      the 1hr after the creation, also\n\tthis machine will be remediated
+                      and this operation is considered a retry - a problem related\n\tto
+                      the original issue happened to M1 -.\n\n\tIf instead the problem
+                      on M1-1 is happening after MinHealthyPeriod expired, e.g. four
+                      days after\n\tm1-1 has been created as a remediation of M1,
+                      the problem on M1-1 is considered unrelated to\n\tthe original
+                      issue happened to M1.\n\nIf not set, this value is defaulted
+                      to 1h."
+                    type: string
+                  retryPeriod:
+                    description: |-
+                      retryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                      for an unhealthy machine (a retry).
+
+                      If not set, a retry will happen immediately.
+                    type: string
+                type: object
+              replicas:
+                description: |-
+                  replicas is the number of desired machines. Defaults to 1. When stacked etcd is used only
+                  odd numbers are permitted, as per [etcd best practice](https://etcd.io/docs/v3.3.12/faq/#why-an-odd-number-of-cluster-members).
+                  This is a pointer to distinguish between explicit zero and not specified.
+                format: int32
+                type: integer
+              rolloutAfter:
+                description: |-
+                  rolloutAfter is a field to indicate a rollout should be performed
+                  after the specified time even if no changes have been made to the
+                  KubeadmControlPlane.
+                  Example: In the YAML the time can be specified in the RFC3339 format.
+                  To specify the rolloutAfter target as March 9, 2023, at 9 am UTC
+                  use "2023-03-09T09:00:00Z".
+                format: date-time
+                type: string
+              rolloutBefore:
+                description: |-
+                  rolloutBefore is a field to indicate a rollout should be performed
+                  if the specified criteria is met.
+                properties:
+                  certificatesExpiryDays:
+                    description: |-
+                      certificatesExpiryDays indicates a rollout needs to be performed if the
+                      certificates of the machine will expire within the specified days.
+                    format: int32
+                    type: integer
+                type: object
+              rolloutStrategy:
+                default:
+                  rollingUpdate:
+                    maxSurge: 1
+                  type: RollingUpdate
+                description: |-
+                  rolloutStrategy is the RolloutStrategy to use to replace control plane machines with
+                  new ones.
+                properties:
+                  rollingUpdate:
+                    description: |-
+                      rollingUpdate is the rolling update config params. Present only if
+                      RolloutStrategyType = RollingUpdate.
+                    properties:
+                      maxSurge:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: |-
+                          maxSurge is the maximum number of control planes that can be scheduled above or under the
+                          desired number of control planes.
+                          Value can be an absolute number 1 or 0.
+                          Defaults to 1.
+                          Example: when this is set to 1, the control plane can be scaled
+                          up immediately when the rolling update starts.
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  type:
+                    description: |-
+                      type of rollout. Currently the only supported strategy is
+                      "RollingUpdate".
+                      Default is RollingUpdate.
+                    enum:
+                    - RollingUpdate
+                    type: string
+                type: object
+              version:
+                description: |-
+                  version defines the desired Kubernetes version.
+                  Please note that if kubeadmConfigSpec.ClusterConfiguration.imageRepository is not set
+                  we don't allow upgrades to versions >= v1.22.0 for which kubeadm uses the old registry (k8s.gcr.io).
+                  Please use a newer patch version with the new registry instead. The default registries of kubeadm are:
+                    * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                    * k8s.gcr.io (old registry): all older versions
+                maxLength: 256
+                minLength: 1
+                type: string
+            required:
+            - kubeadmConfigSpec
+            - machineTemplate
+            - version
+            type: object
+          status:
+            description: status is the observed state of KubeadmControlPlane.
+            properties:
+              conditions:
+                description: conditions defines current service state of the KubeadmControlPlane.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                description: |-
+                  failureMessage indicates that there is a terminal problem reconciling the
+                  state, and will be set to a descriptive error message.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                maxLength: 10240
+                minLength: 1
+                type: string
+              failureReason:
+                description: |-
+                  failureReason indicates that there is a terminal problem reconciling the
+                  state, and will be set to a token value suitable for
+                  programmatic interpretation.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                type: string
+              initialized:
+                description: |-
+                  initialized denotes that the KubeadmControlPlane API Server is initialized and thus
+                  it can accept requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              lastRemediation:
+                description: lastRemediation stores info about last remediation performed.
+                properties:
+                  machine:
+                    description: machine is the machine name of the latest machine
+                      being remediated.
+                    maxLength: 253
+                    minLength: 1
+                    type: string
+                  retryCount:
+                    description: |-
+                      retryCount used to keep track of remediation retry for the last remediated machine.
+                      A retry happens when a machine that was created as a replacement for an unhealthy machine also fails.
+                    format: int32
+                    type: integer
+                  timestamp:
+                    description: timestamp is when last remediation happened. It is
+                      represented in RFC3339 form and is in UTC.
+                    format: date-time
+                    type: string
+                required:
+                - machine
+                - retryCount
+                - timestamp
+                type: object
+              observedGeneration:
+                description: observedGeneration is the latest generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              ready:
+                description: |-
+                  ready denotes that the KubeadmControlPlane API Server became ready during initial provisioning
+                  to receive requests.
+                  NOTE: this field is part of the Cluster API contract and it is used to orchestrate provisioning.
+                  The value of this field is never updated after provisioning is completed. Please use conditions
+                  to check the operational state of the control plane.
+                type: boolean
+              readyReplicas:
+                description: readyReplicas is the total number of fully running and
+                  ready control plane machines.
+                format: int32
+                type: integer
+              replicas:
+                description: |-
+                  replicas is the total number of non-terminated machines targeted by this control plane
+                  (their labels match the selector).
+                format: int32
+                type: integer
+              selector:
+                description: |-
+                  selector is the label selector in string format to avoid introspection
+                  by clients, and is used to provide the CRD-based integration for the
+                  scale subresource and additional integrations for things like kubectl
+                  describe.. The string will be in the same format as the query-param syntax.
+                  More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors
+                maxLength: 4096
+                minLength: 1
+                type: string
+              unavailableReplicas:
+                description: |-
+                  unavailableReplicas is the total number of unavailable machines targeted by this control plane.
+                  This is the total number of machines that are still required for
+                  the deployment to have 100% available capacity. They may either
+                  be machines that are running but not yet ready or machines
+                  that still have not been created.
+
+                  Deprecated: This field is deprecated and is going to be removed in the next apiVersion. Please see https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240916-improve-status-in-CAPI-resources.md for more details.
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: |-
+                  updatedReplicas is the total number of non-terminated machines targeted by this control plane
+                  that have the desired template spec.
+                format: int32
+                type: integer
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in KubeadmControlPlane's status with the V1Beta2 version.
+                properties:
+                  availableReplicas:
+                    description: availableReplicas is the number of available replicas
+                      targeted by this KubeadmControlPlane. A machine is considered
+                      available when Machine's Available condition is true.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a KubeadmControlPlane's current state.
+                      Known condition types are Available, CertificatesAvailable, EtcdClusterAvailable, MachinesReady, MachinesUpToDate,
+                      ScalingUp, ScalingDown, Remediating, Deleting, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  readyReplicas:
+                    description: readyReplicas is the number of ready replicas for
+                      this KubeadmControlPlane. A machine is considered ready when
+                      Machine's Ready condition is true.
+                    format: int32
+                    type: integer
+                  upToDateReplicas:
+                    description: upToDateReplicas is the number of up-to-date replicas
+                      targeted by this KubeadmControlPlane. A machine is considered
+                      up-to-date when Machine's UpToDate condition is true.
+                    format: int32
+                    type: integer
+                type: object
+              version:
+                description: |-
+                  version represents the minimum Kubernetes version for the control plane machines
+                  in the cluster.
+                maxLength: 256
+                minLength: 1
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/docs/shared/crds/cluster_api/kubeadm_control_plane/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
+++ b/docs/shared/crds/cluster_api/kubeadm_control_plane/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
@@ -1,0 +1,2221 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: kubeadmcontrolplanetemplates.controlplane.cluster.x-k8s.io
+spec:
+  group: controlplane.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: KubeadmControlPlaneTemplate
+    listKind: KubeadmControlPlaneTemplateList
+    plural: kubeadmcontrolplanetemplates
+    singular: kubeadmcontrolplanetemplate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of KubeadmControlPlaneTemplate
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: KubeadmControlPlaneTemplate is the Schema for the kubeadmcontrolplanetemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of KubeadmControlPlaneTemplate.
+            properties:
+              template:
+                description: template defines the desired state of KubeadmControlPlaneTemplate.
+                properties:
+                  metadata:
+                    description: |-
+                      metadata is the standard object's metadata.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: spec is the desired state of KubeadmControlPlaneTemplateResource.
+                    properties:
+                      kubeadmConfigSpec:
+                        description: |-
+                          kubeadmConfigSpec is a KubeadmConfigSpec
+                          to use for initializing and joining machines to the control plane.
+                        properties:
+                          bootCommands:
+                            description: |-
+                              bootCommands specifies extra commands to run very early in the boot process via the cloud-init bootcmd
+                              module. bootcmd will run on every boot, 'cloud-init-per' command can be used to make bootcmd run exactly
+                              once. This is typically run in the cloud-init.service systemd unit. This has no effect in Ignition.
+                            items:
+                              maxLength: 10240
+                              minLength: 1
+                              type: string
+                            maxItems: 1000
+                            type: array
+                          clusterConfiguration:
+                            description: clusterConfiguration along with InitConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiServer:
+                                description: apiServer contains extra settings for
+                                  the API server control plane component
+                                properties:
+                                  certSANs:
+                                    description: certSANs sets extra Subject Alternative
+                                      Names for the API Server signing cert.
+                                    items:
+                                      maxLength: 253
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 100
+                                    type: array
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                  timeoutForControlPlane:
+                                    description: timeoutForControlPlane controls the
+                                      timeout that we use for API server to appear
+                                    type: string
+                                type: object
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              certificatesDir:
+                                description: |-
+                                  certificatesDir specifies where to store or look for all required certificates.
+                                  NB: if not provided, this will default to `/etc/kubernetes/pki`
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              clusterName:
+                                description: clusterName is the cluster name
+                                maxLength: 63
+                                minLength: 1
+                                type: string
+                              controlPlaneEndpoint:
+                                description: |-
+                                  controlPlaneEndpoint sets a stable IP address or DNS name for the control plane; it
+                                  can be a valid IP address or a RFC-1123 DNS subdomain, both with optional TCP port.
+                                  In case the ControlPlaneEndpoint is not specified, the AdvertiseAddress + BindPort
+                                  are used; in case the ControlPlaneEndpoint is specified but without a TCP port,
+                                  the BindPort is used.
+                                  Possible usages are:
+                                  e.g. In a cluster with more than one control plane instances, this field should be
+                                  assigned the address of the external load balancer in front of the
+                                  control plane instances.
+                                  e.g.  in environments with enforced node recycling, the ControlPlaneEndpoint
+                                  could be used for assigning a stable DNS to the control plane.
+                                  NB: This value defaults to the first value in the Cluster object status.apiEndpoints array.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              controllerManager:
+                                description: controllerManager contains extra settings
+                                  for the controller manager control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                type: object
+                              dns:
+                                description: dns defines the options for the DNS add-on
+                                  installed in the cluster.
+                                properties:
+                                  imageRepository:
+                                    description: |-
+                                      imageRepository sets the container registry to pull images from.
+                                      if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  imageTag:
+                                    description: |-
+                                      imageTag allows to specify a tag for the image.
+                                      In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                    maxLength: 256
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              etcd:
+                                description: |-
+                                  etcd holds configuration for etcd.
+                                  NB: This value defaults to a Local (stacked) etcd
+                                properties:
+                                  external:
+                                    description: |-
+                                      external describes how to connect to an external etcd cluster
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      caFile:
+                                        description: |-
+                                          caFile is an SSL Certificate Authority file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      certFile:
+                                        description: |-
+                                          certFile is an SSL certification file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      endpoints:
+                                        description: endpoints of etcd members. Required
+                                          for ExternalEtcd.
+                                        items:
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 50
+                                        type: array
+                                      keyFile:
+                                        description: |-
+                                          keyFile is an SSL key file used to secure etcd communication.
+                                          Required if using a TLS connection.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - caFile
+                                    - certFile
+                                    - endpoints
+                                    - keyFile
+                                    type: object
+                                  local:
+                                    description: |-
+                                      local provides configuration knobs for configuring the local etcd instance
+                                      Local and External are mutually exclusive
+                                    properties:
+                                      dataDir:
+                                        description: |-
+                                          dataDir is the directory etcd will place its data.
+                                          Defaults to "/var/lib/etcd".
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      extraArgs:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          extraArgs are extra arguments provided to the etcd binary
+                                          when run inside a static pod.
+                                        type: object
+                                      extraEnvs:
+                                        description: |-
+                                          extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                          Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                          This option takes effect only on Kubernetes >=1.31.0.
+                                        items:
+                                          description: EnvVar represents an environment
+                                            variable present in a Container.
+                                          properties:
+                                            name:
+                                              description: Name of the environment
+                                                variable. Must be a C_IDENTIFIER.
+                                              type: string
+                                            value:
+                                              description: |-
+                                                Variable references $(VAR_NAME) are expanded
+                                                using the previously defined environment variables in the container and
+                                                any service environment variables. If a variable cannot be resolved,
+                                                the reference in the input string will be unchanged. Double $$ are reduced
+                                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                Escaped references will never be expanded, regardless of whether the variable
+                                                exists or not.
+                                                Defaults to "".
+                                              type: string
+                                            valueFrom:
+                                              description: Source for the environment
+                                                variable's value. Cannot be used if
+                                                value is not empty.
+                                              properties:
+                                                configMapKeyRef:
+                                                  description: Selects a key of a
+                                                    ConfigMap.
+                                                  properties:
+                                                    key:
+                                                      description: The key to select.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the ConfigMap or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                fieldRef:
+                                                  description: |-
+                                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                resourceFieldRef:
+                                                  description: |-
+                                                    Selects a resource of the container: only resources limits and requests
+                                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                secretKeyRef:
+                                                  description: Selects a key of a
+                                                    secret in the pod's namespace
+                                                  properties:
+                                                    key:
+                                                      description: The key of the
+                                                        secret to select from.  Must
+                                                        be a valid secret key.
+                                                      type: string
+                                                    name:
+                                                      default: ""
+                                                      description: |-
+                                                        Name of the referent.
+                                                        This field is effectively required, but due to backwards compatibility is
+                                                        allowed to be empty. Instances of this type with an empty value here are
+                                                        almost certainly wrong.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether
+                                                        the Secret or its key must
+                                                        be defined
+                                                      type: boolean
+                                                  required:
+                                                  - key
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                          required:
+                                          - name
+                                          type: object
+                                        maxItems: 100
+                                        type: array
+                                      imageRepository:
+                                        description: |-
+                                          imageRepository sets the container registry to pull images from.
+                                          if not set, the ImageRepository defined in ClusterConfiguration will be used instead.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      imageTag:
+                                        description: |-
+                                          imageTag allows to specify a tag for the image.
+                                          In case this value is set, kubeadm does not change automatically the version of the above components during upgrades.
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      peerCertSANs:
+                                        description: peerCertSANs sets extra Subject
+                                          Alternative Names for the etcd peer signing
+                                          cert.
+                                        items:
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                      serverCertSANs:
+                                        description: serverCertSANs sets extra Subject
+                                          Alternative Names for the etcd server signing
+                                          cert.
+                                        items:
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                    type: object
+                                type: object
+                              featureGates:
+                                additionalProperties:
+                                  type: boolean
+                                description: featureGates enabled by the user.
+                                type: object
+                              imageRepository:
+                                description: |-
+                                  imageRepository sets the container registry to pull images from.
+                                  * If not set, the default registry of kubeadm will be used, i.e.
+                                    * registry.k8s.io (new registry): >= v1.22.17, >= v1.23.15, >= v1.24.9, >= v1.25.0
+                                    * k8s.gcr.io (old registry): all older versions
+                                    Please note that when imageRepository is not set we don't allow upgrades to
+                                    versions >= v1.22.0 which use the old registry (k8s.gcr.io). Please use
+                                    a newer patch version with the new registry instead (i.e. >= v1.22.17,
+                                    >= v1.23.15, >= v1.24.9, >= v1.25.0).
+                                  * If the version is a CI build (kubernetes version starts with `ci/` or `ci-cross/`)
+                                   `gcr.io/k8s-staging-ci-images` will be used as a default for control plane components
+                                    and for kube-proxy, while `registry.k8s.io` will be used for all the other images.
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              kubernetesVersion:
+                                description: |-
+                                  kubernetesVersion is the target version of the control plane.
+                                  NB: This value defaults to the Machine object spec.version
+                                maxLength: 256
+                                minLength: 1
+                                type: string
+                              networking:
+                                description: |-
+                                  networking holds configuration for the networking topology of the cluster.
+                                  NB: This value defaults to the Cluster object spec.clusterNetwork.
+                                properties:
+                                  dnsDomain:
+                                    description: dnsDomain is the dns domain used
+                                      by k8s services. Defaults to "cluster.local".
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  podSubnet:
+                                    description: |-
+                                      podSubnet is the subnet used by pods.
+                                      If unset, the API server will not allocate CIDR ranges for every node.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.services.cidrBlocks if that is set
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                  serviceSubnet:
+                                    description: |-
+                                      serviceSubnet is the subnet used by k8s services.
+                                      Defaults to a comma-delimited string of the Cluster object's spec.clusterNetwork.pods.cidrBlocks, or
+                                      to "10.96.0.0/12" if that's unset.
+                                    maxLength: 1024
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              scheduler:
+                                description: scheduler contains extra settings for
+                                  the scheduler control plane component
+                                properties:
+                                  extraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: extraArgs is an extra set of flags
+                                      to pass to the control plane component.
+                                    type: object
+                                  extraEnvs:
+                                    description: |-
+                                      extraEnvs is an extra set of environment variables to pass to the control plane component.
+                                      Environment variables passed using ExtraEnvs will override any existing environment variables, or *_proxy environment variables that kubeadm adds by default.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                  extraVolumes:
+                                    description: extraVolumes is an extra set of host
+                                      volumes, mounted to the control plane component.
+                                    items:
+                                      description: |-
+                                        HostPathMount contains elements describing volumes that are mounted from the
+                                        host.
+                                      properties:
+                                        hostPath:
+                                          description: |-
+                                            hostPath is the path in the host that will be mounted inside
+                                            the pod.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        mountPath:
+                                          description: mountPath is the path inside
+                                            the pod where hostPath will be mounted.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        name:
+                                          description: name of the volume inside the
+                                            pod template.
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        pathType:
+                                          description: pathType is the type of the
+                                            HostPath.
+                                          type: string
+                                        readOnly:
+                                          description: readOnly controls write access
+                                            to the volume
+                                          type: boolean
+                                      required:
+                                      - hostPath
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                type: object
+                            type: object
+                          diskSetup:
+                            description: diskSetup specifies options for the creation
+                              of partition tables and file systems on devices.
+                            properties:
+                              filesystems:
+                                description: filesystems specifies the list of file
+                                  systems to setup.
+                                items:
+                                  description: Filesystem defines the file systems
+                                    to be created.
+                                  properties:
+                                    device:
+                                      description: device specifies the device name
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    extraOpts:
+                                      description: extraOpts defined extra options
+                                        to add to the command for creating the file
+                                        system.
+                                      items:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      maxItems: 100
+                                      type: array
+                                    filesystem:
+                                      description: filesystem specifies the file system
+                                        type.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    label:
+                                      description: label specifies the file system
+                                        label to be used. If set to None, no label
+                                        is used.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    overwrite:
+                                      description: |-
+                                        overwrite defines whether or not to overwrite any existing filesystem.
+                                        If true, any pre-existing file system will be destroyed. Use with Caution.
+                                      type: boolean
+                                    partition:
+                                      description: 'partition specifies the partition
+                                        to use. The valid options are: "auto|any",
+                                        "auto", "any", "none", and <NUM>, where NUM
+                                        is the actual partition number.'
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                    replaceFS:
+                                      description: |-
+                                        replaceFS is a special directive, used for Microsoft Azure that instructs cloud-init to replace a file system of <FS_TYPE>.
+                                        NOTE: unless you define a label, this requires the use of the 'any' partition directive.
+                                      maxLength: 128
+                                      minLength: 1
+                                      type: string
+                                  required:
+                                  - device
+                                  - filesystem
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              partitions:
+                                description: partitions specifies the list of the
+                                  partitions to setup.
+                                items:
+                                  description: Partition defines how to create and
+                                    layout a partition.
+                                  properties:
+                                    device:
+                                      description: device is the name of the device.
+                                      maxLength: 256
+                                      minLength: 1
+                                      type: string
+                                    layout:
+                                      description: |-
+                                        layout specifies the device layout.
+                                        If it is true, a single partition will be created for the entire device.
+                                        When layout is false, it means don't partition or ignore existing partitioning.
+                                      type: boolean
+                                    overwrite:
+                                      description: |-
+                                        overwrite describes whether to skip checks and create the partition if a partition or filesystem is found on the device.
+                                        Use with caution. Default is 'false'.
+                                      type: boolean
+                                    tableType:
+                                      description: |-
+                                        tableType specifies the tupe of partition table. The following are supported:
+                                        'mbr': default and setups a MS-DOS partition table
+                                        'gpt': setups a GPT partition table
+                                      enum:
+                                      - mbr
+                                      - gpt
+                                      type: string
+                                  required:
+                                  - device
+                                  - layout
+                                  type: object
+                                maxItems: 100
+                                type: array
+                            type: object
+                          files:
+                            description: files specifies extra files to be passed
+                              to user_data upon creation.
+                            items:
+                              description: File defines the input for generating write_files
+                                in cloud-init.
+                              properties:
+                                append:
+                                  description: append specifies whether to append
+                                    Content to existing file if Path exists.
+                                  type: boolean
+                                content:
+                                  description: content is the actual content of the
+                                    file.
+                                  maxLength: 10240
+                                  minLength: 1
+                                  type: string
+                                contentFrom:
+                                  description: contentFrom is a referenced source
+                                    of content to populate the file.
+                                  properties:
+                                    secret:
+                                      description: secret represents a secret that
+                                        should populate this file.
+                                      properties:
+                                        key:
+                                          description: key is the key in the secret's
+                                            data map for this value.
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        name:
+                                          description: name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                encoding:
+                                  description: encoding specifies the encoding of
+                                    the file contents.
+                                  enum:
+                                  - base64
+                                  - gzip
+                                  - gzip+base64
+                                  type: string
+                                owner:
+                                  description: owner specifies the ownership of the
+                                    file, e.g. "root:root".
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                path:
+                                  description: path specifies the full path on disk
+                                    where to store the file.
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                permissions:
+                                  description: permissions specifies the permissions
+                                    to assign to the file, e.g. "0640".
+                                  maxLength: 16
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            maxItems: 200
+                            type: array
+                          format:
+                            description: format specifies the output format of the
+                              bootstrap data
+                            enum:
+                            - cloud-config
+                            - ignition
+                            type: string
+                          ignition:
+                            description: ignition contains Ignition specific configuration.
+                            properties:
+                              containerLinuxConfig:
+                                description: containerLinuxConfig contains CLC specific
+                                  configuration.
+                                properties:
+                                  additionalConfig:
+                                    description: |-
+                                      additionalConfig contains additional configuration to be merged with the Ignition
+                                      configuration generated by the bootstrapper controller. More info: https://coreos.github.io/ignition/operator-notes/#config-merging
+
+                                      The data format is documented here: https://kinvolk.io/docs/flatcar-container-linux/latest/provisioning/cl-config/
+                                    maxLength: 32768
+                                    minLength: 1
+                                    type: string
+                                  strict:
+                                    description: strict controls if AdditionalConfig
+                                      should be strictly parsed. If so, warnings are
+                                      treated as errors.
+                                    type: boolean
+                                type: object
+                            type: object
+                          initConfiguration:
+                            description: initConfiguration along with ClusterConfiguration
+                              are the configurations necessary for the init command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              bootstrapTokens:
+                                description: |-
+                                  bootstrapTokens is respected at `kubeadm init` time and describes a set of Bootstrap Tokens to create.
+                                  This information IS NOT uploaded to the kubeadm cluster configmap, partly because of its sensitive nature
+                                items:
+                                  description: BootstrapToken describes one bootstrap
+                                    token, stored as a Secret in the cluster.
+                                  properties:
+                                    description:
+                                      description: |-
+                                        description sets a human-friendly message why this token exists and what it's used
+                                        for, so other administrators can know its purpose.
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    expires:
+                                      description: |-
+                                        expires specifies the timestamp when this token expires. Defaults to being set
+                                        dynamically at runtime based on the TTL. Expires and TTL are mutually exclusive.
+                                      format: date-time
+                                      type: string
+                                    groups:
+                                      description: |-
+                                        groups specifies the extra groups that this token will authenticate as when/if
+                                        used for authentication
+                                      items:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      maxItems: 100
+                                      type: array
+                                    token:
+                                      description: |-
+                                        token is used for establishing bidirectional trust between nodes and control-planes.
+                                        Used for joining nodes in the cluster.
+                                      type: string
+                                    ttl:
+                                      description: |-
+                                        ttl defines the time to live for this token. Defaults to 24h.
+                                        Expires and TTL are mutually exclusive.
+                                      type: string
+                                    usages:
+                                      description: |-
+                                        usages describes the ways in which this token can be used. Can by default be used
+                                        for establishing bidirectional trust, but that can be changed here.
+                                      items:
+                                        maxLength: 256
+                                        minLength: 1
+                                        type: string
+                                      maxItems: 100
+                                      type: array
+                                  required:
+                                  - token
+                                  type: object
+                                maxItems: 100
+                                type: array
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              localAPIEndpoint:
+                                description: |-
+                                  localAPIEndpoint represents the endpoint of the API server instance that's deployed on this control plane node
+                                  In HA setups, this differs from ClusterConfiguration.ControlPlaneEndpoint in the sense that ControlPlaneEndpoint
+                                  is the global endpoint for the cluster, which then loadbalances the requests to each individual API server. This
+                                  configuration object lets you customize what IP/DNS name and port the local API server advertises it's accessible
+                                  on. By default, kubeadm tries to auto-detect the IP of the default interface and use that, but in case that process
+                                  fails you may set the desired value here.
+                                properties:
+                                  advertiseAddress:
+                                    description: advertiseAddress sets the IP address
+                                      for the API server to advertise.
+                                    maxLength: 39
+                                    minLength: 1
+                                    type: string
+                                  bindPort:
+                                    description: |-
+                                      bindPort sets the secure port for the API Server to bind to.
+                                      Defaults to 6443.
+                                    format: int32
+                                    type: integer
+                                type: object
+                              nodeRegistration:
+                                description: |-
+                                  nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: criSocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: ignorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 50
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      imagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  imagePullSerial:
+                                    description: |-
+                                      imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                      Default: true (defaulted in kubeadm)
+                                    type: boolean
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm init". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  skipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                maxItems: 50
+                                type: array
+                            type: object
+                          joinConfiguration:
+                            description: joinConfiguration is the kubeadm configuration
+                              for the join command
+                            properties:
+                              apiVersion:
+                                description: |-
+                                  APIVersion defines the versioned schema of this representation of an object.
+                                  Servers should convert recognized schemas to the latest internal value, and
+                                  may reject unrecognized values.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                                type: string
+                              caCertPath:
+                                description: |-
+                                  caCertPath is the path to the SSL certificate authority used to
+                                  secure comunications between node and control-plane.
+                                  Defaults to "/etc/kubernetes/pki/ca.crt".
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              controlPlane:
+                                description: |-
+                                  controlPlane defines the additional control plane instance to be deployed on the joining node.
+                                  If nil, no additional control plane instance will be deployed.
+                                properties:
+                                  localAPIEndpoint:
+                                    description: localAPIEndpoint represents the endpoint
+                                      of the API server instance to be deployed on
+                                      this node.
+                                    properties:
+                                      advertiseAddress:
+                                        description: advertiseAddress sets the IP
+                                          address for the API server to advertise.
+                                        maxLength: 39
+                                        minLength: 1
+                                        type: string
+                                      bindPort:
+                                        description: |-
+                                          bindPort sets the secure port for the API Server to bind to.
+                                          Defaults to 6443.
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                type: object
+                              discovery:
+                                description: discovery specifies the options for the
+                                  kubelet to use during the TLS Bootstrap process
+                                properties:
+                                  bootstrapToken:
+                                    description: |-
+                                      bootstrapToken is used to set the options for bootstrap token based discovery
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      apiServerEndpoint:
+                                        description: apiServerEndpoint is an IP or
+                                          domain name to the API server from which
+                                          info will be fetched.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      caCertHashes:
+                                        description: |-
+                                          caCertHashes specifies a set of public key pins to verify
+                                          when token-based discovery is used. The root CA found during discovery
+                                          must match one of these values. Specifying an empty set disables root CA
+                                          pinning, which can be unsafe. Each hash is specified as "<type>:<value>",
+                                          where the only currently supported type is "sha256". This is a hex-encoded
+                                          SHA-256 hash of the Subject Public Key Info (SPKI) object in DER-encoded
+                                          ASN.1. These hashes can be calculated using, for example, OpenSSL:
+                                          openssl x509 -pubkey -in ca.crt openssl rsa -pubin -outform der 2>&/dev/null | openssl dgst -sha256 -hex
+                                        items:
+                                          maxLength: 512
+                                          minLength: 1
+                                          type: string
+                                        maxItems: 100
+                                        type: array
+                                      token:
+                                        description: |-
+                                          token is a token used to validate cluster information
+                                          fetched from the control-plane.
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                      unsafeSkipCAVerification:
+                                        description: |-
+                                          unsafeSkipCAVerification allows token-based discovery
+                                          without CA verification via CACertHashes. This can weaken
+                                          the security of kubeadm since other nodes can impersonate the control-plane.
+                                        type: boolean
+                                    type: object
+                                  file:
+                                    description: |-
+                                      file is used to specify a file or URL to a kubeconfig file from which to load cluster information
+                                      BootstrapToken and File are mutually exclusive
+                                    properties:
+                                      kubeConfig:
+                                        description: |-
+                                          kubeConfig is used (optionally) to generate a KubeConfig based on the KubeadmConfig's information.
+                                          The file is generated at the path specified in KubeConfigPath.
+
+                                          Host address (server field) information is automatically populated based on the Cluster's ControlPlaneEndpoint.
+                                          Certificate Authority (certificate-authority-data field) is gathered from the cluster's CA secret.
+                                        properties:
+                                          cluster:
+                                            description: |-
+                                              cluster contains information about how to communicate with the kubernetes cluster.
+
+                                              By default the following fields are automatically populated:
+                                              - Server with the Cluster's ControlPlaneEndpoint.
+                                              - CertificateAuthorityData with the Cluster's CA certificate.
+                                            properties:
+                                              certificateAuthorityData:
+                                                description: |-
+                                                  certificateAuthorityData contains PEM-encoded certificate authority certificates.
+
+                                                  Defaults to the Cluster's CA certificate if empty.
+                                                format: byte
+                                                maxLength: 51200
+                                                minLength: 1
+                                                type: string
+                                              insecureSkipTLSVerify:
+                                                description: insecureSkipTLSVerify
+                                                  skips the validity check for the
+                                                  server's certificate. This will
+                                                  make your HTTPS connections insecure.
+                                                type: boolean
+                                              proxyURL:
+                                                description: |-
+                                                  proxyURL is the URL to the proxy to be used for all requests made by this
+                                                  client. URLs with "http", "https", and "socks5" schemes are supported.  If
+                                                  this configuration is not provided or the empty string, the client
+                                                  attempts to construct a proxy configuration from http_proxy and
+                                                  https_proxy environment variables. If these environment variables are not
+                                                  set, the client does not attempt to proxy requests.
+
+                                                  socks5 proxying does not currently support spdy streaming endpoints (exec,
+                                                  attach, port forward).
+                                                maxLength: 512
+                                                minLength: 1
+                                                type: string
+                                              server:
+                                                description: |-
+                                                  server is the address of the kubernetes cluster (https://hostname:port).
+
+                                                  Defaults to https:// + Cluster.Spec.ControlPlaneEndpoint.
+                                                maxLength: 512
+                                                minLength: 1
+                                                type: string
+                                              tlsServerName:
+                                                description: tlsServerName is used
+                                                  to check server certificate. If
+                                                  TLSServerName is empty, the hostname
+                                                  used to contact the server is used.
+                                                maxLength: 512
+                                                minLength: 1
+                                                type: string
+                                            type: object
+                                          user:
+                                            description: |-
+                                              user contains information that describes identity information.
+                                              This is used to tell the kubernetes cluster who you are.
+                                            properties:
+                                              authProvider:
+                                                description: authProvider specifies
+                                                  a custom authentication plugin for
+                                                  the kubernetes cluster.
+                                                properties:
+                                                  config:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: config holds the
+                                                      parameters for the authentication
+                                                      plugin.
+                                                    type: object
+                                                  name:
+                                                    description: name is the name
+                                                      of the authentication plugin.
+                                                    maxLength: 256
+                                                    minLength: 1
+                                                    type: string
+                                                required:
+                                                - name
+                                                type: object
+                                              exec:
+                                                description: exec specifies a custom
+                                                  exec-based authentication plugin
+                                                  for the kubernetes cluster.
+                                                properties:
+                                                  apiVersion:
+                                                    description: |-
+                                                      apiVersion is preferred input version of the ExecInfo. The returned ExecCredentials MUST use
+                                                      the same encoding version as the input.
+                                                      Defaults to client.authentication.k8s.io/v1 if not set.
+                                                    maxLength: 512
+                                                    minLength: 1
+                                                    type: string
+                                                  args:
+                                                    description: args is the arguments
+                                                      to pass to the command when
+                                                      executing it.
+                                                    items:
+                                                      maxLength: 512
+                                                      minLength: 1
+                                                      type: string
+                                                    maxItems: 100
+                                                    type: array
+                                                  command:
+                                                    description: command to execute.
+                                                    maxLength: 1024
+                                                    minLength: 1
+                                                    type: string
+                                                  env:
+                                                    description: |-
+                                                      env defines additional environment variables to expose to the process. These
+                                                      are unioned with the host's environment, as well as variables client-go uses
+                                                      to pass argument to the plugin.
+                                                    items:
+                                                      description: |-
+                                                        KubeConfigAuthExecEnv is used for setting environment variables when executing an exec-based
+                                                        credential plugin.
+                                                      properties:
+                                                        name:
+                                                          description: name of the
+                                                            environment variable
+                                                          maxLength: 512
+                                                          minLength: 1
+                                                          type: string
+                                                        value:
+                                                          description: value of the
+                                                            environment variable
+                                                          maxLength: 512
+                                                          minLength: 1
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    maxItems: 100
+                                                    type: array
+                                                  provideClusterInfo:
+                                                    description: |-
+                                                      provideClusterInfo determines whether or not to provide cluster information,
+                                                      which could potentially contain very large CA data, to this exec plugin as a
+                                                      part of the KUBERNETES_EXEC_INFO environment variable. By default, it is set
+                                                      to false. Package k8s.io/client-go/tools/auth/exec provides helper methods for
+                                                      reading this environment variable.
+                                                    type: boolean
+                                                required:
+                                                - command
+                                                type: object
+                                            type: object
+                                        required:
+                                        - user
+                                        type: object
+                                      kubeConfigPath:
+                                        description: kubeConfigPath is used to specify
+                                          the actual file path or URL to the kubeconfig
+                                          file from which to load cluster information
+                                        maxLength: 512
+                                        minLength: 1
+                                        type: string
+                                    required:
+                                    - kubeConfigPath
+                                    type: object
+                                  timeout:
+                                    description: timeout modifies the discovery timeout
+                                    type: string
+                                  tlsBootstrapToken:
+                                    description: |-
+                                      tlsBootstrapToken is a token used for TLS bootstrapping.
+                                      If .BootstrapToken is set, this field is defaulted to .BootstrapToken.Token, but can be overridden.
+                                      If .File is set, this field **must be set** in case the KubeConfigFile does not contain any other authentication information
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              kind:
+                                description: |-
+                                  Kind is a string value representing the REST resource this object represents.
+                                  Servers may infer this from the endpoint the client submits requests to.
+                                  Cannot be updated.
+                                  In CamelCase.
+                                  More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                                type: string
+                              nodeRegistration:
+                                description: |-
+                                  nodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+                                  When used in the context of control plane nodes, NodeRegistration should remain consistent
+                                  across both InitConfiguration and JoinConfiguration
+                                properties:
+                                  criSocket:
+                                    description: criSocket is used to retrieve container
+                                      runtime info. This information will be annotated
+                                      to the Node API object, for later re-use
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                  ignorePreflightErrors:
+                                    description: ignorePreflightErrors provides a
+                                      slice of pre-flight errors to be ignored when
+                                      the current node is registered.
+                                    items:
+                                      maxLength: 512
+                                      minLength: 1
+                                      type: string
+                                    maxItems: 50
+                                    type: array
+                                  imagePullPolicy:
+                                    description: |-
+                                      imagePullPolicy specifies the policy for image pulling
+                                      during kubeadm "init" and "join" operations. The value of
+                                      this field must be one of "Always", "IfNotPresent" or
+                                      "Never". Defaults to "IfNotPresent". This can be used only
+                                      with Kubernetes version equal to 1.22 and later.
+                                    enum:
+                                    - Always
+                                    - IfNotPresent
+                                    - Never
+                                    type: string
+                                  imagePullSerial:
+                                    description: |-
+                                      imagePullSerial specifies if image pulling performed by kubeadm must be done serially or in parallel.
+                                      This option takes effect only on Kubernetes >=1.31.0.
+                                      Default: true (defaulted in kubeadm)
+                                    type: boolean
+                                  kubeletExtraArgs:
+                                    additionalProperties:
+                                      type: string
+                                    description: |-
+                                      kubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+                                      kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config-1.X ConfigMap
+                                      Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name is the `.Metadata.Name` field of the Node API object that will be created in this `kubeadm init` or `kubeadm join` operation.
+                                      This field is also used in the CommonName field of the kubelet's client certificate to the API server.
+                                      Defaults to the hostname of the node if not provided.
+                                    maxLength: 253
+                                    minLength: 1
+                                    type: string
+                                  taints:
+                                    description: |-
+                                      taints specifies the taints the Node API object should be registered with. If this field is unset, i.e. nil, in the `kubeadm init` process
+                                      it will be defaulted to []v1.Taint{'node-role.kubernetes.io/master=""'}. If you don't want to taint your control-plane node, set this field to an
+                                      empty slice, i.e. `taints: []` in the YAML file. This field is solely used for Node registration.
+                                    items:
+                                      description: |-
+                                        The node this Taint is attached to has the "effect" on
+                                        any pod that does not tolerate the Taint.
+                                      properties:
+                                        effect:
+                                          description: |-
+                                            Required. The effect of the taint on pods
+                                            that do not tolerate the taint.
+                                            Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                                          type: string
+                                        key:
+                                          description: Required. The taint key to
+                                            be applied to a node.
+                                          type: string
+                                        timeAdded:
+                                          description: |-
+                                            TimeAdded represents the time at which the taint was added.
+                                            It is only written for NoExecute taints.
+                                          format: date-time
+                                          type: string
+                                        value:
+                                          description: The taint value corresponding
+                                            to the taint key.
+                                          type: string
+                                      required:
+                                      - effect
+                                      - key
+                                      type: object
+                                    maxItems: 100
+                                    type: array
+                                type: object
+                              patches:
+                                description: |-
+                                  patches contains options related to applying patches to components deployed by kubeadm during
+                                  "kubeadm join". The minimum kubernetes version needed to support Patches is v1.22
+                                properties:
+                                  directory:
+                                    description: |-
+                                      directory is a path to a directory that contains files named "target[suffix][+patchtype].extension".
+                                      For example, "kube-apiserver0+merge.yaml" or just "etcd.json". "target" can be one of
+                                      "kube-apiserver", "kube-controller-manager", "kube-scheduler", "etcd". "patchtype" can be one
+                                      of "strategic" "merge" or "json" and they match the patch formats supported by kubectl.
+                                      The default "patchtype" is "strategic". "extension" must be either "json" or "yaml".
+                                      "suffix" is an optional string that can be used to determine which patches are applied
+                                      first alpha-numerically.
+                                      These files can be written into the target directory via KubeadmConfig.Files which
+                                      specifies additional files to be created on the machine, either with content inline or
+                                      by referencing a secret.
+                                    maxLength: 512
+                                    minLength: 1
+                                    type: string
+                                type: object
+                              skipPhases:
+                                description: |-
+                                  skipPhases is a list of phases to skip during command execution.
+                                  The list of phases can be obtained with the "kubeadm init --help" command.
+                                  This option takes effect only on Kubernetes >=1.22.0.
+                                items:
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                maxItems: 50
+                                type: array
+                            type: object
+                          mounts:
+                            description: mounts specifies a list of mount points to
+                              be setup.
+                            items:
+                              description: MountPoints defines input for generated
+                                mounts in cloud-init.
+                              items:
+                                maxLength: 512
+                                minLength: 1
+                                type: string
+                              type: array
+                            maxItems: 100
+                            type: array
+                          ntp:
+                            description: ntp specifies NTP configuration
+                            properties:
+                              enabled:
+                                description: enabled specifies whether NTP should
+                                  be enabled
+                                type: boolean
+                              servers:
+                                description: servers specifies which NTP servers to
+                                  use
+                                items:
+                                  maxLength: 512
+                                  minLength: 1
+                                  type: string
+                                maxItems: 100
+                                type: array
+                            type: object
+                          postKubeadmCommands:
+                            description: |-
+                              postKubeadmCommands specifies extra commands to run after kubeadm runs.
+                              With cloud-init, this is appended to the runcmd module configuration, and is typically executed in
+                              the cloud-final.service systemd unit. In Ignition, this is appended to /etc/kubeadm.sh.
+                            items:
+                              maxLength: 10240
+                              minLength: 1
+                              type: string
+                            maxItems: 1000
+                            type: array
+                          preKubeadmCommands:
+                            description: |-
+                              preKubeadmCommands specifies extra commands to run before kubeadm runs.
+                              With cloud-init, this is prepended to the runcmd module configuration, and is typically executed in
+                              the cloud-final.service systemd unit. In Ignition, this is prepended to /etc/kubeadm.sh.
+                            items:
+                              maxLength: 10240
+                              minLength: 1
+                              type: string
+                            maxItems: 1000
+                            type: array
+                          useExperimentalRetryJoin:
+                            description: |-
+                              useExperimentalRetryJoin replaces a basic kubeadm command with a shell
+                              script with retries for joins.
+
+                              This is meant to be an experimental temporary workaround on some environments
+                              where joins fail due to timing (and other issues). The long term goal is to add retries to
+                              kubeadm proper and use that functionality.
+
+                              This will add about 40KB to userdata
+
+                              For more information, refer to https://github.com/kubernetes-sigs/cluster-api/pull/2763#discussion_r397306055.
+
+                              Deprecated: This experimental fix is no longer needed and this field will be removed in a future release.
+                              When removing also remove from staticcheck exclude-rules for SA1019 in golangci.yml
+                            type: boolean
+                          users:
+                            description: users specifies extra users to add
+                            items:
+                              description: User defines the input for a generated
+                                user in cloud-init.
+                              properties:
+                                gecos:
+                                  description: gecos specifies the gecos to use for
+                                    the user
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                groups:
+                                  description: groups specifies the additional groups
+                                    for the user
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                homeDir:
+                                  description: homeDir specifies the home directory
+                                    to use for the user
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                inactive:
+                                  description: inactive specifies whether to mark
+                                    the user as inactive
+                                  type: boolean
+                                lockPassword:
+                                  description: lockPassword specifies if password
+                                    login should be disabled
+                                  type: boolean
+                                name:
+                                  description: name specifies the user name
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                passwd:
+                                  description: passwd specifies a hashed password
+                                    for the user
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                passwdFrom:
+                                  description: passwdFrom is a referenced source of
+                                    passwd to populate the passwd.
+                                  properties:
+                                    secret:
+                                      description: secret represents a secret that
+                                        should populate this password.
+                                      properties:
+                                        key:
+                                          description: key is the key in the secret's
+                                            data map for this value.
+                                          maxLength: 256
+                                          minLength: 1
+                                          type: string
+                                        name:
+                                          description: name of the secret in the KubeadmBootstrapConfig's
+                                            namespace to use.
+                                          maxLength: 253
+                                          minLength: 1
+                                          type: string
+                                      required:
+                                      - key
+                                      - name
+                                      type: object
+                                  required:
+                                  - secret
+                                  type: object
+                                primaryGroup:
+                                  description: primaryGroup specifies the primary
+                                    group for the user
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                shell:
+                                  description: shell specifies the user's shell
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                                sshAuthorizedKeys:
+                                  description: sshAuthorizedKeys specifies a list
+                                    of ssh authorized keys for the user
+                                  items:
+                                    maxLength: 2048
+                                    minLength: 1
+                                    type: string
+                                  maxItems: 100
+                                  type: array
+                                sudo:
+                                  description: sudo specifies a sudo role for the
+                                    user
+                                  maxLength: 256
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            maxItems: 100
+                            type: array
+                          verbosity:
+                            description: |-
+                              verbosity is the number for the kubeadm log level verbosity.
+                              It overrides the `--v` flag in kubeadm commands.
+                            format: int32
+                            type: integer
+                        type: object
+                      machineNamingStrategy:
+                        description: |-
+                          machineNamingStrategy allows changing the naming pattern used when creating Machines.
+                          InfraMachines & KubeadmConfigs will use the same name as the corresponding Machines.
+                        properties:
+                          template:
+                            description: |-
+                              template defines the template to use for generating the names of the Machine objects.
+                              If not defined, it will fallback to `{{ .kubeadmControlPlane.name }}-{{ .random }}`.
+                              If the generated name string exceeds 63 characters, it will be trimmed to 58 characters and will
+                              get concatenated with a random suffix of length 5.
+                              Length of the template string must not exceed 256 characters.
+                              The template allows the following variables `.cluster.name`, `.kubeadmControlPlane.name` and `.random`.
+                              The variable `.cluster.name` retrieves the name of the cluster object that owns the Machines being created.
+                              The variable `.kubeadmControlPlane.name` retrieves the name of the KubeadmControlPlane object that owns the Machines being created.
+                              The variable `.random` is substituted with random alphanumeric string, without vowels, of length 5. This variable is required
+                              part of the template. If not provided, validation will fail.
+                            maxLength: 256
+                            minLength: 1
+                            type: string
+                        type: object
+                      machineTemplate:
+                        description: |-
+                          machineTemplate contains information about how machines
+                          should be shaped when creating or updating a control plane.
+                        properties:
+                          metadata:
+                            description: |-
+                              metadata is the standard object's metadata.
+                              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                            properties:
+                              annotations:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  annotations is an unstructured key value map stored with a resource that may be
+                                  set by external tools to store and retrieve arbitrary metadata. They are not
+                                  queryable and should be preserved when modifying objects.
+                                  More info: http://kubernetes.io/docs/user-guide/annotations
+                                type: object
+                              labels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  labels is a map of string keys and values that can be used to organize and categorize
+                                  (scope and select) objects. May match selectors of replication controllers
+                                  and services.
+                                  More info: http://kubernetes.io/docs/user-guide/labels
+                                type: object
+                            type: object
+                          nodeDeletionTimeout:
+                            description: |-
+                              nodeDeletionTimeout defines how long the machine controller will attempt to delete the Node that the Machine
+                              hosts after the Machine is marked for deletion. A duration of 0 will retry deletion indefinitely.
+                              If no value is provided, the default value for this property of the Machine resource will be used.
+                            type: string
+                          nodeDrainTimeout:
+                            description: |-
+                              nodeDrainTimeout is the total amount of time that the controller will spend on draining a controlplane node
+                              The default value is 0, meaning that the node can be drained without any time limitations.
+                              NOTE: NodeDrainTimeout is different from `kubectl drain --timeout`
+                            type: string
+                          nodeVolumeDetachTimeout:
+                            description: |-
+                              nodeVolumeDetachTimeout is the total amount of time that the controller will spend on waiting for all volumes
+                              to be detached. The default value is 0, meaning that the volumes can be detached without any time limitations.
+                            type: string
+                        type: object
+                      remediationStrategy:
+                        description: remediationStrategy is the RemediationStrategy
+                          that controls how control plane machine remediation happens.
+                        properties:
+                          maxRetry:
+                            description: "maxRetry is the Max number of retries while
+                              attempting to remediate an unhealthy machine.\nA retry
+                              happens when a machine that was created as a replacement
+                              for an unhealthy machine also fails.\nFor example, given
+                              a control plane with three machines M1, M2, M3:\n\n\tM1
+                              become unhealthy; remediation happens, and M1-1 is created
+                              as a replacement.\n\tIf M1-1 (replacement of M1) has
+                              problems while bootstrapping it will become unhealthy,
+                              and then be\n\tremediated; such operation is considered
+                              a retry, remediation-retry #1.\n\tIf M1-2 (replacement
+                              of M1-1) becomes unhealthy, remediation-retry #2 will
+                              happen, etc.\n\nA retry could happen only after RetryPeriod
+                              from the previous retry.\nIf a machine is marked as
+                              unhealthy after MinHealthyPeriod from the previous remediation
+                              expired,\nthis is not considered a retry anymore because
+                              the new issue is assumed unrelated from the previous
+                              one.\n\nIf not set, the remedation will be retried infinitely."
+                            format: int32
+                            type: integer
+                          minHealthyPeriod:
+                            description: "minHealthyPeriod defines the duration after
+                              which KCP will consider any failure to a machine unrelated\nfrom
+                              the previous one. In this case the remediation is not
+                              considered a retry anymore, and thus the retry\ncounter
+                              restarts from 0. For example, assuming MinHealthyPeriod
+                              is set to 1h (default)\n\n\tM1 become unhealthy; remediation
+                              happens, and M1-1 is created as a replacement.\n\tIf
+                              M1-1 (replacement of M1) has problems within the 1hr
+                              after the creation, also\n\tthis machine will be remediated
+                              and this operation is considered a retry - a problem
+                              related\n\tto the original issue happened to M1 -.\n\n\tIf
+                              instead the problem on M1-1 is happening after MinHealthyPeriod
+                              expired, e.g. four days after\n\tm1-1 has been created
+                              as a remediation of M1, the problem on M1-1 is considered
+                              unrelated to\n\tthe original issue happened to M1.\n\nIf
+                              not set, this value is defaulted to 1h."
+                            type: string
+                          retryPeriod:
+                            description: |-
+                              retryPeriod is the duration that KCP should wait before remediating a machine being created as a replacement
+                              for an unhealthy machine (a retry).
+
+                              If not set, a retry will happen immediately.
+                            type: string
+                        type: object
+                      rolloutAfter:
+                        description: |-
+                          rolloutAfter is a field to indicate a rollout should be performed
+                          after the specified time even if no changes have been made to the
+                          KubeadmControlPlane.
+                        format: date-time
+                        type: string
+                      rolloutBefore:
+                        description: |-
+                          rolloutBefore is a field to indicate a rollout should be performed
+                          if the specified criteria is met.
+                        properties:
+                          certificatesExpiryDays:
+                            description: |-
+                              certificatesExpiryDays indicates a rollout needs to be performed if the
+                              certificates of the machine will expire within the specified days.
+                            format: int32
+                            type: integer
+                        type: object
+                      rolloutStrategy:
+                        default:
+                          rollingUpdate:
+                            maxSurge: 1
+                          type: RollingUpdate
+                        description: |-
+                          rolloutStrategy is the RolloutStrategy to use to replace control plane machines with
+                          new ones.
+                        properties:
+                          rollingUpdate:
+                            description: |-
+                              rollingUpdate is the rolling update config params. Present only if
+                              RolloutStrategyType = RollingUpdate.
+                            properties:
+                              maxSurge:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  maxSurge is the maximum number of control planes that can be scheduled above or under the
+                                  desired number of control planes.
+                                  Value can be an absolute number 1 or 0.
+                                  Defaults to 1.
+                                  Example: when this is set to 1, the control plane can be scaled
+                                  up immediately when the rolling update starts.
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          type:
+                            description: |-
+                              type of rollout. Currently the only supported strategy is
+                              "RollingUpdate".
+                              Default is RollingUpdate.
+                            enum:
+                            - RollingUpdate
+                            type: string
+                        type: object
+                    required:
+                    - kubeadmConfigSpec
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/cluster_api/runtime/runtime.cluster.x-k8s.io_extensionconfigs.yaml
+++ b/docs/shared/crds/cluster_api/runtime/runtime.cluster.x-k8s.io_extensionconfigs.yaml
@@ -1,0 +1,361 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.2
+  name: extensionconfigs.runtime.cluster.x-k8s.io
+spec:
+  group: runtime.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: ExtensionConfig
+    listKind: ExtensionConfigList
+    plural: extensionconfigs
+    shortNames:
+    - ext
+    singular: extensionconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Time duration since creation of ExtensionConfig
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ExtensionConfig is the Schema for the ExtensionConfig API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the desired state of the ExtensionConfig.
+            properties:
+              clientConfig:
+                description: clientConfig defines how to communicate with the Extension
+                  server.
+                properties:
+                  caBundle:
+                    description: caBundle is a PEM encoded CA bundle which will be
+                      used to validate the Extension server's server certificate.
+                    format: byte
+                    maxLength: 51200
+                    minLength: 1
+                    type: string
+                  service:
+                    description: |-
+                      service is a reference to the Kubernetes service for the Extension server.
+                      Note: Exactly one of `url` or `service` must be specified.
+
+                      If the Extension server is running within a cluster, then you should use `service`.
+                    properties:
+                      name:
+                        description: name is the name of the service.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      namespace:
+                        description: namespace is the namespace of the service.
+                        maxLength: 63
+                        minLength: 1
+                        type: string
+                      path:
+                        description: |-
+                          path is an optional URL path and if present may be any string permissible in
+                          a URL. If a path is set it will be used as prefix to the hook-specific path.
+                        maxLength: 512
+                        minLength: 1
+                        type: string
+                      port:
+                        description: |-
+                          port is the port on the service that's hosting the Extension server.
+                          Defaults to 443.
+                          Port should be a valid port number (1-65535, inclusive).
+                        format: int32
+                        type: integer
+                    required:
+                    - name
+                    - namespace
+                    type: object
+                  url:
+                    description: |-
+                      url gives the location of the Extension server, in standard URL form
+                      (`scheme://host:port/path`).
+                      Note: Exactly one of `url` or `service` must be specified.
+
+                      The scheme must be "https".
+
+                      The `host` should not refer to a service running in the cluster; use
+                      the `service` field instead.
+
+                      A path is optional, and if present may be any string permissible in
+                      a URL. If a path is set it will be used as prefix to the hook-specific path.
+
+                      Attempting to use a user or basic auth e.g. "user:password@" is not
+                      allowed. Fragments ("#...") and query parameters ("?...") are not
+                      allowed either.
+                    maxLength: 512
+                    minLength: 1
+                    type: string
+                type: object
+              namespaceSelector:
+                description: |-
+                  namespaceSelector decides whether to call the hook for an object based
+                  on whether the namespace for that object matches the selector.
+                  Defaults to the empty LabelSelector, which matches all objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              settings:
+                additionalProperties:
+                  type: string
+                description: |-
+                  settings defines key value pairs to be passed to all calls
+                  to all supported RuntimeExtensions.
+                  Note: Settings can be overridden on the ClusterClass.
+                type: object
+            required:
+            - clientConfig
+            type: object
+          status:
+            description: status is the current state of the ExtensionConfig
+            properties:
+              conditions:
+                description: conditions define the current service state of the ExtensionConfig.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              handlers:
+                description: handlers defines the current ExtensionHandlers supported
+                  by an Extension.
+                items:
+                  description: ExtensionHandler specifies the details of a handler
+                    for a particular runtime hook registered by an Extension server.
+                  properties:
+                    failurePolicy:
+                      description: |-
+                        failurePolicy defines how failures in calls to the ExtensionHandler should be handled by a client.
+                        Defaults to Fail if not set.
+                      enum:
+                      - Ignore
+                      - Fail
+                      type: string
+                    name:
+                      description: name is the unique name of the ExtensionHandler.
+                      maxLength: 512
+                      minLength: 1
+                      type: string
+                    requestHook:
+                      description: requestHook defines the versioned runtime hook
+                        which this ExtensionHandler serves.
+                      properties:
+                        apiVersion:
+                          description: apiVersion is the group and version of the
+                            Hook.
+                          maxLength: 512
+                          minLength: 1
+                          type: string
+                        hook:
+                          description: hook is the name of the hook.
+                          maxLength: 256
+                          minLength: 1
+                          type: string
+                      required:
+                      - apiVersion
+                      - hook
+                      type: object
+                    timeoutSeconds:
+                      description: |-
+                        timeoutSeconds defines the timeout duration for client calls to the ExtensionHandler.
+                        Defaults to 10 seconds if not set.
+                      format: int32
+                      type: integer
+                  required:
+                  - name
+                  - requestHook
+                  type: object
+                maxItems: 512
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              v1beta2:
+                description: v1beta2 groups all the fields that will be added or modified
+                  in ExtensionConfig's status with the V1Beta2 version.
+                properties:
+                  conditions:
+                    description: |-
+                      conditions represents the observations of a ExtensionConfig's current state.
+                      Known condition types are Discovered, Paused.
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/machine_configuration/machineconfiguration.alauda.io_machineconfigpools.yaml
+++ b/docs/shared/crds/machine_configuration/machineconfiguration.alauda.io_machineconfigpools.yaml
@@ -1,0 +1,584 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: machineconfigpools.machineconfiguration.alauda.io
+spec:
+  group: machineconfiguration.alauda.io
+  names:
+    kind: MachineConfigPool
+    listKind: MachineConfigPoolList
+    plural: machineconfigpools
+    shortNames:
+    - mcp
+    singular: machineconfigpool
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.configuration.name
+      name: Config
+      type: string
+    - description: When all the machines in the pool are updated to the correct machine
+        config.
+      jsonPath: .status.conditions[?(@.type=="Updated")].status
+      name: Updated
+      type: string
+    - description: When at least one machine is not updated or is in the process
+        of updating to the desired machine config.
+      jsonPath: .status.conditions[?(@.type=="Updating")].status
+      name: Updating
+      type: string
+    - description: When progress is blocked on updating one or more nodes or the pool
+        configuration is failing.
+      jsonPath: .status.conditions[?(@.type=="Degraded")].status
+      name: Degraded
+      type: string
+    - description: Total number of machines in the machine config pool
+      jsonPath: .status.machineCount
+      name: MachineCount
+      type: number
+    - description: Total number of ready machines targeted by the pool
+      jsonPath: .status.readyMachineCount
+      name: ReadyMachineCount
+      type: number
+    - description: Total number of machines targeted by the pool that have the CurrentMachineConfig
+        as their config
+      jsonPath: .status.updatedMachineCount
+      name: UpdatedMachineCount
+      type: number
+    - description: Total number of machines marked degraded (or unreconcilable)
+      jsonPath: .status.degradedMachineCount
+      name: DegradedMachineCount
+      type: number
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineConfigPool describes a pool of MachineConfigs.
+
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigPoolSpec is the spec for MachineConfigPool resource.
+            properties:
+              configuration:
+                description: The targeted MachineConfig object for the machine config
+                  pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: |-
+                        ObjectReference contains enough information to let you inspect or modify the referred object.
+                        ---
+                        New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                         1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                         2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                            restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                            Those cannot be well described when embedded.
+                         3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                         4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                            during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                            and the version of the actual struct is irrelevant.
+                         5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                            will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                        Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                        For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                            TODO: this design is not final and this field is subject to change in the future.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          type: string
+                        resourceVersion:
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        uid:
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              machineConfigSelector:
+                description: |-
+                  machineConfigSelector specifies a label selector for MachineConfigs.
+                  Refer https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/ on how label and selectors work.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              maxUnavailable:
+                anyOf:
+                - type: integer
+                - type: string
+                description: |-
+                  maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update.
+                  This includes nodes Unavailable for any reason, including user
+                  initiated cordons, failing nodes, etc. The default value is 1.
+
+
+                  A value larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining nodes.
+                  You cannot set this value to 0 to stop updates (it will default back to 1);
+                  to stop updates, use the 'paused' property instead. Drain will respect
+                  Pod Disruption Budgets (PDBs) such as etcd quorum guards, even if
+                  maxUnavailable is greater than one.
+                x-kubernetes-int-or-string: true
+              nodeSelector:
+                description: nodeSelector specifies a label selector for Machines
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              paused:
+                description: |-
+                  paused specifies whether or not changes to this machine config pool should be stopped.
+                  This includes generating new desiredMachineConfig and update of machines.
+                type: boolean
+            type: object
+          status:
+            description: MachineConfigPoolStatus is the status for MachineConfigPool
+              resource.
+            properties:
+              conditions:
+                description: conditions represents the latest available observations
+                  of current state.
+                items:
+                  description: MachineConfigPoolCondition contains condition information
+                    for an MachineConfigPool.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the timestamp corresponding to the last status
+                        change of this condition.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable description of the details of the last
+                        transition, complementing reason.
+                      type: string
+                    reason:
+                      description: |-
+                        reason is a brief machine readable explanation for the condition's last
+                        transition.
+                      type: string
+                    status:
+                      description: status of the condition, one of ('True', 'False',
+                        'Unknown').
+                      type: string
+                    type:
+                      description: type of the condition, currently ('Done', 'Updating',
+                        'Failed').
+                      type: string
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              configuration:
+                description: configuration represents the current MachineConfig object
+                  for the machine config pool.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                      TODO: this design is not final and this field is subject to change in the future.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  source:
+                    description: source is the list of MachineConfig objects that
+                      were used to generate the single MachineConfig object specified
+                      in `content`.
+                    items:
+                      description: |-
+                        ObjectReference contains enough information to let you inspect or modify the referred object.
+                        ---
+                        New uses of this type are discouraged because of difficulty describing its usage when embedded in APIs.
+                         1. Ignored fields.  It includes many fields which are not generally honored.  For instance, ResourceVersion and FieldPath are both very rarely valid in actual usage.
+                         2. Invalid usage help.  It is impossible to add specific help for individual usage.  In most embedded usages, there are particular
+                            restrictions like, "must refer only to types A and B" or "UID not honored" or "name must be restricted".
+                            Those cannot be well described when embedded.
+                         3. Inconsistent validation.  Because the usages are different, the validation rules are different by usage, which makes it hard for users to predict what will happen.
+                         4. The fields are both imprecise and overly precise.  Kind is not a precise mapping to a URL. This can produce ambiguity
+                            during interpretation and require a REST mapping.  In most cases, the dependency is on the group,resource tuple
+                            and the version of the actual struct is irrelevant.
+                         5. We cannot easily change it.  Because this type is embedded in many locations, updates to this type
+                            will affect numerous schemas.  Don't make new APIs embed an underspecified API type they do not control.
+
+
+                        Instead of using this type, create a locally provided and used type that is well-focused on your reference.
+                        For example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533 .
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                            TODO: this design is not final and this field is subject to change in the future.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          type: string
+                        resourceVersion:
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        uid:
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              degradedMachineCount:
+                description: |-
+                  degradedMachineCount represents the total number of machines marked degraded (or unreconcilable).
+                  A node is marked degraded if applying a configuration failed..
+                format: int32
+                type: integer
+              machineCount:
+                description: machineCount represents the total number of machines
+                  in the machine config pool.
+                format: int32
+                type: integer
+              observedGeneration:
+                description: observedGeneration represents the generation observed
+                  by the controller.
+                format: int64
+                type: integer
+              poolSynchronizersStatus:
+                description: poolSynchronizersStatus is the status of the machines
+                  managed by the pool synchronizers.
+                items:
+                  properties:
+                    availableMachineCount:
+                      description: availableMachineCount is the number of machines
+                        managed by the node synchronizer which are available.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    machineCount:
+                      description: machineCount is the number of machines that are
+                        managed by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    observedGeneration:
+                      description: observedGeneration is the last generation change
+                        that has been applied.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                      x-kubernetes-validations:
+                      - message: observedGeneration must not move backwards except
+                          to zero
+                        rule: self >= oldSelf || (self == 0 && oldSelf > 0)
+                    poolSynchronizerType:
+                      description: poolSynchronizerType describes the type of the
+                        pool synchronizer.
+                      enum:
+                      - PinnedImageSets
+                      maxLength: 256
+                      type: string
+                    readyMachineCount:
+                      description: readyMachineCount is the number of machines managed
+                        by the node synchronizer that are in a ready state.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    unavailableMachineCount:
+                      description: unavailableMachineCount is the number of machines
+                        managed by the node synchronizer but are unavailable.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    updatedMachineCount:
+                      description: updatedMachineCount is the number of machines that
+                        have been updated by the node synchronizer.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                  required:
+                  - availableMachineCount
+                  - machineCount
+                  - poolSynchronizerType
+                  - readyMachineCount
+                  - unavailableMachineCount
+                  - updatedMachineCount
+                  type: object
+                  x-kubernetes-validations:
+                  - message: machineCount must be greater than or equal to updatedMachineCount
+                    rule: self.machineCount >= self.updatedMachineCount
+                  - message: machineCount must be greater than or equal to availableMachineCount
+                    rule: self.machineCount >= self.availableMachineCount
+                  - message: machineCount must be greater than or equal to unavailableMachineCount
+                    rule: self.machineCount >= self.unavailableMachineCount
+                  - message: machineCount must be greater than or equal to readyMachineCount
+                    rule: self.machineCount >= self.readyMachineCount
+                  - message: availableMachineCount must be greater than or equal to
+                      readyMachineCount
+                    rule: self.availableMachineCount >= self.readyMachineCount
+                type: array
+                x-kubernetes-list-map-keys:
+                - poolSynchronizerType
+                x-kubernetes-list-type: map
+              readyMachineCount:
+                description: readyMachineCount represents the total number of ready
+                  machines targeted by the pool.
+                format: int32
+                type: integer
+              unavailableMachineCount:
+                description: |-
+                  unavailableMachineCount represents the total number of unavailable (non-ready) machines targeted by the pool.
+                  A node is marked unavailable if it is in updating state or NodeReady condition is false.
+                format: int32
+                type: integer
+              updatedMachineCount:
+                description: updatedMachineCount represents the total number of machines
+                  targeted by the pool that have the CurrentMachineConfig as their
+                  config.
+                format: int32
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/machine_configuration/machineconfiguration.alauda.io_machineconfigs.yaml
+++ b/docs/shared/crds/machine_configuration/machineconfiguration.alauda.io_machineconfigs.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: machineconfigs.machineconfiguration.alauda.io
+spec:
+  group: machineconfiguration.alauda.io
+  names:
+    kind: MachineConfig
+    listKind: MachineConfigList
+    plural: machineconfigs
+    shortNames:
+    - mc
+    singular: machineconfig
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Version of the Ignition Config defined in the machineconfig.
+      jsonPath: .spec.config.ignition.version
+      name: IgnitionVersion
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineConfig defines the configuration for a machine
+
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MachineConfigSpec is the spec for MachineConfig
+            properties:
+              config:
+                description: Config is a Ignition Config object.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              kernelArguments:
+                description: kernelArguments contains a list of kernel arguments to
+                  be added
+                items:
+                  type: string
+                nullable: true
+                type: array
+                x-kubernetes-list-type: atomic
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources: {}

--- a/docs/shared/crds/machine_configuration/machineconfiguration.alauda.io_machineconfigurations.yaml
+++ b/docs/shared/crds/machine_configuration/machineconfiguration.alauda.io_machineconfigurations.yaml
@@ -1,0 +1,1141 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: (unknown)
+  name: machineconfigurations.machineconfiguration.alauda.io
+spec:
+  group: machineconfiguration.alauda.io
+  names:
+    kind: MachineConfiguration
+    listKind: MachineConfigurationList
+    plural: machineconfigurations
+    singular: machineconfiguration
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MachineConfiguration provides information to configure an operator to manage Machine Configuration.
+
+
+          Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec is the specification of the desired behavior of the
+              Machine Config Operator
+            properties:
+              defaultNodeDisruptionPolicySpecAction:
+                description: DefaultNodeDisruptionPolicy is the default disruption
+                  policy for files/units/sshkeys
+                properties:
+                  files:
+                    description: |-
+                      files is the default node desruption policy for files
+                      This list supports a maximum of 10 entries.
+                    items:
+                      properties:
+                        reload:
+                          description: reload specifies the service to reload, only
+                            valid if type is reload
+                          properties:
+                            serviceName:
+                              description: |-
+                                serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - serviceName
+                          type: object
+                        restart:
+                          description: restart specifies the service to restart, only
+                            valid if type is restart
+                          properties:
+                            serviceName:
+                              description: |-
+                                serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - serviceName
+                          type: object
+                        type:
+                          description: |-
+                            type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed
+                            Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None.
+                            reload/restart requires a corresponding service target specified in the reload/restart field.
+                            Other values require no further configuration
+                          enum:
+                          - Reboot
+                          - Drain
+                          - Reload
+                          - Restart
+                          - DaemonReload
+                          - None
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: reload is required when type is Reload, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                          : !has(self.reload)'
+                      - message: restart is required when type is Restart, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Restart'' ? has(self.restart)
+                          : !has(self.restart)'
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-type: atomic
+                    x-kubernetes-validations:
+                    - message: Reboot action can only be specified standalone, as
+                        it will override any other actions
+                      rule: 'self.exists(x, x.type==''Reboot'') ? size(self) == 1
+                        : true'
+                    - message: None action can only be specified standalone, as it
+                        will override any other actions
+                      rule: 'self.exists(x, x.type==''None'') ? size(self) == 1 :
+                        true'
+                  units:
+                    description: |-
+                      units is the default node desruption policy for units
+                      This list supports a maximum of 10 entries.
+                    items:
+                      properties:
+                        reload:
+                          description: reload specifies the service to reload, only
+                            valid if type is reload
+                          properties:
+                            serviceName:
+                              description: |-
+                                serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - serviceName
+                          type: object
+                        restart:
+                          description: restart specifies the service to restart, only
+                            valid if type is restart
+                          properties:
+                            serviceName:
+                              description: |-
+                                serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - serviceName
+                          type: object
+                        type:
+                          description: |-
+                            type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed
+                            Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None.
+                            reload/restart requires a corresponding service target specified in the reload/restart field.
+                            Other values require no further configuration
+                          enum:
+                          - Reboot
+                          - Drain
+                          - Reload
+                          - Restart
+                          - DaemonReload
+                          - None
+                          type: string
+                      required:
+                      - type
+                      type: object
+                      x-kubernetes-validations:
+                      - message: reload is required when type is Reload, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                          : !has(self.reload)'
+                      - message: restart is required when type is Restart, and forbidden
+                          otherwise
+                        rule: 'has(self.type) && self.type == ''Restart'' ? has(self.restart)
+                          : !has(self.restart)'
+                    maxItems: 10
+                    type: array
+                    x-kubernetes-list-type: atomic
+                    x-kubernetes-validations:
+                    - message: Reboot action can only be specified standalone, as
+                        it will override any other actions
+                      rule: 'self.exists(x, x.type==''Reboot'') ? size(self) == 1
+                        : true'
+                    - message: None action can only be specified standalone, as it
+                        will override any other actions
+                      rule: 'self.exists(x, x.type==''None'') ? size(self) == 1 :
+                        true'
+                required:
+                - files
+                - units
+                type: object
+              nodeDisruptionPolicy:
+                description: |-
+                  nodeDisruptionPolicy allows an admin to set granular node disruption actions for
+                  MachineConfig-based updates, such as drains, service reloads, etc. Specifying this will allow
+                  for less downtime when doing small configuration updates to the cluster. This configuration
+                  has no effect on cluster upgrades which will still incur node disruption where required.
+                properties:
+                  files:
+                    description: |-
+                      files is a list of MachineConfig file definitions and actions to take to changes on those paths
+                      This list supports a maximum of 50 entries.
+                    items:
+                      description: NodeDisruptionPolicySpecFile is a file entry and
+                        corresponding actions to take and is used in the NodeDisruptionPolicyConfig
+                        object
+                      properties:
+                        actions:
+                          description: |-
+                            actions represents the series of commands to be executed on changes to the file at
+                            the corresponding file path. Actions will be applied in the order that
+                            they are set in this list. If there are other incoming changes to other MachineConfig
+                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            Valid actions are Reboot, Drain, Reload, DaemonReload and None.
+                            The Reboot action and the None action cannot be used in conjunction with any of the other actions.
+                            This list supports a maximum of 10 entries.
+                          items:
+                            properties:
+                              reload:
+                                description: reload specifies the service to reload,
+                                  only valid if type is reload
+                                properties:
+                                  serviceName:
+                                    description: |-
+                                      serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                      Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                      ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                      ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              restart:
+                                description: restart specifies the service to restart,
+                                  only valid if type is restart
+                                properties:
+                                  serviceName:
+                                    description: |-
+                                      serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                      Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                      ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                      ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              type:
+                                description: |-
+                                  type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed
+                                  Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None.
+                                  reload/restart requires a corresponding service target specified in the reload/restart field.
+                                  Other values require no further configuration
+                                enum:
+                                - Reboot
+                                - Drain
+                                - Reload
+                                - Restart
+                                - DaemonReload
+                                - None
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: reload is required when type is Reload, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                                : !has(self.reload)'
+                            - message: restart is required when type is Restart, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Restart'' ?
+                                has(self.restart) : !has(self.restart)'
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                          - message: Reboot action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                              == 1 : true'
+                          - message: None action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                              1 : true'
+                        path:
+                          description: |-
+                            path is the location of a file being managed through a MachineConfig.
+                            The Actions in the policy will apply to changes to the file at this path.
+                          type: string
+                      required:
+                      - actions
+                      - path
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - path
+                    x-kubernetes-list-type: map
+                  sshkey:
+                    description: |-
+                      sshkey maps to the ignition.sshkeys field in the MachineConfig object, definition an action for this
+                      will apply to all sshkey changes in the cluster
+                    properties:
+                      actions:
+                        description: |-
+                          actions represents the series of commands to be executed on changes to the file at
+                          the corresponding file path. Actions will be applied in the order that
+                          they are set in this list. If there are other incoming changes to other MachineConfig
+                          entries in the same update that require a reboot, the reboot will supercede these actions.
+                          Valid actions are Reboot, Drain, Reload, DaemonReload and None.
+                          The Reboot action and the None action cannot be used in conjunction with any of the other actions.
+                          This list supports a maximum of 10 entries.
+                        items:
+                          properties:
+                            reload:
+                              description: reload specifies the service to reload,
+                                only valid if type is reload
+                              properties:
+                                serviceName:
+                                  description: |-
+                                    serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                    Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                    ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                    ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                  maxLength: 255
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: Invalid ${SERVICETYPE} in service name.
+                                      Expected format is ${NAME}${SERVICETYPE}, where
+                                      ${SERVICETYPE} must be one of ".service", ".socket",
+                                      ".device", ".mount", ".automount", ".swap",
+                                      ".target", ".path", ".timer",".snapshot", ".slice"
+                                      or ".scope".
+                                    rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                  - message: Invalid ${NAME} in service name. Expected
+                                      format is ${NAME}${SERVICETYPE}, where {NAME}
+                                      must be atleast 1 character long and can only
+                                      consist of alphabets, digits, ":", "-", "_",
+                                      ".", and "\"
+                                    rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                              required:
+                              - serviceName
+                              type: object
+                            restart:
+                              description: restart specifies the service to restart,
+                                only valid if type is restart
+                              properties:
+                                serviceName:
+                                  description: |-
+                                    serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                    Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                    ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                    ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                  maxLength: 255
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: Invalid ${SERVICETYPE} in service name.
+                                      Expected format is ${NAME}${SERVICETYPE}, where
+                                      ${SERVICETYPE} must be one of ".service", ".socket",
+                                      ".device", ".mount", ".automount", ".swap",
+                                      ".target", ".path", ".timer",".snapshot", ".slice"
+                                      or ".scope".
+                                    rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                  - message: Invalid ${NAME} in service name. Expected
+                                      format is ${NAME}${SERVICETYPE}, where {NAME}
+                                      must be atleast 1 character long and can only
+                                      consist of alphabets, digits, ":", "-", "_",
+                                      ".", and "\"
+                                    rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                              required:
+                              - serviceName
+                              type: object
+                            type:
+                              description: |-
+                                type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed
+                                Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None.
+                                reload/restart requires a corresponding service target specified in the reload/restart field.
+                                Other values require no further configuration
+                              enum:
+                              - Reboot
+                              - Drain
+                              - Reload
+                              - Restart
+                              - DaemonReload
+                              - None
+                              type: string
+                          required:
+                          - type
+                          type: object
+                          x-kubernetes-validations:
+                          - message: reload is required when type is Reload, and forbidden
+                              otherwise
+                            rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                              : !has(self.reload)'
+                          - message: restart is required when type is Restart, and
+                              forbidden otherwise
+                            rule: 'has(self.type) && self.type == ''Restart'' ? has(self.restart)
+                              : !has(self.restart)'
+                        maxItems: 10
+                        type: array
+                        x-kubernetes-list-type: atomic
+                        x-kubernetes-validations:
+                        - message: Reboot action can only be specified standalone,
+                            as it will override any other actions
+                          rule: 'self.exists(x, x.type==''Reboot'') ? size(self) ==
+                            1 : true'
+                        - message: None action can only be specified standalone, as
+                            it will override any other actions
+                          rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                            1 : true'
+                    required:
+                    - actions
+                    type: object
+                  units:
+                    description: |-
+                      units is a list MachineConfig unit definitions and actions to take on changes to those services
+                      This list supports a maximum of 50 entries.
+                    items:
+                      description: NodeDisruptionPolicySpecUnit is a systemd unit
+                        name and corresponding actions to take and is used in the
+                        NodeDisruptionPolicyConfig object
+                      properties:
+                        actions:
+                          description: |-
+                            actions represents the series of commands to be executed on changes to the file at
+                            the corresponding file path. Actions will be applied in the order that
+                            they are set in this list. If there are other incoming changes to other MachineConfig
+                            entries in the same update that require a reboot, the reboot will supercede these actions.
+                            Valid actions are Reboot, Drain, Reload, DaemonReload and None.
+                            The Reboot action and the None action cannot be used in conjunction with any of the other actions.
+                            This list supports a maximum of 10 entries.
+                          items:
+                            properties:
+                              reload:
+                                description: reload specifies the service to reload,
+                                  only valid if type is reload
+                                properties:
+                                  serviceName:
+                                    description: |-
+                                      serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                      Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                      ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                      ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              restart:
+                                description: restart specifies the service to restart,
+                                  only valid if type is restart
+                                properties:
+                                  serviceName:
+                                    description: |-
+                                      serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                      Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                      ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                      ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                    maxLength: 255
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: Invalid ${SERVICETYPE} in service name.
+                                        Expected format is ${NAME}${SERVICETYPE},
+                                        where ${SERVICETYPE} must be one of ".service",
+                                        ".socket", ".device", ".mount", ".automount",
+                                        ".swap", ".target", ".path", ".timer",".snapshot",
+                                        ".slice" or ".scope".
+                                      rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                    - message: Invalid ${NAME} in service name. Expected
+                                        format is ${NAME}${SERVICETYPE}, where {NAME}
+                                        must be atleast 1 character long and can only
+                                        consist of alphabets, digits, ":", "-", "_",
+                                        ".", and "\"
+                                      rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                required:
+                                - serviceName
+                                type: object
+                              type:
+                                description: |-
+                                  type represents the commands that will be carried out if this NodeDisruptionPolicySpecActionType is executed
+                                  Valid values are Reboot, Drain, Reload, Restart, DaemonReload and None.
+                                  reload/restart requires a corresponding service target specified in the reload/restart field.
+                                  Other values require no further configuration
+                                enum:
+                                - Reboot
+                                - Drain
+                                - Reload
+                                - Restart
+                                - DaemonReload
+                                - None
+                                type: string
+                            required:
+                            - type
+                            type: object
+                            x-kubernetes-validations:
+                            - message: reload is required when type is Reload, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Reload'' ? has(self.reload)
+                                : !has(self.reload)'
+                            - message: restart is required when type is Restart, and
+                                forbidden otherwise
+                              rule: 'has(self.type) && self.type == ''Restart'' ?
+                                has(self.restart) : !has(self.restart)'
+                          maxItems: 10
+                          type: array
+                          x-kubernetes-list-type: atomic
+                          x-kubernetes-validations:
+                          - message: Reboot action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                              == 1 : true'
+                          - message: None action can only be specified standalone,
+                              as it will override any other actions
+                            rule: 'self.exists(x, x.type==''None'') ? size(self) ==
+                              1 : true'
+                        name:
+                          description: |-
+                            name represents the service name of a systemd service managed through a MachineConfig
+                            Actions specified will be applied for changes to the named service.
+                            Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                            ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                            ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                          maxLength: 255
+                          type: string
+                          x-kubernetes-validations:
+                          - message: Invalid ${SERVICETYPE} in service name. Expected
+                              format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                              must be one of ".service", ".socket", ".device", ".mount",
+                              ".automount", ".swap", ".target", ".path", ".timer",".snapshot",
+                              ".slice" or ".scope".
+                            rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                          - message: Invalid ${NAME} in service name. Expected format
+                              is ${NAME}${SERVICETYPE}, where {NAME} must be atleast
+                              1 character long and can only consist of alphabets,
+                              digits, ":", "-", "_", ".", and "\"
+                            rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                      required:
+                      - actions
+                      - name
+                      type: object
+                    maxItems: 50
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
+            type: object
+          status:
+            description: status is the most recently observed status of the Machine
+              Config Operator
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              nodeDisruptionPolicyStatus:
+                description: |-
+                  nodeDisruptionPolicyStatus status reflects what the latest cluster-validated policies are,
+                  and will be used by the Machine Config Daemon during future node updates.
+                properties:
+                  clusterPolicies:
+                    description: clusterPolicies is a merge of cluster default and
+                      user provided node disruption policies.
+                    properties:
+                      files:
+                        description: files is a list of MachineConfig file definitions
+                          and actions to take to changes on those paths
+                        items:
+                          description: NodeDisruptionPolicyStatusFile is a file entry
+                            and corresponding actions to take and is used in the NodeDisruptionPolicyClusterStatus
+                            object
+                          properties:
+                            actions:
+                              description: |-
+                                actions represents the series of commands to be executed on changes to the file at
+                                the corresponding file path. Actions will be applied in the order that
+                                they are set in this list. If there are other incoming changes to other MachineConfig
+                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                Valid actions are Reboot, Drain, Reload, DaemonReload and None.
+                                The Reboot action and the None action cannot be used in conjunction with any of the other actions.
+                                This list supports a maximum of 10 entries.
+                              items:
+                                properties:
+                                  reload:
+                                    description: reload specifies the service to reload,
+                                      only valid if type is reload
+                                    properties:
+                                      serviceName:
+                                        description: |-
+                                          serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                          Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                          ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                          ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  restart:
+                                    description: restart specifies the service to
+                                      restart, only valid if type is restart
+                                    properties:
+                                      serviceName:
+                                        description: |-
+                                          serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                          Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                          ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                          ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  type:
+                                    description: |-
+                                      type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed
+                                      Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service target specified in the reload/restart field.
+                                      Other values require no further configuration
+                                    enum:
+                                    - Reboot
+                                    - Drain
+                                    - Reload
+                                    - Restart
+                                    - DaemonReload
+                                    - None
+                                    - Special
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: reload is required when type is Reload,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Reload''
+                                    ? has(self.reload) : !has(self.reload)'
+                                - message: restart is required when type is Restart,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Restart''
+                                    ? has(self.restart) : !has(self.restart)'
+                              maxItems: 10
+                              type: array
+                              x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: Reboot action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                  == 1 : true'
+                              - message: None action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                  == 1 : true'
+                            path:
+                              description: |-
+                                path is the location of a file being managed through a MachineConfig.
+                                The Actions in the policy will apply to changes to the file at this path.
+                              type: string
+                          required:
+                          - actions
+                          - path
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - path
+                        x-kubernetes-list-type: map
+                      sshkey:
+                        description: sshkey is the overall sshkey MachineConfig definition
+                        properties:
+                          actions:
+                            description: |-
+                              actions represents the series of commands to be executed on changes to the file at
+                              the corresponding file path. Actions will be applied in the order that
+                              they are set in this list. If there are other incoming changes to other MachineConfig
+                              entries in the same update that require a reboot, the reboot will supercede these actions.
+                              Valid actions are Reboot, Drain, Reload, DaemonReload and None.
+                              The Reboot action and the None action cannot be used in conjunction with any of the other actions.
+                              This list supports a maximum of 10 entries.
+                            items:
+                              properties:
+                                reload:
+                                  description: reload specifies the service to reload,
+                                    only valid if type is reload
+                                  properties:
+                                    serviceName:
+                                      description: |-
+                                        serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                        Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                        ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                        ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                      maxLength: 255
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: Invalid ${SERVICETYPE} in service
+                                          name. Expected format is ${NAME}${SERVICETYPE},
+                                          where ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer",".snapshot",
+                                          ".slice" or ".scope".
+                                        rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                      - message: Invalid ${NAME} in service name.
+                                          Expected format is ${NAME}${SERVICETYPE},
+                                          where {NAME} must be atleast 1 character
+                                          long and can only consist of alphabets,
+                                          digits, ":", "-", "_", ".", and "\"
+                                        rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                  required:
+                                  - serviceName
+                                  type: object
+                                restart:
+                                  description: restart specifies the service to restart,
+                                    only valid if type is restart
+                                  properties:
+                                    serviceName:
+                                      description: |-
+                                        serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                        Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                        ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                        ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                      maxLength: 255
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: Invalid ${SERVICETYPE} in service
+                                          name. Expected format is ${NAME}${SERVICETYPE},
+                                          where ${SERVICETYPE} must be one of ".service",
+                                          ".socket", ".device", ".mount", ".automount",
+                                          ".swap", ".target", ".path", ".timer",".snapshot",
+                                          ".slice" or ".scope".
+                                        rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                      - message: Invalid ${NAME} in service name.
+                                          Expected format is ${NAME}${SERVICETYPE},
+                                          where {NAME} must be atleast 1 character
+                                          long and can only consist of alphabets,
+                                          digits, ":", "-", "_", ".", and "\"
+                                        rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                  required:
+                                  - serviceName
+                                  type: object
+                                type:
+                                  description: |-
+                                    type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed
+                                    Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special.
+                                    reload/restart requires a corresponding service target specified in the reload/restart field.
+                                    Other values require no further configuration
+                                  enum:
+                                  - Reboot
+                                  - Drain
+                                  - Reload
+                                  - Restart
+                                  - DaemonReload
+                                  - None
+                                  - Special
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                              x-kubernetes-validations:
+                              - message: reload is required when type is Reload, and
+                                  forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Reload'' ?
+                                  has(self.reload) : !has(self.reload)'
+                              - message: restart is required when type is Restart,
+                                  and forbidden otherwise
+                                rule: 'has(self.type) && self.type == ''Restart''
+                                  ? has(self.restart) : !has(self.restart)'
+                            maxItems: 10
+                            type: array
+                            x-kubernetes-list-type: atomic
+                            x-kubernetes-validations:
+                            - message: Reboot action can only be specified standalone,
+                                as it will override any other actions
+                              rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                == 1 : true'
+                            - message: None action can only be specified standalone,
+                                as it will override any other actions
+                              rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                == 1 : true'
+                        required:
+                        - actions
+                        type: object
+                      units:
+                        description: units is a list MachineConfig unit definitions
+                          and actions to take on changes to those services
+                        items:
+                          description: NodeDisruptionPolicyStatusUnit is a systemd
+                            unit name and corresponding actions to take and is used
+                            in the NodeDisruptionPolicyClusterStatus object
+                          properties:
+                            actions:
+                              description: |-
+                                actions represents the series of commands to be executed on changes to the file at
+                                the corresponding file path. Actions will be applied in the order that
+                                they are set in this list. If there are other incoming changes to other MachineConfig
+                                entries in the same update that require a reboot, the reboot will supercede these actions.
+                                Valid actions are Reboot, Drain, Reload, DaemonReload and None.
+                                The Reboot action and the None action cannot be used in conjunction with any of the other actions.
+                                This list supports a maximum of 10 entries.
+                              items:
+                                properties:
+                                  reload:
+                                    description: reload specifies the service to reload,
+                                      only valid if type is reload
+                                    properties:
+                                      serviceName:
+                                        description: |-
+                                          serviceName is the full name (e.g. crio.service) of the service to be reloaded
+                                          Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                          ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                          ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  restart:
+                                    description: restart specifies the service to
+                                      restart, only valid if type is restart
+                                    properties:
+                                      serviceName:
+                                        description: |-
+                                          serviceName is the full name (e.g. crio.service) of the service to be restarted
+                                          Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                          ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                          ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                                        maxLength: 255
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: Invalid ${SERVICETYPE} in service
+                                            name. Expected format is ${NAME}${SERVICETYPE},
+                                            where ${SERVICETYPE} must be one of ".service",
+                                            ".socket", ".device", ".mount", ".automount",
+                                            ".swap", ".target", ".path", ".timer",".snapshot",
+                                            ".slice" or ".scope".
+                                          rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                                        - message: Invalid ${NAME} in service name.
+                                            Expected format is ${NAME}${SERVICETYPE},
+                                            where {NAME} must be atleast 1 character
+                                            long and can only consist of alphabets,
+                                            digits, ":", "-", "_", ".", and "\"
+                                          rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                                    required:
+                                    - serviceName
+                                    type: object
+                                  type:
+                                    description: |-
+                                      type represents the commands that will be carried out if this NodeDisruptionPolicyStatusActionType is executed
+                                      Valid values are Reboot, Drain, Reload, Restart, DaemonReload, None and Special.
+                                      reload/restart requires a corresponding service target specified in the reload/restart field.
+                                      Other values require no further configuration
+                                    enum:
+                                    - Reboot
+                                    - Drain
+                                    - Reload
+                                    - Restart
+                                    - DaemonReload
+                                    - None
+                                    - Special
+                                    type: string
+                                required:
+                                - type
+                                type: object
+                                x-kubernetes-validations:
+                                - message: reload is required when type is Reload,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Reload''
+                                    ? has(self.reload) : !has(self.reload)'
+                                - message: restart is required when type is Restart,
+                                    and forbidden otherwise
+                                  rule: 'has(self.type) && self.type == ''Restart''
+                                    ? has(self.restart) : !has(self.restart)'
+                              maxItems: 10
+                              type: array
+                              x-kubernetes-list-type: atomic
+                              x-kubernetes-validations:
+                              - message: Reboot action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''Reboot'') ? size(self)
+                                  == 1 : true'
+                              - message: None action can only be specified standalone,
+                                  as it will override any other actions
+                                rule: 'self.exists(x, x.type==''None'') ? size(self)
+                                  == 1 : true'
+                            name:
+                              description: |-
+                                name represents the service name of a systemd service managed through a MachineConfig
+                                Actions specified will be applied for changes to the named service.
+                                Service names should be of the format ${NAME}${SERVICETYPE} and can up to 255 characters long.
+                                ${NAME} must be atleast 1 character long and can only consist of alphabets, digits, ":", "-", "_", ".", and "\".
+                                ${SERVICETYPE} must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".snapshot", ".slice" or ".scope".
+                              maxLength: 255
+                              type: string
+                              x-kubernetes-validations:
+                              - message: Invalid ${SERVICETYPE} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where ${SERVICETYPE}
+                                  must be one of ".service", ".socket", ".device",
+                                  ".mount", ".automount", ".swap", ".target", ".path",
+                                  ".timer",".snapshot", ".slice" or ".scope".
+                                rule: self.matches('\\.(service|socket|device|mount|automount|swap|target|path|timer|snapshot|slice|scope)$')
+                              - message: Invalid ${NAME} in service name. Expected
+                                  format is ${NAME}${SERVICETYPE}, where {NAME} must
+                                  be atleast 1 character long and can only consist
+                                  of alphabets, digits, ":", "-", "_", ".", and "\"
+                                rule: self.matches('^[a-zA-Z0-9:._\\\\-]+\\..')
+                          required:
+                          - actions
+                          - name
+                          type: object
+                        maxItems: 100
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    type: object
+                type: object
+              observedGeneration:
+                description: observedGeneration is the last generation change you've
+                  dealt with
+                format: int64
+                type: integer
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsiphostnamepools.yaml
+++ b/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsiphostnamepools.yaml
@@ -69,8 +69,8 @@ spec:
                       type: string
                     dvSwitchName:
                       description: |-
-                        DVSwitch name for multi-NIC support.
-                        If NIC's DVSwitchName or PortGroupName is nil, the VM template's DVSwitchName and PortGroupName will be used as fallback.
+                        add for multi nic support
+                        if nic DVSwitchName or PortGroupName is nil, we will use vmtemplate DVSwitchName and PortGroupName
                       type: string
                     gateway:
                       type: string
@@ -84,6 +84,68 @@ spec:
                       type: string
                     mask:
                       type: string
+                    persistentDisk:
+                      description: |-
+                        PersistentDisk defines disks that should survive VM upgrades (delete-recreate).
+                        Each entry is bound to (ip, slot); slot determines attach order and guest device name.
+                      items:
+                        description: |-
+                          PersistentDisk describes a disk that survives VM upgrades on an IP slot.
+                          Identity key is (ip, slot). Path/Format are guest-side concerns: when both
+                          are nil the disk runs in raw block mode — the controller still attaches it
+                          to the VM, but Ignition skips mkfs/mount, leaving the device for guest-side
+                          applications (e.g. Ceph OSD) to manage.
+                        properties:
+                          datastoreClusterName:
+                            description: Provide exactly one of DatastoreClusterName
+                              or DatastoreName.
+                            type: string
+                          datastoreName:
+                            type: string
+                          format:
+                            description: |-
+                              Format is the filesystem (xfs/ext4/...). Optional: when nil and Path is
+                              also nil, the disk runs in raw block mode; when Path is set but Format
+                              is nil, the Ignition template falls back to ext4. Immutable after
+                              creation.
+                            type: string
+                          mountOptions:
+                            items:
+                              type: string
+                            type: array
+                          options:
+                            description: 'Options: mkfs flags. Immutable after creation.'
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            description: |-
+                              Path is the guest mount point (e.g. /var/lib/etcd). Optional: when nil,
+                              Ignition does not render mkfs/mount for this disk (raw block mode).
+                            pattern: ^/.+
+                            type: string
+                          pciType:
+                            description: PciType defaults to "VIRTIO". Immutable after
+                              creation.
+                            type: string
+                          quantityGB:
+                            minimum: 1
+                            type: integer
+                          slot:
+                            description: |-
+                              Slot is the disk position (>= 0), unique per IP. Determines attach
+                              order, sequenceNum and guest device name. Immutable.
+                            minimum: 0
+                            type: integer
+                        required:
+                        - quantityGB
+                        - slot
+                        type: object
+                        x-kubernetes-validations:
+                        - message: exactly one of datastoreClusterName or datastoreName
+                            is required
+                          rule: has(self.datastoreClusterName) != has(self.datastoreName)
+                      type: array
                     portGroupName:
                       type: string
                     portGroupUrn:
@@ -95,6 +157,61 @@ spec:
             type: object
           status:
             description: DCSIpHostnamePoolStatus defines the observed state of DCSIpHostnamePool.
+            properties:
+              persistentDiskStatus:
+                description: |-
+                  PersistentDiskStatus survives DCSMachine delete-recreate; used for
+                  volume coordination and crash recovery.
+                items:
+                  description: PersistentDiskStatus is the runtime state of a persistent
+                    volume at a (ip, slot).
+                  properties:
+                    attachedVmUrn:
+                      type: string
+                    datastoreUrn:
+                      type: string
+                    ip:
+                      type: string
+                    lastError:
+                      type: string
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    name:
+                      description: |-
+                        Name is the DCS volume name; format: {poolName}-{sha256(ip/slot)[:8]}.
+                        Used for idempotent CreateVolume-by-name lookup.
+                      type: string
+                    ownerMachineName:
+                      type: string
+                    ownerMachineUID:
+                      description: |-
+                        OwnerMachineUID is retained across Machine delete so rolling upgrade
+                        can hand the record to the next Machine rather than orphan it.
+                      type: string
+                    path:
+                      type: string
+                    phase:
+                      description: DiskPhase is the coordination phase of a persistent
+                        disk record.
+                      enum:
+                      - Creating
+                      - Available
+                      - Attaching
+                      - Attached
+                      - Detaching
+                      - Deleting
+                      - Error
+                      type: string
+                    slot:
+                      type: integer
+                    volumeUrn:
+                      type: string
+                  required:
+                  - ip
+                  - slot
+                  type: object
+                type: array
             type: object
         type: object
     served: true

--- a/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsmachines.yaml
+++ b/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsmachines.yaml
@@ -278,6 +278,10 @@ spec:
                 description: FailureDomains is a slice of FailureDomains.
                 type: object
               networkConfig:
+                description: |-
+                  DCSMachineNetworkConfig is the Pool IP entry projected onto a DCSMachine.
+                  It mirrors DCSIpHostname but excludes pool-owned fields that have no meaning on
+                  a per-Machine record (notably PersistentDisk, which is coordinated by the Pool).
                 properties:
                   additionNic:
                     items:
@@ -303,9 +307,6 @@ spec:
                   dns:
                     type: string
                   dvSwitchName:
-                    description: |-
-                      DVSwitch name for multi-NIC support.
-                      If NIC's DVSwitchName or PortGroupName is nil, the VM template's DVSwitchName and PortGroupName will be used as fallback.
                     type: string
                   gateway:
                     type: string

--- a/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshclusters.yaml
+++ b/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshclusters.yaml
@@ -3,23 +3,23 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.4
-  name: dcsclusters.infrastructure.cluster.x-k8s.io
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: sshclusters.infrastructure.cluster.x-k8s.io
   labels:
     cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
-    kind: DCSCluster
-    listKind: DCSClusterList
-    plural: dcsclusters
-    singular: dcscluster
+    kind: SSHCluster
+    listKind: SSHClusterList
+    plural: sshclusters
+    singular: sshcluster
   scope: Namespaced
   versions:
   - name: v1beta1
     schema:
       openAPIV3Schema:
-        description: DCSCluster is the Schema for the dcsclusters API.
+        description: SSHCluster is the Schema for the sshclusters API.
         properties:
           apiVersion:
             description: |-
@@ -39,11 +39,41 @@ spec:
           metadata:
             type: object
           spec:
-            description: DCSClusterSpec defines the desired state of DCSCluster.
+            description: SSHClusterSpec defines the desired state of SSHCluster.
             properties:
+              bootstrapImage:
+                properties:
+                  auth:
+                    description: |-
+                      LocalObjectReference contains enough information to let you locate the
+                      referenced object inside the same namespace.
+                    properties:
+                      name:
+                        default: ""
+                        description: |-
+                          Name of the referent.
+                          This field is effectively required, but due to backwards compatibility is
+                          allowed to be empty. Instances of this type with an empty value here are
+                          almost certainly wrong.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  registry:
+                    type: string
+                required:
+                - registry
+                type: object
+              containerNetwork:
+                properties:
+                  type:
+                    default: calico
+                    type: string
+                required:
+                - type
+                type: object
               controlPlaneEndpoint:
-                description: ControlPlaneEndpoint represents the endpoint used to
-                  communicate with the control plane.
+                description: APIEndpoint represents a reachable Kubernetes API endpoint.
                 properties:
                   host:
                     description: host is the hostname on which the API server is serving.
@@ -57,69 +87,25 @@ spec:
                 - host
                 - port
                 type: object
-              controlPlaneLoadBalancer:
+              controlPlaneLoadBalancers:
                 properties:
                   host:
                     type: string
                   port:
-                    format: int32
                     type: integer
                   type:
+                    default: None
                     type: string
                   vrid:
-                    format: int64
                     type: integer
                 required:
-                - host
-                - port
                 - type
                 type: object
-              credentialSecretRef:
-                description: CredentialSecretRef
-                properties:
-                  name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              encryptionProviderConfigRef:
-                description: |-
-                  EncryptionProviderConfigRef references a Secret containing a pre-existing
-                  encryption-provider.conf for the cluster. When set, the controller uses
-                  this config instead of generating a new random encryption key.
-                  Required for disaster recovery: the standby cluster must use the same
-                  encryption key as the primary cluster so that restored etcd data can be
-                  decrypted by the API server.
-                  The referenced Secret must contain a key "encryption-provider.conf".
-                properties:
-                  name:
-                    default: ""
-                    description: |-
-                      Name of the referent.
-                      This field is effectively required, but due to backwards compatibility is
-                      allowed to be empty. Instances of this type with an empty value here are
-                      almost certainly wrong.
-                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              networkType:
-                type: string
-              site:
-                type: string
             required:
-            - controlPlaneLoadBalancer
-            - credentialSecretRef
-            - networkType
+            - bootstrapImage
             type: object
           status:
-            description: DCSClusterStatus defines the observed state of DCSCluster.
+            description: SSHClusterStatus defines the observed state of SSHCluster.
             properties:
               conditions:
                 description: Conditions provide observations of the operational state
@@ -174,27 +160,17 @@ spec:
                   - type
                   type: object
                 type: array
-              failureDomains:
-                additionalProperties:
-                  description: |-
-                    FailureDomainSpec is the Schema for Cluster API failure domains.
-                    It allows controllers to understand how many failure domains a cluster can optionally span across.
-                  properties:
-                    attributes:
-                      additionalProperties:
-                        type: string
-                      description: attributes is a free form map of attributes an
-                        infrastructure provider might use or require.
-                      type: object
-                    controlPlane:
-                      description: controlPlane determines if this failure domain
-                        is suitable for use by control plane machines.
-                      type: boolean
-                  type: object
-                description: FailureDomains is a slice of FailureDomains.
-                type: object
+              failureMessage:
+                type: string
+              failureReason:
+                description: MachineStatusError defines errors states for Machine
+                  objects.
+                type: string
               ready:
+                default: false
                 type: boolean
+            required:
+            - ready
             type: object
         type: object
     served: true

--- a/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshhosts.yaml
+++ b/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshhosts.yaml
@@ -1,0 +1,241 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: sshhosts.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: SSHHost
+    listKind: SSHHostList
+    plural: sshhosts
+    singular: sshhost
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: SSHHost is the Schema for the sshhosts API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SSHHostSpec defines the desired state of SSHHost.
+            properties:
+              authCredential:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              ip:
+                type: string
+              ipv6:
+                type: string
+              port:
+                type: integer
+              publicIp:
+                type: string
+              reUse:
+                type: boolean
+            type: object
+          status:
+            description: SSHHostStatus defines the observed state of SSHHost.
+            properties:
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              nodeInfo:
+                description: NodeSystemInfo is a set of ids/uuids to uniquely identify
+                  the node.
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: 'Deprecated: KubeProxy Version reported by the node.'
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  swap:
+                    description: Swap Info reported by the node.
+                    properties:
+                      capacity:
+                        description: Total amount of swap memory in bytes.
+                        format: int64
+                        type: integer
+                    type: object
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeProxyVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: ObjectReference contains enough information to let you
+                  inspect or modify the referred object.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              phase:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshmachines.yaml
+++ b/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshmachines.yaml
@@ -1,0 +1,262 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: sshmachines.infrastructure.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: SSHMachine
+    listKind: SSHMachineList
+    plural: sshmachines
+    singular: sshmachine
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: SSHMachine is the Schema for the sshmachines API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SSHMachineSpec defines the desired state of SSHMachine.
+            properties:
+              containerRuntime:
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - type
+                - version
+                type: object
+              hostLabelSelector:
+                description: |-
+                  A label selector is a label query over a set of resources. The result of matchLabels and
+                  matchExpressions are ANDed. An empty label selector matches all objects. A null
+                  label selector matches no objects.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              hostReference:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              providerID:
+                type: string
+            type: object
+          status:
+            description: SSHMachineStatus defines the observed state of SSHMachine.
+            properties:
+              addresses:
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: address is the machine address.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    type:
+                      description: type is the machine address type, one of Hostname,
+                        ExternalIP, InternalIP, ExternalDNS or InternalDNS.
+                      enum:
+                      - Hostname
+                      - ExternalIP
+                      - InternalIP
+                      - ExternalDNS
+                      - InternalDNS
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                description: Conditions provide observations of the operational state
+                  of a Cluster API resource.
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This field may be empty.
+                      maxLength: 10240
+                      minLength: 1
+                      type: string
+                    reason:
+                      description: |-
+                        reason is the reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may be empty.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                    severity:
+                      description: |-
+                        severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      maxLength: 32
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      maxLength: 256
+                      minLength: 1
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              failureMessage:
+                type: string
+              failureReason:
+                description: MachineStatusError defines errors states for Machine
+                  objects.
+                type: string
+              hostPhase:
+                type: string
+              hostReference:
+                description: ObjectReference contains enough information to let you
+                  inspect or modify the referred object.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              ready:
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshmachinetemplates.yaml
+++ b/docs/shared/crds/providers/ssh/infrastructure.cluster.x-k8s.io_sshmachinetemplates.yaml
@@ -1,0 +1,182 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.18.0
+  name: sshmachinetemplates.infrastructure.cluster.x-k8s.io
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: SSHMachineTemplate
+    listKind: SSHMachineTemplateList
+    plural: sshmachinetemplates
+    singular: sshmachinetemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: SSHMachineTemplate is the Schema for the sshmachinetemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SSHMachineTemplateSpec defines the desired state of SSHMachineTemplate.
+            properties:
+              template:
+                properties:
+                  metadata:
+                    description: |-
+                      ObjectMeta is metadata that all persisted resources must have, which includes all objects
+                      users must create. This is a copy of customizable fields from metav1.ObjectMeta.
+
+                      ObjectMeta is embedded in `Machine.Spec`, `MachineDeployment.Template` and `MachineSet.Template`,
+                      which are not top-level Kubernetes objects. Given that metav1.ObjectMeta has lots of special cases
+                      and read-only fields which end up in the generated CRD validation, having it as a subset simplifies
+                      the API and some issues that can impact user experience.
+
+                      During the [upgrade to controller-tools@v2](https://github.com/kubernetes-sigs/cluster-api/pull/1054)
+                      for v1alpha2, we noticed a failure would occur running Cluster API test suite against the new CRDs,
+                      specifically `spec.metadata.creationTimestamp in body must be of type string: "null"`.
+                      The investigation showed that `controller-tools@v2` behaves differently than its previous version
+                      when handling types from [metav1](k8s.io/apimachinery/pkg/apis/meta/v1) package.
+
+                      In more details, we found that embedded (non-top level) types that embedded `metav1.ObjectMeta`
+                      had validation properties, including for `creationTimestamp` (metav1.Time).
+                      The `metav1.Time` type specifies a custom json marshaller that, when IsZero() is true, returns `null`
+                      which breaks validation because the field isn't marked as nullable.
+
+                      In future versions, controller-tools@v2 might allow overriding the type and validation for embedded
+                      types. When that happens, this hack should be revisited.
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          annotations is an unstructured key value map stored with a resource that may be
+                          set by external tools to store and retrieve arbitrary metadata. They are not
+                          queryable and should be preserved when modifying objects.
+                          More info: http://kubernetes.io/docs/user-guide/annotations
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          labels is a map of string keys and values that can be used to organize and categorize
+                          (scope and select) objects. May match selectors of replication controllers
+                          and services.
+                          More info: http://kubernetes.io/docs/user-guide/labels
+                        type: object
+                    type: object
+                  spec:
+                    description: SSHMachineSpec defines the desired state of SSHMachine.
+                    properties:
+                      containerRuntime:
+                        properties:
+                          type:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - type
+                        - version
+                        type: object
+                      hostLabelSelector:
+                        description: |-
+                          A label selector is a label query over a set of resources. The result of matchLabels and
+                          matchExpressions are ANDed. An empty label selector matches all objects. A null
+                          label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      hostReference:
+                        description: |-
+                          LocalObjectReference contains enough information to let you locate the
+                          referenced object inside the same namespace.
+                        properties:
+                          name:
+                            default: ""
+                            description: |-
+                              Name of the referent.
+                              This field is effectively required, but due to backwards compatibility is
+                              allowed to be empty. Instances of this type with an empty value here are
+                              almost certainly wrong.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      providerID:
+                        type: string
+                    type: object
+                type: object
+            required:
+            - template
+            type: object
+          status:
+            description: SSHMachineTemplateStatus defines the observed state of SSHMachineTemplate.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/user_provisioned/infrastructure.cluster.x-k8s.io_userprovisionedclusters.yaml
+++ b/docs/shared/crds/providers/user_provisioned/infrastructure.cluster.x-k8s.io_userprovisionedclusters.yaml
@@ -1,0 +1,337 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: userprovisionedclusters.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: UserProvisionedCluster
+    listKind: UserProvisionedClusterList
+    plural: userprovisionedclusters
+    shortNames:
+    - upcluster
+    singular: userprovisionedcluster
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current lifecycle phase of the UserProvisionedCluster.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UserProvisionedCluster is the Schema for the baremetalclusters
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UserProvisionedClusterSpec defines the desired state of UserProvisionedCluster
+            properties:
+              apiserverExtraArgs:
+                additionalProperties:
+                  type: string
+                type: object
+              clusterCIDR:
+                description: NetworkRanges represents ranges of network addresses.
+                properties:
+                  cidrBlocks:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - cidrBlocks
+                type: object
+              controlPlaneEndpoint:
+                description: APIEndpoint represents a reachable Kubernetes API endpoint.
+                properties:
+                  host:
+                    description: The hostname on which the API server is serving.
+                    type: string
+                  port:
+                    description: The port on which the API server is serving.
+                    format: int32
+                    type: integer
+                required:
+                - host
+                - port
+                type: object
+              controllerManagerExtraArgs:
+                additionalProperties:
+                  type: string
+                type: object
+              credentialRef:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              dnsDomain:
+                type: string
+              dockerExtraArgs:
+                additionalProperties:
+                  type: string
+                type: object
+              etcd:
+                properties:
+                  local:
+                    properties:
+                      dataDir:
+                        description: |-
+                          DataDir is the directory etcd will place its data.
+                          Defaults to "/var/lib/etcd".
+                        type: string
+                      extraArgs:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ExtraArgs are extra arguments provided to the etcd binary
+                          when run inside a static pod.
+                        type: object
+                      peerCertSANs:
+                        description: PeerCertSANs sets extra Subject Alternative Names
+                          for the etcd peer signing cert.
+                        items:
+                          type: string
+                        type: array
+                      serverCertSANs:
+                        description: ServerCertSANs sets extra Subject Alternative
+                          Names for the etcd server signing cert.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              ha:
+                properties:
+                  config:
+                    properties:
+                      vip:
+                        type: string
+                      vport:
+                        format: int32
+                        type: integer
+                      vrid:
+                        format: int32
+                        type: integer
+                    required:
+                    - vip
+                    - vport
+                    - vrid
+                    type: object
+                  type:
+                    type: string
+                required:
+                - config
+                - type
+                type: object
+              hostnameAsNodeName:
+                type: boolean
+              kubeProxy:
+                properties:
+                  ipvs:
+                    type: boolean
+                required:
+                - ipvs
+                type: object
+              kubeletExtraArgs:
+                additionalProperties:
+                  type: string
+                type: object
+              machinePoolRef:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              maxNodePodNum:
+                type: integer
+              networkConfig:
+                properties:
+                  device:
+                    type: string
+                  stack:
+                    type: string
+                required:
+                - device
+                - stack
+                type: object
+              networkType:
+                type: string
+              publicAlternaticenames:
+                items:
+                  type: string
+                type: array
+              schedulerExtraArgs:
+                additionalProperties:
+                  type: string
+                type: object
+              serviceCIDR:
+                description: NetworkRanges represents ranges of network addresses.
+                properties:
+                  cidrBlocks:
+                    items:
+                      type: string
+                    type: array
+                required:
+                - cidrBlocks
+                type: object
+              version:
+                type: string
+            required:
+            - clusterCIDR
+            - credentialRef
+            - dnsDomain
+            - ha
+            - hostnameAsNodeName
+            - kubeProxy
+            - machinePoolRef
+            - networkConfig
+            - networkType
+            - serviceCIDR
+            type: object
+          status:
+            description: UserProvisionedSpecClusterStatus defines the observed state
+              of UserProvisionedCluster
+            properties:
+              addresses:
+                items:
+                  description: ClusterAddress contains information for the cluster's
+                    address.
+                  properties:
+                    host:
+                      description: The cluster address.
+                      type: string
+                    path:
+                      description: path
+                      type: string
+                    port:
+                      description: port
+                      format: int32
+                      type: integer
+                    type:
+                      description: Cluster address type, one of Public, ExternalIP
+                        or InternalIP.
+                      type: string
+                  required:
+                  - host
+                  - path
+                  - port
+                  - type
+                  type: object
+                type: array
+              clusterCIDR:
+                type: string
+              conditions:
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              dnsIP:
+                type: string
+              initialized:
+                type: boolean
+              nodeCIDRMaskSize:
+                format: int32
+                type: integer
+              nodeCIDRMaskSizeIPv4:
+                format: int32
+                type: integer
+              nodeCIDRMaskSizeIPv6:
+                format: int32
+                type: integer
+              phase:
+                type: string
+              ready:
+                type: boolean
+              secondaryClusterCIDR:
+                type: string
+              secondaryServiceCIDR:
+                type: string
+              serviceCIDR:
+                type: string
+              version:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/user_provisioned/infrastructure.cluster.x-k8s.io_userprovisionedmachinepools.yaml
+++ b/docs/shared/crds/providers/user_provisioned/infrastructure.cluster.x-k8s.io_userprovisionedmachinepools.yaml
@@ -1,0 +1,208 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: userprovisionedmachinepools.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: UserProvisionedMachinePool
+    listKind: UserProvisionedMachinePoolList
+    plural: userprovisionedmachinepools
+    shortNames:
+    - upmachinepool
+    singular: userprovisionedmachinepool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current lifecycle phase of the UserProvisionedMachinePool.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UserProvisionedMachinePool is the Schema for the userprovisionedmachinepools
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UserProvisionedMachinePoolSpec defines the desired state
+              of UserProvisionedMachinePool
+            properties:
+              clusterName:
+                type: string
+              cri:
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - type
+                - version
+                type: object
+              pool:
+                items:
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    credentialRef:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    ip:
+                      type: string
+                    ipv6:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    networkDevice:
+                      type: string
+                    port:
+                      type: integer
+                    publicIp:
+                      type: string
+                    taints:
+                      items:
+                        description: |-
+                          The node this Taint is attached to has the "effect" on
+                          any pod that does not tolerate the Taint.
+                        properties:
+                          effect:
+                            description: |-
+                              Required. The effect of the taint on pods
+                              that do not tolerate the taint.
+                              Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: Required. The taint key to be applied to
+                              a node.
+                            type: string
+                          timeAdded:
+                            description: |-
+                              TimeAdded represents the time at which the taint was added.
+                              It is only written for NoExecute taints.
+                            format: date-time
+                            type: string
+                          value:
+                            description: The taint value corresponding to the taint
+                              key.
+                            type: string
+                        required:
+                        - effect
+                        - key
+                        type: object
+                      type: array
+                  required:
+                  - credentialRef
+                  - port
+                  type: object
+                type: array
+              role:
+                type: string
+              version:
+                type: string
+            required:
+            - cri
+            - version
+            type: object
+          status:
+            description: UserProvisionedMachinePoolStatus defines the observed state
+              of UserProvisionedMachinePool
+            properties:
+              conditions:
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              machines:
+                items:
+                  type: string
+                type: array
+              phase:
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/user_provisioned/infrastructure.cluster.x-k8s.io_userprovisionedmachines.yaml
+++ b/docs/shared/crds/providers/user_provisioned/infrastructure.cluster.x-k8s.io_userprovisionedmachines.yaml
@@ -1,0 +1,327 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: userprovisionedmachines.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    kind: UserProvisionedMachine
+    listKind: UserProvisionedMachineList
+    plural: userprovisionedmachines
+    shortNames:
+    - upmachine
+    singular: userprovisionedmachine
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: The current lifecycle phase of the UserProvisionedMachine.
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC.
+      jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: UserProvisionedMachine is the Schema for the baremetalmachines
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: UserProvisionedMachineSpec defines the desired state of UserProvisionedMachine
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              clusterName:
+                type: string
+              credentialRef:
+                description: |-
+                  LocalObjectReference contains enough information to let you locate the
+                  referenced object inside the same namespace.
+                properties:
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              cri:
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - type
+                - version
+                type: object
+              ip:
+                type: string
+              ipv6:
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+              networkDevice:
+                type: string
+              port:
+                type: integer
+              providerID:
+                type: string
+              publicIp:
+                type: string
+              role:
+                type: string
+              taints:
+                items:
+                  description: |-
+                    The node this Taint is attached to has the "effect" on
+                    any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: |-
+                        Required. The effect of the taint on pods
+                        that do not tolerate the taint.
+                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: |-
+                        TimeAdded represents the time at which the taint was added.
+                        It is only written for NoExecute taints.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                type: array
+              version:
+                type: string
+            required:
+            - credentialRef
+            - cri
+            - port
+            - role
+            - version
+            type: object
+          status:
+            description: UserProvisionedMachineStatus defines the observed state of
+              UserProvisionedMachine
+            properties:
+              addresses:
+                items:
+                  description: MachineAddress contains information for the node's
+                    address.
+                  properties:
+                    address:
+                      description: The machine address.
+                      type: string
+                    type:
+                      description: Machine address type, one of Hostname, ExternalIP,
+                        InternalIP, ExternalDNS or InternalDNS.
+                      type: string
+                  required:
+                  - address
+                  - type
+                  type: object
+                type: array
+              conditions:
+                items:
+                  description: Condition defines an observation of a Cluster API resource
+                    operational state.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        Last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed. If that is not known, then using the time when
+                        the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        A human readable message indicating details about the transition.
+                        This field may be empty.
+                      type: string
+                    reason:
+                      description: |-
+                        The reason for the condition's last transition in CamelCase.
+                        The specific API may choose whether or not this field is considered a guaranteed API.
+                        This field may not be empty.
+                      type: string
+                    severity:
+                      description: |-
+                        Severity provides an explicit classification of Reason code, so the users or machines can immediately
+                        understand the current situation and act accordingly.
+                        The Severity field MUST be set only when Status=False.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: |-
+                        Type of condition in CamelCase or in foo.example.com/CamelCase.
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions
+                        can be useful (see .node.status.conditions), the ability to deconflict is important.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - status
+                  - type
+                  type: object
+                type: array
+              cri:
+                properties:
+                  type:
+                    type: string
+                  version:
+                    type: string
+                required:
+                - type
+                - version
+                type: object
+              nodeInfo:
+                description: NodeSystemInfo is a set of ids/uuids to uniquely identify
+                  the node.
+                properties:
+                  architecture:
+                    description: The Architecture reported by the node
+                    type: string
+                  bootID:
+                    description: Boot ID reported by the node.
+                    type: string
+                  containerRuntimeVersion:
+                    description: ContainerRuntime Version reported by the node through
+                      runtime remote API (e.g. containerd://1.4.2).
+                    type: string
+                  kernelVersion:
+                    description: Kernel Version reported by the node from 'uname -r'
+                      (e.g. 3.16.0-0.bpo.4-amd64).
+                    type: string
+                  kubeProxyVersion:
+                    description: KubeProxy Version reported by the node.
+                    type: string
+                  kubeletVersion:
+                    description: Kubelet Version reported by the node.
+                    type: string
+                  machineID:
+                    description: |-
+                      MachineID reported by the node. For unique machine identification
+                      in the cluster this field is preferred. Learn more from man(5)
+                      machine-id: http://man7.org/linux/man-pages/man5/machine-id.5.html
+                    type: string
+                  operatingSystem:
+                    description: The Operating System reported by the node
+                    type: string
+                  osImage:
+                    description: OS Image reported by the node from /etc/os-release
+                      (e.g. Debian GNU/Linux 7 (wheezy)).
+                    type: string
+                  systemUUID:
+                    description: |-
+                      SystemUUID reported by the node. For unique machine identification
+                      MachineID is preferred. This field is specific to Red Hat hosts
+                      https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/rhsm/uuid
+                    type: string
+                required:
+                - architecture
+                - bootID
+                - containerRuntimeVersion
+                - kernelVersion
+                - kubeletVersion
+                - machineID
+                - operatingSystem
+                - osImage
+                - systemUUID
+                type: object
+              nodeRef:
+                description: ObjectReference contains enough information to let you
+                  inspect or modify the referred object.
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: |-
+                      If referring to a piece of an object instead of an entire object, this string
+                      should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within a pod, this would take on a value like:
+                      "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]" (container with
+                      index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                      referencing a part of an object.
+                    type: string
+                  kind:
+                    description: |-
+                      Kind of the referent.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                    type: string
+                  name:
+                    description: |-
+                      Name of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                  namespace:
+                    description: |-
+                      Namespace of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                    type: string
+                  resourceVersion:
+                    description: |-
+                      Specific resourceVersion to which this reference is made, if any.
+                      More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                    type: string
+                  uid:
+                    description: |-
+                      UID of the referent.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              phase:
+                type: string
+              ready:
+                type: boolean
+              version:
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
+++ b/docs/shared/crds/providers/vmware-vsphere/infrastructure.cluster.x-k8s.io_vsphereclustertemplates.yaml
@@ -1,0 +1,192 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.0
+  labels:
+    cluster.x-k8s.io/v1beta1: v1beta1
+  name: vsphereclustertemplates.infrastructure.cluster.x-k8s.io
+spec:
+  group: infrastructure.cluster.x-k8s.io
+  names:
+    categories:
+    - cluster-api
+    kind: VSphereClusterTemplate
+    listKind: VSphereClusterTemplateList
+    plural: vsphereclustertemplates
+    singular: vsphereclustertemplate
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: VSphereClusterTemplate is the Schema for the vsphereclustertemplates
+          API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VSphereClusterTemplateSpec defines the desired state of VSphereClusterTemplate.
+            properties:
+              template:
+                description: VSphereClusterTemplateResource describes the data for
+                  creating a VSphereCluster from a template.
+                properties:
+                  spec:
+                    description: VSphereClusterSpec defines the desired state of VSphereCluster.
+                    properties:
+                      clusterModules:
+                        description: |-
+                          ClusterModules hosts information regarding the anti-affinity vSphere constructs
+                          for each of the objects responsible for creation of VM objects belonging to the cluster.
+                        items:
+                          description: |-
+                            ClusterModule holds the anti affinity construct `ClusterModule` identifier
+                            in use by the VMs owned by the object referred by the TargetObjectName field.
+                          properties:
+                            controlPlane:
+                              description: |-
+                                ControlPlane indicates whether the referred object is responsible for control plane nodes.
+                                Currently, only the KubeadmControlPlane objects have this flag set to true.
+                                Only a single object in the slice can have this value set to true.
+                              type: boolean
+                            moduleUUID:
+                              description: ModuleUUID is the unique identifier of
+                                the `ClusterModule` used by the object.
+                              type: string
+                            targetObjectName:
+                              description: |-
+                                TargetObjectName points to the object that uses the Cluster Module information to enforce
+                                anti-affinity amongst its descendant VM objects.
+                              type: string
+                          required:
+                          - controlPlane
+                          - moduleUUID
+                          - targetObjectName
+                          type: object
+                        type: array
+                      controlPlaneEndpoint:
+                        description: ControlPlaneEndpoint represents the endpoint
+                          used to communicate with the control plane.
+                        properties:
+                          host:
+                            description: The hostname on which the API server is serving.
+                            type: string
+                          port:
+                            description: The port on which the API server is serving.
+                            format: int32
+                            type: integer
+                        required:
+                        - host
+                        - port
+                        type: object
+                      disableClusterModule:
+                        description: |-
+                          DisableClusterModule is used to explicitly turn off the ClusterModule feature.
+                          This should work along side NodeAntiAffinity feature flag.
+                          If the NodeAntiAffinity feature flag is turned off, this will be disregarded.
+                        type: boolean
+                      failureDomainSelector:
+                        description: |-
+                          FailureDomainSelector is the label selector to use for failure domain selection
+                          for the control plane nodes of the cluster.
+                          If not set (`nil`), selecting failure domains will be disabled.
+                          An empty value (`{}`) selects all existing failure domains.
+                          A valid selector will select all failure domains which match the selector.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      identityRef:
+                        description: |-
+                          IdentityRef is a reference to either a Secret or VSphereClusterIdentity that contains
+                          the identity to use when reconciling the cluster.
+                        properties:
+                          kind:
+                            description: Kind of the identity. Can either be VSphereClusterIdentity
+                              or Secret
+                            enum:
+                            - VSphereClusterIdentity
+                            - Secret
+                            type: string
+                          name:
+                            description: Name of the identity.
+                            minLength: 1
+                            type: string
+                        required:
+                        - kind
+                        - name
+                        type: object
+                      server:
+                        description: Server is the address of the vSphere endpoint.
+                        type: string
+                      thumbprint:
+                        description: Thumbprint is the colon-separated SHA-1 checksum
+                          of the given vCenter server's host certificate
+                        type: string
+                    type: object
+                required:
+                - spec
+                type: object
+            required:
+            - template
+            type: object
+        type: object
+    served: true
+    storage: true


### PR DESCRIPTION
## Summary

Backport AIT-68181 Immutable Infrastructure standard API references to the `release-1.0` documentation line.

This backport carries the same canonical placement used on mainline: Cluster API, Hosted Control Plane, provider lifecycle APIs, and Machine Configuration APIs live in `immutable-infra-docs`. The release branch now receives the same API reference set and the same post-review cleanup needed to keep the rendered API docs coherent.

Mainline reference:
- `alauda/immutable-infra-docs#57`

## Scope included in this backport

### Cluster API
- Core lifecycle APIs
- Add-on APIs
- IPAM APIs
- Runtime API

### Kubeadm providers
- Bootstrap provider APIs
- Control plane provider APIs

### Hosted Control Plane / Kamaji
- `KamajiControlPlane`, `KamajiControlPlaneTemplate`
- `DataStore`, `TenantControlPlane`

### Infrastructure providers
- User-Provisioned Infrastructure provider APIs
- SSH provider APIs
- vSphere `VSphereClusterTemplate`

### Machine Configuration
- `MachineConfig`, `MachineConfigPool`, `MachineConfiguration`

## Important decisions

- This backport preserves the same source-of-truth boundary as mainline: ACP docs should link here for UPI / Cluster API lifecycle APIs instead of duplicating them.
- Served-version filtering and version ordering from the mainline CRD cleanup are included, so the rendered release API docs do not surface unserved versions.
- The documentation-side CRD description cleanup reviewed after CodeRabbit feedback is also included here.
- `UserProvisionedSpecClusterStatus` remains unchanged because that exact type name exists in the source implementation; changing it in docs would diverge from code.
- The description-only cleanup does not change schema structure, validation, served/storage versions, or controller behavior. It only fixes rendered text such as `IPAdress`, malformed `deletePolicy` value lists, `namespaced named`, and stale copy-paste UPI phase descriptions.
- Upstream source repositories still need follow-up fixes so future CRD syncs do not reintroduce those typos.

## Verification

- `docs/shared/crds/**/*.yaml` parsing passed
- `git diff --check` passed
- `yarn lint` passed with 0 errors and 0 warnings

Note: lint still prints the existing local environment warning that Node.js `22.11.0` is outside the recommended Rspack range, but lint completes successfully.
