### PR TITLE
docs(global): backport Global Cluster section to release-1.0

### DIFF
--- a/docs/en/global/disaster_recovery.mdx
+++ b/docs/en/global/disaster_recovery.mdx
@@ -1,0 +1,32 @@
+---
+weight: 40
+title: Global Cluster Disaster Recovery
+queries:
+  - global cluster disaster recovery on immutable infrastructure
+  - immutable infra etcd sync
+  - microos global dr
+  - immutable os disaster recovery
+---
+
+# Global Cluster Disaster Recovery
+
+<Directive type="info" title="Status: Planned">
+  Disaster recovery for the `global` cluster on Immutable Infrastructure is in development. This page reserves the location in the documentation tree so that links from sibling pages remain stable. The detailed procedure will be added in a subsequent release.
+</Directive>
+
+## Scope
+
+When this documentation lands, this page will cover:
+
+- etcd synchronization between a primary and a standby `global` cluster that both run on Immutable Infrastructure.
+- The `baseDirPath` and persistent-disk conventions used by the disaster-recovery manifests on each supported provider.
+- Failover, failback, and verification procedures.
+
+## See Also
+
+For traditional-operating-system `global` cluster disaster recovery, see <ExternalSiteLink name="acp" href="/install/global_dr.html" children="Global Cluster Disaster Recovery" />.
+
+For installation and upgrade of the `global` cluster on Immutable Infrastructure, see:
+
+- [Installing the global Cluster](./install.mdx)
+- [Upgrading the global Cluster](./upgrade.mdx)

