### PR TITLE
docs(huawei-dcs): support FC/DCS domain users via optional userType Secret key (AIT-69516)

### DIFF
--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -831,3 +831,7 @@ After creating a cluster:
 
 - [Manage Nodes](../manage-nodes/huawei-dcs.mdx)
 - [Upgrade Cluster](../upgrade-cluster/huawei-dcs.mdx)
+
+## Troubleshooting
+
+If the cluster reaches `Provisioned` but never becomes Ready — for example, workload nodes stay `NotReady` because the CNI is not deployed — see [Troubleshoot a Workload Cluster Stuck in Provisioned](../how-to/troubleshoot-cluster-not-ready.mdx).

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -222,7 +222,7 @@ The example manifests below use `<placeholder>` syntax for values that are envir
 | `<auth-secret-name>` | The Secret you authored in [Infrastructure → Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials). | `kubectl -n cpaas-system get secret <name>` |
 | `<cluster-name>` | Operator-chosen; must satisfy DNS-1123. Reused across `Cluster`, `KubeadmControlPlane`, and the `cluster.x-k8s.io/cluster-name` label on every `Machine`. | n/a |
 | `<load-balancer-ip-or-domain-name>` | Operator-supplied: the IP / hostname clients use to reach the cluster API server. For single-control-plane clusters with no external LB, this is the IP of the sole master node (see [Single-control-plane layout](#single-control-plane-layout)). | n/a |
-| `<pods-cidr>` / `<services-cidr>` / `<kube-ovn-join-cidr>` | Operator-supplied. Must not overlap with the host network, the global cluster's CIDRs, or any other CAPI cluster's CIDRs you intend to interconnect. kube-ovn defaults are documented in the [Kube-OVN reference](../../overview/networks.mdx); leaving them empty is **not recommended** for production. | n/a |
+| `<pods-cidr>` / `<services-cidr>` / `<kube-ovn-join-cidr>` | Operator-supplied. Must not overlap with the host network, the global cluster's CIDRs, or any other CAPI cluster's CIDRs you intend to interconnect. Leaving them empty falls back to the kube-ovn defaults shipped with the global cluster, which is **not recommended** for production: explicit CIDRs avoid silent collisions when multiple workload clusters live on the same global. | n/a |
 
 ### Magic-Token Placeholders \{#magic-tokens}
 
@@ -381,6 +381,8 @@ For development, PoC, or any deployment where the control plane has only **one**
 
 - `.spec.controlPlaneLoadBalancer.host` and `.spec.controlPlaneEndpoint.host` — set both to **the IP of the sole master node** (the same IP allocated to the master in the control-plane `DCSIpHostnamePool`).
 - `.spec.controlPlaneLoadBalancer.type` — keep as `external` (the type field has no other supported value).
+
+Concretely:
 
 ```yaml
 spec:

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -342,7 +342,7 @@ spec:
 | `.spec.controlPlaneLoadBalancer` | object | Control plane API server exposure method | Yes |
 | `.spec.controlPlaneLoadBalancer.type` | string | Currently only supports "external" | Yes |
 | `.spec.controlPlaneLoadBalancer.host` | string | Load balancer IP or domain name | Yes |
-| `.spec.credentialSecretRef.name` | string | DCS authentication Secret name | Yes |
+| `.spec.credentialSecretRef.name` | string | DCS authentication Secret name. The Secret defines whether DCS Provider authenticates as an interface interconnection user (default) or a domain user — see [Credential User Types](../infrastructure/huawei-dcs.mdx#user-types). | Yes |
 | `.spec.networkType` | string | Currently only supports "kube-ovn" | Yes |
 | `.spec.site` | string | DCS platform site ID | Yes |
 

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -196,15 +196,44 @@ To ensure proper integration as business clusters, all resources must be deploye
 
 ### Configuration Workflow
 
-Follow these steps in order:
+Follow these steps in order to provision a functional cluster (control plane **and** worker nodes):
 
-1. Configure KubeadmControlPlane
-2. Configure DCSCluster
-3. Create the Cluster resource
+1. Configure `KubeadmControlPlane` (control-plane spec and kubeadm bootstrap).
+2. Configure `DCSCluster` (infrastructure binding and load balancer reference).
+3. Create the `Cluster` resource (top-level CAPI object that links the two above).
+4. Configure worker resources: `KubeadmConfigTemplate` (worker bootstrap), worker `DCSMachineTemplate`, worker `DCSIpHostnamePool`, and `MachineDeployment`. **The control plane alone is not a usable cluster.** See [Managing Nodes on Huawei DCS](../manage-nodes/huawei-dcs.mdx#worker-node-deployment) for the four worker YAML resources.
 
-**Note**: Infrastructure resources (Secret, DCSIpHostnamePool, DCSMachineTemplate) should be configured separately. See [Infrastructure Resources for Huawei DCS](../infrastructure/huawei-dcs.mdx) for instructions.
+**Note**: Infrastructure resources (Secret, control-plane `DCSIpHostnamePool`, control-plane `DCSMachineTemplate`) should be configured separately. See [Infrastructure Resources for Huawei DCS](../infrastructure/huawei-dcs.mdx) for instructions.
 
 If you need any disk to survive rolling replacement, declare it in the matching `DCSIpHostnamePool.spec.pool[].persistentDisk` entry. This includes the platform-required `/var/cpaas` disk.
+
+### Resolving Placeholder Values \{#resolving-placeholders}
+
+The example manifests below use `<placeholder>` syntax for values that are environment-specific. Several of these have a canonical source of truth that you should query rather than hand-pick:
+
+| Placeholder | Source of truth | How to retrieve |
+|---|---|---|
+| `<control-plane-kubernetes-version>` / `<worker-kubernetes-version>` | A `cpaas.io/dcs-vm-template` ConfigMap in the `cpaas-system` namespace, one per distribution version. | `kubectl -n cpaas-system get cm -l cpaas.io/dcs-vm-template -o yaml` — read `data.kubernetesVersion`. |
+| `<dns-image-tag>` | Same ConfigMap, `data.corednsTag`. | Same `kubectl get cm` query as above. |
+| `<etcd-image-tag>` | Same ConfigMap, `data.etcdTag`. | Same `kubectl get cm` query as above. |
+| `<vm-template-name>` (in `DCSMachineTemplate.spec.template.spec.vmTemplateName`) | The ConfigMap's `cpaas.io/dcs-vm-template` label value (must match the VM template name registered in the DCS platform). | Same `kubectl get cm` query — read the label. |
+| `<base64-encoded-secret>` in `encryption-provider.conf` | Generated locally; treat as a real cluster secret. | `head -c 32 /dev/urandom \| base64` — store securely and reuse across control-plane replicas of the same cluster. |
+| `<ssh-authorized-keys>` | Operator-supplied. Each entry is a single-line OpenSSH-format public key (`ssh-ed25519 AAAA…` / `ssh-rsa AAAA…`). The field is required by the ignition validator and must be non-empty. For test or PoC clusters that do not need interactive SSH, supply any syntactically valid public key (you do not need to hold the matching private key); for production, use the operator team's signing key. | n/a — generated or sourced from the operator. |
+| `<auth-secret-name>` | The Secret you authored in [Infrastructure → Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials). | `kubectl -n cpaas-system get secret <name>` |
+| `<cluster-name>` | Operator-chosen; must satisfy DNS-1123. Reused across `Cluster`, `KubeadmControlPlane`, and the `cluster.x-k8s.io/cluster-name` label on every `Machine`. | n/a |
+| `<load-balancer-ip-or-domain-name>` | Operator-supplied: the IP / hostname clients use to reach the cluster API server. For single-control-plane clusters with no external LB, this is the IP of the sole master node (see [Single-control-plane layout](#single-control-plane-layout)). | n/a |
+| `<pods-cidr>` / `<services-cidr>` / `<kube-ovn-join-cidr>` | Operator-supplied. Must not overlap with the host network, the global cluster's CIDRs, or any other CAPI cluster's CIDRs you intend to interconnect. kube-ovn defaults are documented in the [Kube-OVN reference](../../overview/networks.mdx); leaving them empty is **not recommended** for production. | n/a |
+
+### Magic-Token Placeholders \{#magic-tokens}
+
+A few values in the example manifests look like placeholders but are **actually literal tokens** substituted by the DCS Provider at machine-join time. Leave them exactly as written:
+
+| Literal token | Meaning | Substituted by |
+|---|---|---|
+| `PROVIDER_ID` | The per-Machine provider ID (e.g. `dcs://<dcsmachine-name>`). | DCS Provider — overwritten in the generated kubelet config before `kubeadm init` / `kubeadm join` runs. |
+| `NODE_IP` | The node IP allocated from the `DCSIpHostnamePool` entry attached to this Machine. | DCS Provider — overwritten with the value of `DCSIpHostnamePool.spec.pool[].ip`. |
+
+Replacing or quoting these tokens manually breaks the join flow and produces nodes that never register with the control plane.
 
 ### Network Planning and Load Balancer
 
@@ -306,8 +335,8 @@ spec:
 |-----------|------|-------------|----------|
 | `.spec.kubeadmConfigSpec` | object | kubeadm bootstrap provider startup parameters | Yes |
 | `.spec.machineTemplate.infrastructureRef` | object | DCSMachineTemplate reference | Yes |
-| `.spec.replicas` | int | Control plane replica count (≤ IP Pool size) | Yes |
-| `.spec.version` | string | Kubernetes version (must match VM template) | Yes |
+| `.spec.replicas` | int | Control plane replica count. Must satisfy `1 ≤ replicas ≤ IP Pool size`. Set to `1` for development / PoC single-control-plane deployments (see [Single-control-plane layout](#single-control-plane-layout)). Production usually uses `3` for HA. | Yes |
+| `.spec.version` | string | Kubernetes version (must match VM template — see [Resolving Placeholder Values](#resolving-placeholders)) | Yes |
 
 For component versions (e.g., `<dns-image-tag>`, `<etcd-image-tag>`), refer to [OS Support Matrix](../overview/os-support-matrix.mdx).
 
@@ -345,6 +374,26 @@ spec:
 | `.spec.credentialSecretRef.name` | string | DCS authentication Secret name. The Secret defines whether DCS Provider authenticates as an interface interconnection user (default) or a domain user — see [Credential User Types](../infrastructure/huawei-dcs.mdx#user-types). | Yes |
 | `.spec.networkType` | string | Currently only supports "kube-ovn" | Yes |
 | `.spec.site` | string | DCS platform site ID | Yes |
+
+#### Single-Control-Plane (No External LB) Layout \{#single-control-plane-layout}
+
+For development, PoC, or any deployment where the control plane has only **one** replica (`KubeadmControlPlane.spec.replicas: 1`), you do not have a real load balancer in front of the API server. Two fields nevertheless still require a value:
+
+- `.spec.controlPlaneLoadBalancer.host` and `.spec.controlPlaneEndpoint.host` — set both to **the IP of the sole master node** (the same IP allocated to the master in the control-plane `DCSIpHostnamePool`).
+- `.spec.controlPlaneLoadBalancer.type` — keep as `external` (the type field has no other supported value).
+
+```yaml
+spec:
+  controlPlaneLoadBalancer:
+    host: 10.226.82.150     # same IP as the master node from the IP pool
+    port: 6443
+    type: external
+  controlPlaneEndpoint:
+    host: 10.226.82.150     # same as above
+    port: 6443
+```
+
+This layout has no HA — losing the single master makes the cluster API unreachable until the master is recovered. For production, use `replicas: 3` with a real load balancer.
 
 ### Configure Cluster
 
@@ -384,10 +433,26 @@ spec:
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| `.spec.clusterNetwork.pods.cidrBlocks` | []string | Pod CIDR | No |
-| `.spec.clusterNetwork.services.cidrBlocks` | []string | Service network CIDR | No |
+| `.spec.clusterNetwork.pods.cidrBlocks` | []string | Pod CIDR. Optional in the CAPI schema but **recommended to set explicitly** so multiple CAPI clusters can co-exist without overlap. If unset, kube-ovn falls back to a default that may conflict with another cluster on the same global. | Recommended |
+| `.spec.clusterNetwork.services.cidrBlocks` | []string | Service CIDR. Same recommendation as the pod CIDR — set explicitly to avoid collisions across clusters. | Recommended |
 | `.spec.controlPlaneRef` | object | Control plane reference | Yes |
 | `.spec.infrastructureRef` | object | Infrastructure cluster reference | Yes |
+
+**Cluster Annotations**:
+
+The example above shows three annotations, but a complete `Cluster` resource carries a few more. The table below lists the annotations the **operator authors** (some others are written by ACP controllers and you should not pre-set them):
+
+| Annotation | Required | Value source | Purpose |
+|---|---|---|---|
+| `capi.cpaas.io/resource-group-version` | Yes | Literal `infrastructure.cluster.x-k8s.io/v1beta1` | Tells the CAPI infrastructure binding which API group to use. |
+| `capi.cpaas.io/resource-kind` | Yes | Literal `DCSCluster` | Tells the CAPI infrastructure binding which kind to bind to. |
+| `capi.cpaas.io/kubernetes` | Yes | Same value as `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version`. | Display label, also consumed by some upgrade and inventory tooling. Source-of-truth is the `cpaas.io/dcs-vm-template` ConfigMap's `kubernetesVersion`. |
+| `cpaas.io/kube-ovn-join-cidr` | Yes | Operator-chosen `/16` CIDR, must not overlap with pod / service CIDRs or any other cluster's join CIDR. | Kube-OVN inter-node tunnel network. |
+| `cpaas.io/kube-ovn-version` | Yes | The kube-ovn release the global cluster ships with (read from the existing `cpaas.io/kube-ovn-version` annotation of any healthy cluster on the same global). | Pin the kube-ovn version installed into the workload cluster. |
+| `cpaas.io/registry-address` | Yes | The image registry the global cluster uses (typically `<global-cluster-ip>:11443`). Read from the existing `cpaas.io/registry-address` annotation of any healthy cluster. | Workload cluster pulls platform images (CoreDNS, kube-proxy, kube-ovn) from this registry. |
+| `cpaas.io/nodes-mode` | Yes | Literal `self-managed` for clusters that DCS Provider provisions. | Marks the cluster as having its node lifecycle managed by CAPI + this provider. |
+
+ACP controllers may write additional read-only annotations (`cpaas.io/cpu-cores-number`, `cpaas.io/memories`, `cpaas.io/nodes-number`, and so on) after the cluster is up — these are computed and **must not** be pre-set in the YAML you apply.
 
 ### Deploying Nodes
 

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -450,8 +450,8 @@ The example above shows three annotations, but a complete `Cluster` resource car
 | `capi.cpaas.io/resource-kind` | Yes | Literal `DCSCluster` | Tells the CAPI infrastructure binding which kind to bind to. |
 | `capi.cpaas.io/kubernetes` | Yes | Same value as `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version`. | Display label, also consumed by some upgrade and inventory tooling. Source-of-truth is the `cpaas.io/dcs-vm-template` ConfigMap's `kubernetesVersion`. |
 | `cpaas.io/kube-ovn-join-cidr` | Yes | Operator-chosen `/16` CIDR, must not overlap with pod / service CIDRs or any other cluster's join CIDR. | Kube-OVN inter-node tunnel network. |
-| `cpaas.io/kube-ovn-version` | Yes | The kube-ovn release the global cluster ships with (read from the existing `cpaas.io/kube-ovn-version` annotation of any healthy cluster on the same global). | Pin the kube-ovn version installed into the workload cluster. |
-| `cpaas.io/registry-address` | Yes | The image registry the global cluster uses (typically `<global-cluster-ip>:11443`). Read from the existing `cpaas.io/registry-address` annotation of any healthy cluster. | Workload cluster pulls platform images (CoreDNS, kube-proxy, kube-ovn) from this registry. |
+| `cpaas.io/kube-ovn-version` | Yes | The kube-ovn release the global cluster ships with. Read it from the `cpaas.io/kube-ovn-version` annotation on the `global` CAPI Cluster (`kubectl get cluster global -n cpaas-system -o jsonpath='{.metadata.annotations.cpaas\.io/kube-ovn-version}'`). The same value lives on every healthy workload cluster on the same global, so you can also read it from any of those if they exist. | Pin the kube-ovn version installed into the workload cluster. |
+| `cpaas.io/registry-address` | Yes | The image registry the global cluster uses (typically `<global-cluster-ip>:11443`). Read it from the `cpaas.io/registry-address` annotation on the `global` CAPI Cluster (`kubectl get cluster global -n cpaas-system -o jsonpath='{.metadata.annotations.cpaas\.io/registry-address}'`). | Workload cluster pulls platform images (CoreDNS, kube-proxy, kube-ovn) from this registry. |
 | `cpaas.io/nodes-mode` | Yes | Literal `self-managed` for clusters that DCS Provider provisions. | Marks the cluster as having its node lifecycle managed by CAPI + this provider. |
 
 ACP controllers may write additional read-only annotations (`cpaas.io/cpu-cores-number`, `cpaas.io/memories`, `cpaas.io/nodes-number`, and so on) after the cluster is up — these are computed and **must not** be pre-set in the YAML you apply.
@@ -817,7 +817,10 @@ files:
 **Minimum plugin version**: This Secret is shipped by the DCS Provider plugin starting from `v1.0.13`. On older plugin versions the Secret does not exist; keep the inline `content:` form in that case. To check whether the Secret is present on the target cluster before deciding which form to use:
 
 ```bash
-kubectl -n cpaas-system get secret dcs-kubernetes-1.33-files >/dev/null 2>&1 \
+# Replace <kubernetes-major-minor> with the value matching this cluster
+# (for example, 1.33 for Kubernetes v1.33.x).
+K8S_MM=<kubernetes-major-minor>
+kubectl -n cpaas-system get secret "dcs-kubernetes-${K8S_MM}-files" >/dev/null 2>&1 \
   && echo "Secret present — contentFrom.secret form is supported" \
   || echo "Secret missing — use inline content form"
 ```

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -813,6 +813,14 @@ files:
 ```
 
 `encryption-provider.conf` is not provided by the Secret. You can either keep it inline as shown above (and supply your own `<base64-encoded-secret>`), or omit the inline file entirely and rely on the version that the DCS VM template image already bakes in — both are valid; the latter is simpler when the VM template's default key is acceptable for your environment.
+
+**Minimum plugin version**: This Secret is shipped by the DCS Provider plugin starting from `v1.0.13`. On older plugin versions the Secret does not exist; keep the inline `content:` form in that case. To check whether the Secret is present on the target cluster before deciding which form to use:
+
+```bash
+kubectl -n cpaas-system get secret dcs-kubernetes-1.33-files >/dev/null 2>&1 \
+  && echo "Secret present — contentFrom.secret form is supported" \
+  || echo "Secret missing — use inline content form"
+```
 :::
 
 ---

--- a/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
+++ b/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
@@ -54,12 +54,17 @@ Once a workload cluster reaches a healthy steady state, all of the following mus
 
 2. The Cluster API `Cluster` resource carries the label `capi.cpaas.io/imported: ""`.
 
+   The label value is the empty string `""` on a healthy import, so a `jsonpath` query alone cannot distinguish "label missing" from "label value is empty". Use `jq` to check label presence explicitly:
+
    ```shell
-   kubectl get cluster <cluster-name> -n <namespace> \
-     -o jsonpath='{.metadata.labels.capi\.cpaas\.io/imported}'
+   kubectl get cluster <cluster-name> -n <namespace> -o json | \
+     jq -r 'if (.metadata.labels | has("capi.cpaas.io/imported"))
+            then "present (value=\"\(.metadata.labels["capi.cpaas.io/imported"])\")"
+            else "missing"
+            end'
    ```
 
-   An empty string `""` is the expected label value. Missing means the import has not completed.
+   Expected output: `present (value="")`. `missing` means the import has not completed.
 
 3. Exactly one `clustercredentials.platform.tkestack.io` object is labelled for the cluster.
 

--- a/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
+++ b/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
@@ -1,0 +1,159 @@
+---
+weight: 30
+title: Troubleshoot a Workload Cluster Stuck in Provisioned
+queries:
+  - troubleshoot workload cluster stuck in provisioned
+  - workload cluster never becomes ready cni missing
+  - sentry service account not found dcs provider
+  - cluster transformer did not import cluster
+---
+
+# Troubleshoot a Workload Cluster Stuck in Provisioned
+
+Use this guide when a workload cluster on Immutable Infrastructure has reached `Cluster.status.phase = Provisioned` and the Kubernetes control plane reports ready, but the cluster never becomes fully usable.
+
+The diagnostic flow assumes the workload cluster was created by applying provider Cluster API manifests to the `global` cluster.
+
+## Scope
+
+The diagnostic flow in this guide targets the **`global` cluster's import controller**, which is shared across all Immutable Infrastructure providers (Huawei DCS, VMware vSphere, Huawei Cloud Stack). The four invariants in [Invariants of a Healthy Imported Cluster](#invariants-of-a-healthy-imported-cluster) — `clusters.platform.tkestack.io` presence, the `capi.cpaas.io/imported` label, the `ClusterCredential` count, and the workload-cluster `sentry` ServiceAccount — apply to every provider.
+
+The example log strings in this guide come from the **DCS provider** (`KubeOvn`, `DCSCluster`). Other providers produce equivalent failures but use provider-specific reconciler object names (for example, `HCSCluster` on Huawei Cloud Stack). The diagnostic pattern is the same; only the reconciler object names differ.
+
+## Symptoms
+
+The cluster reaches a partial-success state and stays there. The following indicators appear together:
+
+| Where to look | What you see |
+|---|---|
+| `Cluster.status.phase` (on the `global` cluster) | `Provisioned` |
+| `KubeadmControlPlane.status.ready` | `true` |
+| `Machine.status.phase` | `Running` |
+| `Machine.status.conditions[?(@.type=="NodeHealthy")]` | `status: False`, `reason: NodeConditionsFailed`, `message: Node condition Ready is False` |
+| `MachineDeployment.status.conditions[?(@.type=="Available")]` | `status: False`, `reason: NotAvailable`, `message: WorkersAvailable: 0 available replicas` |
+| Inside the workload cluster: `kubectl get nodes` | One or more nodes report `STATUS=NotReady` because the CNI is not running |
+
+A typical secondary signature appears in the infrastructure provider reconciler logs on the `global` cluster:
+
+```text
+ERROR  failed to reconcile KubeOvn object: ServiceAccount "sentry" not found
+ERROR  failed to reconcile DCSCluster: ServiceAccount "sentry" not found
+```
+
+The reconciler tries to apply the CNI through an `AppRelease` resource that is executed by the workload cluster's own `sentry` ServiceAccount. If that ServiceAccount is not present, the CNI is never deployed and the workload nodes stay `NotReady`.
+
+## Invariants of a Healthy Imported Cluster
+
+Once a workload cluster reaches a healthy steady state, all of the following must hold. Verify each invariant from the `global` cluster context unless noted otherwise.
+
+1. A `clusters.platform.tkestack.io/<cluster-name>` object exists.
+
+   ```shell
+   kubectl get clusters.platform.tkestack.io <cluster-name>
+   ```
+
+2. The Cluster API `Cluster` resource carries the label `capi.cpaas.io/imported: ""`.
+
+   ```shell
+   kubectl get cluster <cluster-name> -n <namespace> \
+     -o jsonpath='{.metadata.labels.capi\.cpaas\.io/imported}'
+   ```
+
+   An empty string `""` is the expected label value. Missing means the import has not completed.
+
+3. Exactly one `clustercredentials.platform.tkestack.io` object is labelled for the cluster.
+
+   ```shell
+   kubectl get clustercredentials.platform.tkestack.io -o json | \
+     jq -r --arg c <cluster-name> \
+       '.items[] | select(.metadata.labels["cluster.x-k8s.io/cluster-name"]==$c) | .metadata.name'
+   ```
+
+   Exactly one name should print.
+
+4. Inside the workload cluster, ServiceAccount `sentry` exists in `cpaas-system`.
+
+   ```shell
+   kubectl --kubeconfig <workload-kubeconfig> -n cpaas-system get serviceaccount sentry
+   ```
+
+If any invariant fails, the workload cluster has not been imported by the `global` cluster's import controller, and the symptom pattern above is expected.
+
+## Diagnostic Steps
+
+### Step 1 — Confirm the Cluster API surface is healthy
+
+```shell
+kubectl get cluster <cluster-name> -n <namespace> -o wide
+kubectl get kubeadmcontrolplane -n <namespace>
+kubectl get machinedeployment -n <namespace>
+```
+
+A failure here is unrelated to the import pattern; investigate the infrastructure provider directly.
+
+### Step 2 — Check Machine and Node conditions
+
+```shell
+kubectl get machine -n <namespace> \
+  -l cluster.x-k8s.io/cluster-name=<cluster-name> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{" phase="}{.status.phase}{" "}{range .status.conditions[*]}{.type}={.status} {end}{"\n"}{end}'
+```
+
+If `phase=Running` but the `NodeHealthy` condition is `False`, the underlying workload node is `NotReady`. Continue to Step 3.
+
+### Step 3 — Inspect the infrastructure provider reconciler logs
+
+```shell
+kubectl logs -n cpaas-system <infra-provider-manager-pod> --tail=200 | \
+  grep -E 'ServiceAccount|sentry|<cluster-name>'
+```
+
+If you see repeated `ServiceAccount "sentry" not found` errors paired with a failure to reconcile the CNI object (for example, `KubeOvn`), the workload cluster's CNI is not being deployed because the import flow has not completed. Continue to Step 4.
+
+### Step 4 — Verify the global cluster has imported the workload cluster
+
+Run the invariant checks from the previous section. The combined diagnostic signature for a failed import is:
+
+- `clusters.platform.tkestack.io/<cluster-name>` returns `NotFound`.
+- `Cluster.metadata.labels` does not include `capi.cpaas.io/imported`.
+
+### Step 5 — Verify the ClusterCredential count invariant
+
+```shell
+kubectl get clustercredentials.platform.tkestack.io -o json | \
+  jq -r --arg c <cluster-name> \
+    '[.items[] | select(.metadata.labels["cluster.x-k8s.io/cluster-name"]==$c)] | length'
+```
+
+A healthy cluster prints `1`. A value greater than `1` (for example, `8`) indicates that the import flow tried and failed repeatedly, leaving orphan credentials behind.
+
+## Pattern That Indicates a Failed Import
+
+The diagnostics indicate a failed import when **all** of the following are true at the same time:
+
+- The Cluster API surface is healthy (`Cluster.status.phase=Provisioned`, `KubeadmControlPlane.status.ready=true`).
+- `Machine.condition.NodeHealthy=False` and at least one workload node is `NotReady`.
+- Infrastructure provider logs repeatedly report `ServiceAccount "sentry" not found`.
+- `clusters.platform.tkestack.io/<cluster-name>` does not exist.
+- The Cluster resource does not carry the `capi.cpaas.io/imported` label.
+- More than one `clustercredentials.platform.tkestack.io` object is labelled for the cluster.
+
+When this pattern holds, the workload cluster's initial import on the `global` cluster failed and the import controller does not currently retry from scratch.
+
+## What Does Not Resolve This Pattern
+
+:::warning
+Restarting the cluster-transformer pod on the `global` cluster does **not** re-import a workload cluster whose initial import already failed in this pattern. This was validated on 2026-05-12 against a live test environment: after a manual pod restart no log entries referenced the affected cluster and the missing `clusters.platform.tkestack.io` entry was not created.
+:::
+
+Do not assume the controller will eventually recover on its own when more than one orphan `ClusterCredential` is present for the same cluster.
+
+## Next Step
+
+Engage platform support with the following information:
+
+- The cluster name and namespace.
+- The output of the diagnostic commands in Steps 1 through 5.
+- The names and creation timestamps of every `clustercredentials.platform.tkestack.io` object that shares the same `cluster.x-k8s.io/cluster-name` label as the affected cluster.
+
+Recovery currently requires deleting and recreating the workload cluster after cleaning up the orphan `ClusterCredential` entries. Do not perform this on a production cluster without platform-support guidance: the recreate path triggers deletion of the underlying virtual machines on the IaaS platform, and provider-specific details (for example, DCS IP-pool and hostname planning, or HCS `HCSMachineConfigPool` re-allocation) must be reviewed before the recreate is applied.

--- a/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
+++ b/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
@@ -42,7 +42,7 @@ ERROR  failed to reconcile DCSCluster: ServiceAccount "sentry" not found
 
 The reconciler tries to apply the CNI through an `AppRelease` resource that is executed by the workload cluster's own `sentry` ServiceAccount. If that ServiceAccount is not present, the CNI is never deployed and the workload nodes stay `NotReady`.
 
-## Invariants of a Healthy Imported Cluster
+## Invariants of a Healthy Imported Cluster \{#invariants-of-a-healthy-imported-cluster}
 
 Once a workload cluster reaches a healthy steady state, all of the following must hold. Verify each invariant from the `global` cluster context unless noted otherwise.
 

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -81,7 +81,7 @@ For `Domain user`, password lifecycle is governed by your LDAP/AD directory serv
 :::info
 **Domain user support: YAML only in this version**
 
-The web UI currently only creates `Interface interconnection user` credentials. To create a `Domain user` credential, use the YAML path below and set `userType: domain` in the Secret.
+The web UI currently only creates `Interface interconnection user` credentials. To create a `Domain user` credential, use the YAML path below and set `.data.userType` to the base64 value of `domain` (for example, `ZG9tYWlu`) in the Secret. The base64 encoding step is shown in the `Example` block further down this page.
 :::
 
 ### Using YAML

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -102,6 +102,28 @@ metadata:
 type: Opaque
 ```
 
+:::tip
+**Skip the manual base64 step with `stringData`**
+
+The example above uses `data:`, which is Kubernetes' standard for Secrets — every value must already be base64-encoded. If you would rather author the Secret in plain text, replace the `data:` block with `stringData:` and provide the values directly. The API server transparently base64-encodes them at write time, so the final stored Secret is byte-identical to the `data:` form and the DCS Provider controller sees the same content either way.
+
+```yaml title="dcs-secret-stringdata.yaml"
+apiVersion: v1
+stringData:
+  authUser: <plain-text-auth-user>
+  authKey: <plain-text-auth-key>
+  endpoint: <plain-text-endpoint>
+  userType: <plain-text-user-type>   # optional; "interconnect" (default) or "domain"
+kind: Secret
+metadata:
+  name: <auth-secret-name>
+  namespace: cpaas-system
+type: Opaque
+```
+
+`stringData:` is write-only — once the Secret is created, `kubectl get secret -o yaml` will only show the `data:` form, which is the canonical representation. The two forms are mutually exclusive at write time; do not set the same key in both blocks.
+:::
+
 **Parameter Descriptions**:
 
 | Parameter | Description |

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -36,15 +36,20 @@ Cloud credentials store the DCS platform access information required for cluster
 Before creating a cloud credential, verify the following DCS platform requirements:
 
 **User Configuration**:
-- **User Type**: Must be `Interface interconnection user`
+- **User Type**: One of the following:
+  - `Interface interconnection user` — default; existing behaviour. Use this when an interconnect-style account is already provisioned in the DCS portal.
+  - `Domain user` — LDAP/AD-backed user managed in the directory service. Requires that DCS has **domain authentication configured by your DCS administrator**, and that the directory user is **pre-created in the DCS portal** with the role mapping below.
 - **Role**: Must be `administrator`
 
-**Password Policy**:
+**Password Policy** (applies to `Interface interconnection user` only):
+
 Navigate to **System Management** → **Rights Management** → **Rights Management Policy** and verify:
 - **Policy**: `Whether to modify the password of an interface interconnection user upon password resetting and first login`
 - **Value**: Must be set to **No**
 
 If set to `Yes`, the user's password will be forced to change upon first login, breaking authentication and causing cluster creation failures.
+
+For `Domain user`, password lifecycle is governed by your LDAP/AD directory service, not by DCS portal policy.
 
 #### Creating a Cloud Credential
 
@@ -73,6 +78,12 @@ If set to `Yes`, the user's password will be forced to change upon first login, 
 
 **Deleting Credentials**: Click **Delete** to remove a credential. Confirm the deletion in the dialog.
 
+:::info
+**Domain user support: YAML only in this version**
+
+The web UI currently only creates `Interface interconnection user` credentials. To create a `Domain user` credential, use the YAML path below and set `userType: domain` in the Secret.
+:::
+
 ### Using YAML
 
 Create a Secret resource to store DCS authentication information:
@@ -83,6 +94,7 @@ data:
   authUser: <base64-encoded-auth-user>
   authKey: <base64-encoded-auth-key>
   endpoint: <base64-encoded-endpoint>
+  userType: <base64-encoded-user-type>   # optional; "interconnect" (default) or "domain"
 kind: Secret
 metadata:
   name: <auth-secret-name>
@@ -97,6 +109,7 @@ type: Opaque
 | `.data.authUser` | DCS platform API user login name (base64-encoded) |
 | `.data.authKey` | DCS platform API user login password (base64-encoded) |
 | `.data.endpoint` | DCS platform API address with http or https protocol (base64-encoded). **Note**: The default API port for DCS platform is 7443 (not the common 8443). If your environment uses a custom port, confirm with your administrator. |
+| `.data.userType` | Optional. Base64 of the credential user type. Allowed plain-text values (before base64) are `interconnect` (default; used when the key is absent or empty) or `domain`. Matching is case-insensitive (`Domain`, `DOMAIN`, and `domain` all map to the same value). Any other value, including the legacy DCS magic numbers `1` and `2`, is rejected with a configuration error so a `domain` user is never silently authenticated as `interconnect`. |
 
 **Example**:
 
@@ -105,10 +118,24 @@ type: Opaque
 echo -n "admin" | base64
 echo -n "your-password" | base64
 echo -n "https://dcs.example.com:7443" | base64
+echo -n "domain" | base64   # only when using a domain user; omit for interconnect (default)
 
 # Apply the Secret
 kubectl apply -f dcs-secret.yaml -n cpaas-system
 ```
+
+### Credential User Types \{#user-types}
+
+DCS Provider supports two credential user types, selected by the optional Secret key `userType`:
+
+| `userType` value | Maps to DCS user | When to use | DCS-side requirement | Password lifecycle |
+|---|---|---|---|---|
+| `interconnect` (default; equivalent to the key being absent or empty) | `Interface interconnection user` | Existing deployments and the simplest path when an interconnect account is already provisioned in DCS. | DCS portal must keep the policy "Whether to modify the password of an interface interconnection user upon password resetting and first login" set to **No**. | Governed by DCS portal policy. |
+| `domain` | `Domain user` (LDAP/AD-backed) | Customers whose security audit requires LDAP/AD-managed credentials, or deployments that already standardize on directory-service accounts. | DCS must have **domain authentication configured by your DCS administrator**, and the directory user must be **pre-created in the DCS portal with the `administrator` role**. | Governed by your LDAP/AD directory service, not by DCS portal policy. |
+
+**Compatibility**: Existing Secrets without a `userType` key continue to authenticate as before; no migration is required to keep using interconnect-style credentials.
+
+**UI coverage**: The current web UI form does not expose the `userType` field. To use the `domain` value, configure the Secret through YAML.
 
 ---
 

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -320,6 +320,85 @@ spec:
 
 ---
 
+## DCS Platform Capacity and Placement \{#capacity-and-placement}
+
+Before authoring `DCSMachineTemplate` resources, verify that the target DCS site, datastore, and compute cluster have enough free capacity to host the planned VMs, and that the DCS-side scheduling policy can place new VMs on the available hosts. Skipping these checks is the single most common cause of VMs that appear to hang in `creating` state with no error returned by the DCS API.
+
+### Choosing a datastore \{#choosing-datastore}
+
+Each `DCSMachineDiskSpec` entry binds a disk to a DCS datastore through one of two mutually exclusive fields:
+
+- `datastoreName` — pins the disk to a specific datastore. The DCS scheduler does **not** look at sibling datastores even if they have free space. This is the strictest binding.
+- `datastoreClusterName` — pins the disk to a datastore cluster (a DCS-side group of datastores). The DCS scheduler chooses one specific datastore from the cluster that satisfies capacity. This is the safer default when the platform provides a datastore cluster.
+
+Prefer `datastoreClusterName` whenever the DCS administrator has configured a datastore cluster, so a single near-full datastore does not block deployments while sibling datastores still have free space.
+
+**Capacity preflight**:
+
+Before applying a new `DCSMachineTemplate`, list the existing DCS datastores and confirm that the target has enough free capacity for the worst case of `system disk + ∑(spec disk size) × replica count`. From an environment with DCS API access, the read-only listing looks like this:
+
+```bash
+curl -k -sS "${DCS_BASE}/service/sites/${SITE}/datastores" \
+  -H "X-Auth-Token: ${TOKEN}" -H 'version: 8.1' \
+  | python3 -c "
+import json,sys
+for ds in json.load(sys.stdin).get('datastores',[]) or []:
+  print(f\"{ds.get('name','?'):24} cap={ds.get('capacityGB','?')}GB used={ds.get('usedSizeGB','?')}GB free={ds.get('freeSizeGB','?')}GB state={ds.get('status','?')}\")"
+```
+
+Each `DCSMachineTemplate` cp / worker pair commonly needs the system disk (template-default, often ~80 GB) plus the explicit data disks declared in the spec, so a single control-plane node with `etcd 10G + kubelet 100G + containerd 100G + /var/cpaas 100G` consumes roughly 390 GB before the template's system disk. A datastore used above ~70 % is a strong signal to pick a different datastore — even if the absolute free space looks large, fragmentation and reservations can cause new VM placement to stall.
+
+### Host placement requirements \{#host-placement}
+
+A `DCSMachineTemplate.spec.template.spec.resource` field controls how DCS picks the physical host for the cloned VM:
+
+- `type: cluster` + `name: <cluster-name>` — lets the DCS cluster scheduler pick a host automatically. Requires the DCS cluster to have **DRS enabled** (or an equivalent balancer policy) so the scheduler can place new VMs on under-utilized hosts.
+- `type: host` + `name: <host-name>` — pins every cloned VM to one specific host. Use this when DRS is disabled, or when the platform has uneven host capacity and you must steer new VMs onto a specific host with free CPU and memory.
+
+If the DCS cluster has DRS disabled and the existing hosts are unevenly loaded (for example, one host is severely CPU-over-committed while another is mostly idle), the `type: cluster` mode can leave the deploy task stalled because the scheduler cannot pick a host that simultaneously satisfies the cluster's overcommit and reservation policies. Switching to `type: host` and pointing at a known-healthy host removes that ambiguity.
+
+To check current host load before applying a new template:
+
+```bash
+curl -k -sS "${DCS_BASE}/service/sites/${SITE}/hosts" \
+  -H "X-Auth-Token: ${TOKEN}" -H 'version: 8.1' \
+  | python3 -c "
+import json,sys
+for h in json.load(sys.stdin).get('hosts',[]) or []:
+  print(f\"{h.get('name','?'):10} status={h.get('status','?'):10} cpuUsed/total={h.get('cpuUsedCores','?')}/{h.get('cpuTotalCores','?')}c memUsed={h.get('memUsedSizeMB','?')}MB cpuMuxRatio={h.get('cpuMuxRatio','?')}\")"
+```
+
+A `cpuMuxRatio` (CPU allocation / physical cores) above ~3× on every host in the cluster, combined with DRS disabled, indicates the cluster is already saturated and will likely refuse new placements until either DRS is enabled or the load is rebalanced manually.
+
+### Troubleshooting: VM stuck in `creating` \{#stuck-creating}
+
+If a `DCSMachine` stays in `Provisioning` with `status.cdRomFile` set (so DCS API auth and ISO upload succeeded) but the DCS-side VM never leaves `status=creating` and never gets a `hostName`, the failure is almost always at the DCS placement layer, not in the controller.
+
+Diagnostic ladder, in order:
+
+1. **Confirm it is a placement stall**, not a slow boot. Query the VM and the matching deploy task on DCS:
+
+    ```bash
+    curl -k -sS "${DCS_BASE}/service/sites/${SITE}/vms?name=${VM_NAME}&limit=10" \
+      -H "X-Auth-Token: ${TOKEN}" -H 'version: 8.1'
+    curl -k -sS "${DCS_BASE}/service/sites/${SITE}/tasks?status=running&limit=50" \
+      -H "X-Auth-Token: ${TOKEN}" -H 'version: 8.1'
+    ```
+
+    Symptoms of a placement stall: `status=creating`, `hostName=` (empty / unscheduled), `disks` array empty or unchanging, and the deploy task sitting at the same `progress` value with no errors for more than ~5 minutes.
+
+2. **Check datastore free space** and **host load** using the snippets in [Choosing a datastore](#choosing-datastore) and [Host placement requirements](#host-placement). Datastore above 70 % used, or all hosts at high `cpuMuxRatio`, are the leading causes.
+
+3. **If DRS is disabled on the DCS cluster**, switch the relevant `DCSMachineTemplate.spec.template.spec.resource` to `type: host` + an explicit healthy host name, delete the stuck `Machine`, and let the controller re-derive a fresh `DCSMachine` against the new template.
+
+4. **If the DCS-side deploy task is genuinely deadlocked** (cancellable but unresponsive to ACP-driven `DeleteVm`), escalate to a DCS administrator with portal-admin credentials to cancel the task. The 7443 REST API does not expose a task-cancel endpoint for non-admin users, so the recovery path is owned by the DCS platform team, not by ACP.
+
+5. **Watch out for serialization side-effects**. In environments with a global DeployVM lock, a single stuck task can cause every new deploy to stall at the same progress percentage. Resolving the original stuck task usually unblocks the queue.
+
+A `DCSMachine` whose status conditions show `InfrastructureReady=False reason=WaitingForInfrastructure` for more than 10 minutes, together with the symptoms above, should be treated as a DCS-platform incident and not as a Cluster API or DCS Provider regression.
+
+---
+
 ## Machine Templates \{#machine-templates}
 
 Machine templates define the virtual machine specifications (VM template, CPU, memory, disk, network) for cluster nodes. Each machine template has a **Type** that determines its usage:

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -267,6 +267,27 @@ spec:
             protect-kernel-defaults: "true"
 ```
 
+`PROVIDER_ID` and `NODE_IP` are literal magic tokens that DCS Provider substitutes at machine-join time — keep them exactly as written. See [Magic-Token Placeholders](../create-cluster/huawei-dcs.mdx#magic-tokens) for the full list.
+
+:::tip
+**Alternative: reference a centrally managed Secret for the worker kubelet patch**
+
+The DCS Provider plugin ships a Secret named `dcs-kubernetes-<kubernetes-major-minor>-files` in the `cpaas-system` namespace (for example, `dcs-kubernetes-1.33-files` for Kubernetes 1.33). In addition to the control-plane files it serves to `KubeadmControlPlane` (see the create-cluster Appendix), this Secret also contains a `worker-kubelet-patch.json` key suitable for the worker `KubeadmConfigTemplate`. When that Secret is present, you can replace the inline `files` entry above with a `contentFrom.secret` reference — this keeps the worker kubelet patch in sync with the installed plugin version and avoids manual updates on cluster upgrades.
+
+```yaml
+files:
+- contentFrom:
+    secret:
+      key: worker-kubelet-patch.json
+      name: dcs-kubernetes-1.33-files
+  owner: "root:root"
+  path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+  permissions: "0644"
+```
+
+The inline and Secret-referenced forms are functionally equivalent; the Secret form is the recommended path when the plugin Secret is available in the target cluster.
+:::
+
 ### Step 4: Configure Machine Deployment
 
 The MachineDeployment orchestrates the creation and management of worker nodes by referencing the previously configured DCSMachineTemplate and KubeadmConfigTemplate resources. It manages the desired number of nodes and handles rolling updates.
@@ -923,6 +944,24 @@ Click the **Conditions** link on the Control Plane Node Pool card to view detail
 | Type | Status | Last Transition Time | Reason | Message |
 |------|--------|---------------------|--------|---------|
 | Condition Type | Status | Timestamp | Reason | Human-readable details |
+
+---
+
+## Troubleshooting \{#troubleshooting}
+
+### A new worker `Machine` stays in `Provisioning` and the DCS VM stays in `creating` \{#worker-stuck-creating}
+
+The diagnostic flow is identical for control-plane and worker `Machine` objects — when a `DCSMachine` reaches `Provisioning` with `status.cdRomFile` already set (DCS API auth and ISO upload succeeded), but the underlying DCS VM never schedules to a host, the failure is on the DCS platform side and not in the controller.
+
+See [Infrastructure → Troubleshooting: VM stuck in `creating`](../infrastructure/huawei-dcs.mdx#stuck-creating) for the full diagnostic ladder, which covers:
+
+- Confirming the symptom is a placement stall (not a slow boot).
+- Checking datastore free space.
+- Checking host CPU / memory utilisation and overcommit ratios.
+- Switching `DCSMachineTemplate.spec.template.spec.resource` from `type: cluster` to `type: host` when the DCS cluster has DRS disabled.
+- Escalation path when the deploy task is genuinely deadlocked.
+
+The same diagnostic applies whether the stuck node is the first control-plane node of a fresh cluster, a new worker added through `MachineDeployment` scaling, or a replacement worker created during a rolling update.
 
 ---
 

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -31,7 +31,7 @@ Worker nodes are managed through Cluster API `Machine` resources, providing decl
 3. **Bootstrap Configuration** - Node initialization and join settings
 4. **Machine Deployment** - Orchestration of node creation and management
 
-## Worker Node Deployment
+## Worker Node Deployment \{#worker-node-deployment}
 
 ### Step 1: Configure IP-Hostname Pool
 

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -286,6 +286,8 @@ files:
 ```
 
 The inline and Secret-referenced forms are functionally equivalent; the Secret form is the recommended path when the plugin Secret is available in the target cluster.
+
+**Minimum plugin version**: Same as the control-plane Appendix tip — `worker-kubelet-patch.json` is part of the `dcs-kubernetes-1.33-files` Secret shipped from DCS Provider `v1.0.13`. On older plugin versions the Secret does not exist; keep the inline `content:` form in that case.
 :::
 
 ### Step 4: Configure Machine Deployment

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -88,7 +88,11 @@ The DCS Provider implements the Cluster API infrastructure provider specificatio
 ## Requirements
 
 - DCS platform with API access
-- Interface interconnection user with administrator role
+- A DCS administrator-role user, either:
+  - `Interface interconnection user` (default), or
+  - `Domain user` (LDAP/AD-backed; requires DCS domain authentication configured by your DCS administrator).
+
+  See [Credential User Types](../../infrastructure/huawei-dcs.mdx#user-types) for selection criteria and DCS-side requirements.
 - Virtual machine templates with MicroOS images
 - DCS VM templates `4.2.1` or later when you use pool-managed persistent disks, because safe shutdown and disk detach depend on guest tools
 - Shared storage with cross-host access capability


### PR DESCRIPTION
## Summary

Document the new optional `userType` key on the DCS credential Secret introduced by [`cluster-api-provider-dcs` MR !35](https://gitlab-ce.alauda.cn/ait/cluster-api-provider-dcs/-/merge_requests/35) for AIT-69516.

The DCS Provider can now authenticate against the FC/DCS API as either an `Interface interconnection user` (default; existing behaviour) or a `Domain user` (LDAP/AD-backed). Existing Secrets without the new key continue to authenticate as before — no migration required.

## What changed (per file)

- **`docs/en/infrastructure/huawei-dcs.mdx`** (main edit):
  - Prerequisites § User Configuration: list both supported user types (interconnect = default, domain = LDAP/AD with DCS-side requirements).
  - Scope the DCS password-policy requirement to interconnect users; note domain users' password lifecycle is governed by LDAP/AD.
  - `:::info` note that the web UI currently creates only interconnect credentials; domain users go through YAML.
  - Extend the YAML Secret example, parameter table, and bash encoding snippet to include the optional `userType` key.
  - New subsection **Credential User Types** (`{#user-types}`) comparing interconnect vs domain on usage, DCS-side requirement, and password lifecycle.
- **`docs/en/overview/providers/huawei-dcs.mdx`**: Requirements list now lists both user types and cross-references the new Credential User Types subsection.
- **`docs/en/create-cluster/huawei-dcs.mdx`**: `DCSCluster .spec.credentialSecretRef.name` table row notes that the Secret determines interconnect vs domain authentication; cross-references the new subsection.

## User-visible Secret schema change

| Aspect | Behaviour |
|---|---|
| New key | `.data.userType` on the DCS credential Secret (optional) |
| Allowed values (before base64) | `interconnect` (default) or `domain` |
| Default | Absent or empty key → `interconnect` |
| Case sensitivity | Case-insensitive (`Domain`, `DOMAIN`, `domain` all map to the same value) |
| Rejected values | Any other value, including the legacy DCS magic numbers `1` / `2`, is rejected with a configuration error |
| Compatibility | Existing Secrets without the key continue to authenticate as before |
| UI coverage | Current web UI creates only interconnect credentials; domain credentials require YAML |

## Why

Customer security audits require DCS Provider to support DCS domain users (LDAP/AD-backed) when calling FC APIs, not just interconnect interface users. Backend implementation chose a semantic Secret key (`userType: interconnect` / `domain`) over exposing the raw DCS magic number (`X-Auth-UserType: 2` / `1`) to keep the operator-facing API readable.

## Test plan

- [x] **Backend**: 21 + 6 unit-test subcases pass (Secret loading, header mapping, case-insensitivity, magic-number rejection, fake-server header verification). See `docs/AIT-69516-domain-user/test-report.md` in the upstream MR.
- [x] **SDK smoke**: domain-user login + 7 read-only inventory endpoints on the live test DCS API (HTTP 200 across all 7).
- [x] **Regression**: existing interconnect-user `cluster-1m1n-cluster` reconciles cleanly on the new manager image with no auth errors.
- [x] **Doc review**: human reviewer to run `yarn dev` locally and verify rendering of the new subsection, anchors, and cross-references.

## Not in scope of this PR

- `docs/en/overview/release_notes.mdx` — release notes are written at official release time by the release author. This PR description plus the upstream code MR description are designed to be directly consumable as their input.
- Web UI / `docs/en/global/`, `install/`, `manage-nodes/`, `upgrade-cluster/`, `apis/providers/`, `how-to/`, i18n — no schema or workflow changes there.
- A future iteration may expose the `userType` field in the web UI; that is gated on a confirmed UI affordance request (phase 2 of AIT-69516).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Huawei DCS docs with an ordered provisioning checklist, single-control-plane (no external LB) layout, and tightened control-plane replica/version guidance.
  * Added placeholder/magic-token guidance (PROVIDER_ID/NODE_IP), secret/SSH key handling, and Secret-backed kubelet files with a plugin-version check.
  * Introduced credential user-type docs (interconnect vs domain), capacity/placement runbooks, CIDR recommendation, cluster annotations docs, and new troubleshooting guides for NotReady/stuck deployments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/immutable-infra-docs/pull/65)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->