--- a/docs/en/global/index.mdx
+++ b/docs/en/global/index.mdx
@@ -1,0 +1,23 @@
+---
+weight: 10
+title: Global Cluster
+queries:
+  - global cluster on immutable infrastructure
+  - global cluster lifecycle
+  - install upgrade dr global cluster
+---
+
+# Global Cluster
+
+The `global` cluster is the platform's control plane: it hosts the registry, the base operator, the cluster registry, and the platform's identity stack, and it orchestrates the lifecycle of every workload cluster. This section documents the lifecycle of the `global` cluster itself when it runs on Immutable Infrastructure.
+
+For traditional-OS `global` clusters, see <ExternalSiteLink name="acp" href="/install/index.html" children="the standard installation path" />.
+
+<Overview />
+
+## What This Section Does Not Cover
+
+- Installing provider plugins onto an already-running `global` cluster: see [Installation](../install/index.mdx).
+- Configuring infrastructure resources for workload clusters: see [Infrastructure Resources](../infrastructure/index.mdx).
+- Creating workload clusters: see [Creating Clusters](../create-cluster/index.mdx).
+- Upgrading workload clusters: see [Upgrading Clusters](../upgrade-cluster/index.mdx).

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -1,0 +1,146 @@
+---
+weight: 20
+title: Installing the global Cluster
+queries:
+  - install global cluster on immutable infrastructure
+  - microos global cluster installation
+  - install platform on huawei dcs vmware vsphere huawei cloud stack
+  - immutable os global install
+---
+
+# Installing the global Cluster
+
+This document describes how to install the `global` cluster onto Immutable Infrastructure. The `global` cluster is the platform's control plane and is provisioned through Cluster API. Use this path when you want the platform's own cluster to run on an immutable operating system such as MicroOS.
+
+## When to Use This Path
+
+Choose this installation path when **all** of the following apply:
+
+- You want the `global` cluster to run on an immutable operating system. MicroOS is the supported image today; additional images may be added later.
+- Your infrastructure is one of the supported providers: Huawei DCS, VMware vSphere, or Huawei Cloud Stack. Bare-metal support is planned.
+- You can run a temporary KIND host that has network access to the target IaaS platform.
+
+For traditional operating systems such as Ubuntu or RHEL, use <ExternalSiteLink name="acp" href="/install/index.html" children="the standard installation path" /> instead.
+
+## Common Prerequisites
+
+The following prerequisites apply to every provider. Provider-specific prerequisites are listed in the corresponding tab in Step 2 of the procedure below.
+
+- A KIND host that meets the minimum hardware and network requirements. See the [Overview](../overview/index.mdx) for sizing guidance.
+- The Core Package and the provider plugin packages from the Customer Portal.
+- Network reachability between the KIND host and the target IaaS platform's API endpoint.
+- IP and hostname planning for the `global` control plane and worker nodes. See [Infrastructure Resources](../infrastructure/index.mdx) for the resource model used by each provider.
+- For x86_64 nodes that use ACP-provided MicroOS images, the underlying CPUs must support the `x86-64-v2` ISA baseline. See [OS Support Matrix](../overview/os-support-matrix.mdx).
+
+## Procedure
+
+### Step 1 — Bootstrap the KIND Host
+
+Run the bootstrap script provided by the Core Package. This brings up a temporary management cluster (`minialauda`) on the KIND host, which is used to drive the installation.
+
+```shell
+tar -xvf <core-package> -C /root/cpaas-install
+cd /root/cpaas-install/installer
+sh setup.sh
+```
+
+The bootstrap script provisions an embedded registry, the Cluster API control plane, and the provider plugins required to reach the IaaS platform.
+
+### Step 2 — Configure the global Cluster Manifest
+
+Apply the Cluster API manifest that describes the desired `global` cluster. The manifest is provider-specific.
+
+<Tabs>
+  <Tab label="Huawei DCS">
+
+This tab is owned by the Huawei DCS provider author. Place the `DCSCluster`, `DCSMachineTemplate`, `DCSIpHostnamePool`, and `KubeadmControlPlane` manifests here, including immutable-OS-specific values such as `baseDirPath: /var/cpaas`.
+
+  </Tab>
+  <Tab label="VMware vSphere">
+
+This tab is owned by the VMware vSphere provider author. Place the `VSphereCluster`, `VSphereMachineTemplate`, and related manifests here, including any immutable-OS-specific values.
+
+  </Tab>
+  <Tab label="Huawei Cloud Stack">
+
+This tab is owned by the Huawei Cloud Stack provider author. Place the `HCSCluster`, `HCSMachineTemplate`, and related manifests here, including any immutable-OS-specific values.
+
+  </Tab>
+  <Tab label="Bare Metal">
+    <Directive type="info" title="Status: Planned">
+      Bare-metal support for the `global` cluster on Immutable Infrastructure is in development.
+    </Directive>
+  </Tab>
+</Tabs>
+
+### Step 3 — Wait for the Control Plane
+
+Wait for the Cluster API provider to provision the virtual machines and bring up the Kubernetes control plane.
+
+```shell
+kubectl --kubeconfig <minialauda-kubeconfig> get clusters.cluster.x-k8s.io -A
+kubectl --kubeconfig <minialauda-kubeconfig> get kubeadmcontrolplane -A
+```
+
+The control plane is ready when the `KubeadmControlPlane` reports `Ready: True` and the `Cluster` reports `Phase: Provisioned`.
+
+### Step 4 — Trigger the Platform Installation
+
+Submit the platform installation request to the embedded installer's REST API. The installer takes care of importing the Cluster API resources into the new `global` cluster, deploying the platform's base operator, and installing the selected plugins.
+
+<Directive type="info" title="Network Scope">
+  `INSTALLER_IP` is the address of the temporary KIND host. The installer endpoint is exposed only on that host for the duration of the installation and is not routable from external networks.
+</Directive>
+
+```shell
+curl -X POST "http://${INSTALLER_IP}:8080/cpaas-installer/api/config/<provider>" \
+  -H 'Content-Type: application/json' \
+  -d @config.json
+```
+
+Replace `<provider>` with the endpoint suffix that matches the provider you selected in Step 2.
+
+### Step 5 — Provide Provider Credentials
+
+After the platform installation starts, supply the provider credentials so that ongoing reconciliation against the IaaS platform can continue without the KIND host.
+
+<Tabs>
+  <Tab label="Huawei DCS">
+
+Provider author: document the credential `Secret` shape and the values that must be filled in for DCS.
+
+  </Tab>
+  <Tab label="VMware vSphere">
+
+Provider author: document the credential `Secret` shape for vSphere.
+
+  </Tab>
+  <Tab label="Huawei Cloud Stack">
+
+Provider author: document the credential `Secret` shape for HCS.
+
+  </Tab>
+  <Tab label="Bare Metal">
+    <Directive type="info" title="Status: Planned" />
+  </Tab>
+</Tabs>
+
+## Verification
+
+After the installer reports completion, verify that the `global` cluster is healthy.
+
+```shell
+kubectl --kubeconfig <global-kubeconfig> get nodes
+kubectl --kubeconfig <global-kubeconfig> get clusters.platform.tkestack.io global \
+  -o jsonpath='{.status.phase}'
+kubectl --kubeconfig <global-kubeconfig> get pods -n cpaas-system
+```
+
+All control plane and worker nodes must be `Ready`, the `global` cluster must report `Phase: Running`, and core platform pods must be `Running` or `Completed`.
+
+## Next Steps
+
+- Install additional provider plugins on the new `global` cluster: see [Installation](../install/index.mdx).
+- Configure infrastructure resources for workload clusters: see [Infrastructure Resources](../infrastructure/index.mdx).
+- Create your first workload cluster: see [Creating Clusters](../create-cluster/index.mdx).
+- Plan disaster recovery: see [Disaster Recovery](./disaster_recovery.mdx).

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -1,0 +1,137 @@
+---
+weight: 30
+title: Upgrading the global Cluster
+queries:
+  - upgrade global cluster on immutable infrastructure
+  - microos global cluster upgrade
+  - upgrade platform on huawei dcs vmware vsphere huawei cloud stack
+  - immutable os global upgrade
+---
+
+# Upgrading the global Cluster
+
+This document describes how to upgrade a `global` cluster that runs on Immutable Infrastructure. Upgrades replace nodes with new MicroOS images managed by the Cluster API provider; in-place node upgrades are not used.
+
+## When to Use This Path
+
+Choose this upgrade path when:
+
+- The `global` cluster was originally installed on Immutable Infrastructure. See [Installing the global Cluster](./install.mdx).
+- Your infrastructure is one of the supported providers: Huawei DCS, VMware vSphere, or Huawei Cloud Stack. Bare-metal support is planned.
+
+For traditional-OS `global` clusters, use <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="the standard upgrade path" /> instead.
+
+## Two-Phase Upgrade Overview
+
+Like workload clusters, the `global` cluster on Immutable Infrastructure follows a two-phase upgrade.
+
+1. **Phase 1 — Distribution Version**: aligned and agnostic extensions are upgraded to the target Distribution Version. The procedure is shared with workload clusters; see [Upgrading Clusters](../upgrade-cluster/index.mdx) for the Phase 1 mechanics.
+2. **Phase 2 — Kubernetes and OS Image**: nodes are replaced with new MicroOS images that contain the target Kubernetes version. This document focuses on Phase 2 for the `global` cluster.
+
+<Directive type="info" title="Phase 1 Compatibility">
+  Before starting Phase 2, verify that every workload cluster falls within the Compatible Versions matrix of the target Distribution Version. Workload clusters that are out of range must be upgraded first.
+</Directive>
+
+## Common Prerequisites
+
+- The `global` cluster has completed Phase 1 (Distribution Version upgrade).
+- An etcd backup of the `global` cluster has been taken and verified.
+- The new MicroOS image and the matching `KubeadmControlPlane` and `MachineDeployment` versions are available on the platform's registry.
+- A maintenance window plan that accounts for rolling control plane replacement.
+
+## Procedure
+
+After installation, the Cluster API controllers that manage the `global` cluster run on the `global` cluster itself. Use the `global` kubeconfig for the `kubectl` commands in this procedure.
+
+### Step 1 — Update the global Cluster Manifest
+
+Update the Cluster API manifests of the `global` cluster to reference the new MicroOS image and Kubernetes version. The manifest fields to update are provider-specific.
+
+<Tabs>
+  <Tab label="Huawei DCS">
+
+Provider author: list the manifest fields to update for DCS (for example, `KubeadmControlPlane.spec.version` and `DCSMachineTemplate.spec.template.spec.vmTemplateName`).
+
+  </Tab>
+  <Tab label="VMware vSphere">
+
+Provider author: list the manifest fields to update for vSphere.
+
+  </Tab>
+  <Tab label="Huawei Cloud Stack">
+
+Provider author: list the manifest fields to update for HCS.
+
+  </Tab>
+  <Tab label="Bare Metal">
+    <Directive type="info" title="Status: Planned">
+      Bare-metal support for the `global` cluster on Immutable Infrastructure is in development.
+    </Directive>
+  </Tab>
+</Tabs>
+
+### Step 2 — Apply the Updated Manifest
+
+Apply the updated manifest against the `global` cluster.
+
+```shell
+kubectl --kubeconfig <global-kubeconfig> apply -f <updated-manifest>
+```
+
+The Cluster API provider begins replacing control plane and worker nodes one at a time using the new image. Original nodes are deleted only after the replacement nodes report `Ready`.
+
+### Step 3 — Monitor the Rolling Replacement
+
+Watch the rolling replacement until all control plane and worker nodes have been replaced.
+
+```shell
+kubectl --kubeconfig <global-kubeconfig> get machines -A -o wide
+kubectl --kubeconfig <global-kubeconfig> get kubeadmcontrolplane -A
+```
+
+The upgrade is complete when every `Machine` reports the new Kubernetes version and `Phase: Running`, and the `KubeadmControlPlane` reports `Ready: True` against the new version.
+
+## Verification
+
+After the rolling replacement finishes, verify that the upgraded `global` cluster is healthy.
+
+```shell
+kubectl --kubeconfig <global-kubeconfig> get nodes -o wide
+kubectl --kubeconfig <global-kubeconfig> get clusterversionshadow -o yaml
+kubectl --kubeconfig <global-kubeconfig> get pods -n cpaas-system
+```
+
+All nodes must report the new Kubernetes version, the `ClusterVersionShadow` must reflect the target Distribution Version, and core platform pods must be `Running`.
+
+## Rollback Considerations
+
+Rollback after a partial Phase 2 upgrade is provider-specific. In general:
+
+- If the upgrade has not yet replaced any control plane node, revert the manifest to the previous image and reapply.
+- If control plane nodes have been replaced, restore from the etcd backup taken before starting the upgrade, then revert the manifest.
+
+<Tabs>
+  <Tab label="Huawei DCS">
+
+Provider author: document any DCS-specific rollback considerations, such as IP-pool persistent disk binding.
+
+  </Tab>
+  <Tab label="VMware vSphere">
+
+Provider author: document any vSphere-specific rollback considerations.
+
+  </Tab>
+  <Tab label="Huawei Cloud Stack">
+
+Provider author: document any HCS-specific rollback considerations.
+
+  </Tab>
+  <Tab label="Bare Metal">
+    <Directive type="info" title="Status: Planned" />
+  </Tab>
+</Tabs>
+
+## Next Steps
+
+- Upgrade workload clusters to the same Distribution Version: see [Upgrading Clusters](../upgrade-cluster/index.mdx).
+- Review machine configuration changes that ship with the new image: see [Machine Configuration](../machine-configuration/index.mdx).


### PR DESCRIPTION
## Summary

Backports the new `docs/en/global/` section from master (#62) to `release-1.0` so the GA documentation site catches up with the actually-shipped ACP 4.3 capability.

The section covers the lifecycle of the `global` cluster on Immutable Infrastructure (DCS / VMware vSphere / HCS): install, upgrade, and disaster recovery (placeholder).

## Backported commits

- `2f4ed80` docs(global): add Global Cluster section for Immutable Infrastructure
- `10a4630` docs(global): address CodeRabbit feedback

## Scope

Only `docs/en/global/` is brought across. `package.json` and `yarn.lock` are intentionally left at the release-1.0 baseline (`@alauda/doom ^2.2.0`); the doom bump on master to `^2.4.0` is not part of this backport.

## Validation

- [x] `yarn install` succeeded against the release-1.0 lockfile
- [x] `yarn lint` passes (0 errors / 0 warnings)
- [x] Reviewer: confirm sidebar ordering and `<Tabs>` rendering on `yarn dev`

## Master PR

alauda/immutable-infra-docs#62 (merged)

## Companion backport

acp-docs path-selection banners to release-4.3: alauda/acp-docs#762

Refs: AIT-66126