### PR TITLE
docs(huawei-dcs): remove dead spec.resource, add platform terminology

### DIFF
--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -25,6 +25,11 @@ On Huawei DCS, the IP pool also carries any disks that must survive VM replaceme
 All infrastructure resources must be deployed in the `cpaas-system` namespace to ensure proper integration with the platform as business clusters.
 :::
 
+:::info
+**DCS platform concepts**
+If terms such as `DCS Cluster`, `DCS Host`, `DCS VM Folder`, or `DCS VM Template` are unfamiliar, or if it is not clear how they relate to the `DCSCluster` and `DCSMachineTemplate` custom resources, read [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) first.
+:::
+
 ## Cloud Credentials \{#cloud-credentials}
 
 Cloud credentials store the DCS platform access information required for cluster operations.
@@ -346,6 +351,47 @@ spec:
 
 Before authoring `DCSMachineTemplate` resources, verify that the target DCS site, datastore, and compute cluster have enough free capacity to host the planned VMs, and that the DCS-side scheduling policy can place new VMs on the available hosts. Skipping these checks is the single most common cause of VMs that appear to hang in `creating` state with no error returned by the DCS API.
 
+### Running the diagnostic snippets \{#diagnostic-prereqs}
+
+The capacity and placement checks below use read-only DCS REST calls. Before running any snippet, set the following environment variables in your shell:
+
+| Variable | Meaning | How to obtain |
+|---|---|---|
+| `DCS_BASE` | DCS REST API base URL, including scheme and port. The DCS REST API is published on port 7443 (separate from the 8443 web portal). | Ask the DCS platform administrator for the API endpoint. The same value is stored in the cloud-credential `Secret` under the `endpoint` key. |
+| `SITE` | DCS site ID (uppercase alphanumeric, for example `EC1C108C`). | Stored in the cloud-credential `Secret` under the `site` key, and also visible as `DCSCluster.spec.site`. |
+| `TOKEN` | Short-lived `X-Auth-Token` returned by `POST /service/session`. The token is valid for approximately 30 minutes of idle time. | Run the session command shown below. The DCS user and key are stored in the cloud-credential `Secret` under `authUser` and `authKey`. |
+
+Set the three variables once at the start of the diagnostic session:
+
+```bash
+# Replace the placeholders with values appropriate for your environment.
+export DCS_BASE='https://<dcs-api-host>:7443'
+export SITE='<site-id>'
+
+# Read the user and key from the cloud-credential Secret without printing them.
+DCS_USER="$(kubectl -n cpaas-system get secret <credential-secret-name> -o jsonpath='{.data.authUser}' | base64 -d)"
+DCS_KEY="$(kubectl -n cpaas-system get secret <credential-secret-name> -o jsonpath='{.data.authKey}' | base64 -d)"
+
+# Acquire a session token. The response header X-AUTH-TOKEN carries the value used by subsequent calls.
+HEADERS="$(mktemp)"
+curl -k -sS -D "$HEADERS" -o /dev/null -X POST "${DCS_BASE}/service/session" \
+  -H "X-Auth-User: $DCS_USER" \
+  -H "X-Auth-Key: $DCS_KEY" \
+  -H 'X-ENCRYPT-ALGORITHM: 1' \
+  -H 'X-Auth-UserType: 2' \
+  -H 'version: 8.1'
+export TOKEN="$(grep -i '^X-AUTH-TOKEN:' "$HEADERS" | tail -n1 | cut -d' ' -f2- | tr -d '\r\n ')"
+rm -f "$HEADERS"
+unset DCS_USER DCS_KEY
+```
+
+:::warning
+**Token handling**
+Do not log the token to a file or to shell history. The session token grants the same privileges as the underlying DCS user, which is typically an administrator.
+:::
+
+Reuse `$DCS_BASE`, `$SITE`, and `$TOKEN` in every subsequent diagnostic snippet on this page. Refresh the token by re-running the `POST /service/session` command when the API begins returning `errorCode: 10000002` (session expired or not logged in).
+
 ### Choosing a datastore \{#choosing-datastore}
 
 Each `DCSMachineDiskSpec` entry binds a disk to a DCS datastore through one of two mutually exclusive fields:
@@ -370,14 +416,14 @@ for ds in json.load(sys.stdin).get('datastores',[]) or []:
 
 Each `DCSMachineTemplate` cp / worker pair commonly needs the system disk (template-default, often ~80 GB) plus the explicit data disks declared in the spec, so a single control-plane node with `etcd 10G + kubelet 100G + containerd 100G + /var/cpaas 100G` consumes roughly 390 GB before the template's system disk. A datastore used above ~70 % is a strong signal to pick a different datastore — even if the absolute free space looks large, fragmentation and reservations can cause new VM placement to stall.
 
-### Host placement requirements \{#host-placement}
+### Host placement and high availability \{#host-placement}
 
-A `DCSMachineTemplate.spec.template.spec.resource` field controls how DCS picks the physical host for the cloned VM:
+Host placement on the DCS platform is performed by the DCS scheduler. The DCS Provider does not expose a way to pin a virtual machine to a specific DCS Host through `DCSMachineTemplate`. Virtual machines cloned from the same template can therefore land on the same physical host.
 
-- `type: cluster` + `name: <cluster-name>` — lets the DCS cluster scheduler pick a host automatically. Requires the DCS cluster to have **DRS enabled** (or an equivalent balancer policy) so the scheduler can place new VMs on under-utilized hosts.
-- `type: host` + `name: <host-name>` — pins every cloned VM to one specific host. Use this when DRS is disabled, or when the platform has uneven host capacity and you must steer new VMs onto a specific host with free CPU and memory.
+Two consequences follow from this:
 
-If the DCS cluster has DRS disabled and the existing hosts are unevenly loaded (for example, one host is severely CPU-over-committed while another is mostly idle), the `type: cluster` mode can leave the deploy task stalled because the scheduler cannot pick a host that simultaneously satisfies the cluster's overcommit and reservation policies. Switching to `type: host` and pointing at a known-healthy host removes that ambiguity.
+- **Capacity hot spots**: If the DCS cluster has uneven host load (for example, one host is severely CPU-over-committed while another is mostly idle), the DCS scheduler may refuse new placements on the over-committed host. The deploy task can stall until the load is rebalanced on the DCS side or DRS is enabled. Use the snippet below to confirm whether host load is the cause.
+- **No automatic spread for control plane**: Control-plane virtual machines from a single `DCSMachineTemplate` are not automatically distributed across multiple physical hosts. For high-availability deployments, configure VM-VM anti-affinity on the DCS platform side as described in [Cross-Host High Availability for Control Plane](#cross-host-ha) below.
 
 To check current host load before applying a new template:
 
@@ -390,7 +436,15 @@ for h in json.load(sys.stdin).get('hosts',[]) or []:
   print(f\"{h.get('name','?'):10} status={h.get('status','?'):10} cpuUsed/total={h.get('cpuUsedCores','?')}/{h.get('cpuTotalCores','?')}c memUsed={h.get('memUsedSizeMB','?')}MB cpuMuxRatio={h.get('cpuMuxRatio','?')}\")"
 ```
 
-A `cpuMuxRatio` (CPU allocation / physical cores) above ~3× on every host in the cluster, combined with DRS disabled, indicates the cluster is already saturated and will likely refuse new placements until either DRS is enabled or the load is rebalanced manually.
+A `cpuMuxRatio` (CPU allocation / physical cores) above ~3× on every host in the cluster indicates the cluster is already saturated and will likely refuse new placements until the load is rebalanced on the DCS side.
+
+### Cross-Host High Availability for Control Plane \{#cross-host-ha}
+
+The DCS Provider does not currently implement host pinning or Cluster API `FailureDomain` spreading. As a result, the three control-plane virtual machines of a Kubernetes cluster created through this provider can be placed on the same physical DCS Host. If that host fails, the entire Kubernetes control plane is unavailable until the host recovers.
+
+To force control-plane virtual machines onto different physical hosts, configure a VM-VM anti-affinity rule on the DCS platform side. The DCS platform calls this feature 互斥虚拟机 (Mutually Exclusive Virtual Machines). The rule is configured under the DCS Cluster's compute resource scheduling settings, lists the control-plane virtual machines by name, and instructs the DCS scheduler to keep those virtual machines on different hosts.
+
+A full operational runbook for this configuration is being prepared and will be published as a separate document. Until it is available, follow the DCS / FusionCompute platform documentation, or contact the DCS platform support team. Two prerequisites apply on the DCS side: the target cluster must have enough healthy hosts (typically at least one host per control-plane virtual machine), and the cluster must have DRS enabled if the rule should also be honoured during runtime rebalancing.
 
 ### Troubleshooting: VM stuck in `creating` \{#stuck-creating}
 
@@ -411,7 +465,7 @@ Diagnostic ladder, in order:
 
 2. **Check datastore free space** and **host load** using the snippets in [Choosing a datastore](#choosing-datastore) and [Host placement requirements](#host-placement). Datastore above 70 % used, or all hosts at high `cpuMuxRatio`, are the leading causes.
 
-3. **If DRS is disabled on the DCS cluster**, switch the relevant `DCSMachineTemplate.spec.template.spec.resource` to `type: host` + an explicit healthy host name, delete the stuck `Machine`, and let the controller re-derive a fresh `DCSMachine` against the new template.
+3. **Rebalance load on the DCS side**. If a single host is saturated while others have free capacity, ask the DCS platform team to rebalance the load (manual `Migrate` or DRS-driven rebalance) before retrying. The DCS Provider does not expose a per-template host pin, so this remediation is owned by the DCS platform team.
 
 4. **If the DCS-side deploy task is genuinely deadlocked** (cancellable but unresponsive to ACP-driven `DeleteVm`), escalate to a DCS administrator with portal-admin credentials to cancel the task. The 7443 REST API does not expose a task-cancel endpoint for non-admin users, so the recovery path is owned by the DCS platform team, not by ACP.
 
@@ -470,8 +524,7 @@ metadata:
 | Name | text | Yes | Unique identifier for the template (1-63 characters, lowercase letters, numbers, and hyphens only) |
 | Type | dropdown | Yes | Control Plane or Worker Node |
 | VM Template Name | dropdown | Yes | From ConfigMap, shows OS Version and Kubernetes Version |
-| Location | dropdown | No | DCS platform location (datacenter, rack, etc.) |
-| Resource | dropdown | No | DCS platform resource pool or cluster |
+| Location | dropdown | No | DCS VM Folder used to group the cloned virtual machines on the DCS platform. See [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) for the VM Folder definition. The folder must be created on the DCS platform first. |
 | Specs | - | Yes | CPU and memory specifications |
 | Specs.CPU | number | Yes | CPU cores (integer) |
 | Specs.Mem | number | Yes | Memory size in MB (displayed as GB in list view) |
@@ -523,7 +576,7 @@ If multiple VM templates have the same Kubernetes version, select the template w
 
 #### Managing Machine Templates
 
-**Viewing Templates**: Navigate to Clusters → Virtual Machine → Machine Templates to view all templates with their VM Template Name, Resource, Location, Specs, and IP Pool.
+**Viewing Templates**: Navigate to Clusters → Virtual Machine → Machine Templates to view all templates with their VM Template Name, Location, Specs, and IP Pool.
 
 **Updating Templates**: Click **Update** to modify specifications. Note that the Name field cannot be changed after creation.
 
@@ -546,9 +599,6 @@ spec:
       location:
         type: folder
         name: <folder-name>
-      resource: # Optional, if not specified, uses template defaults
-        type: cluster # cluster | host
-        name: <cluster-name>
       vmConfig:
         dvSwitchName: <dv-switch-name> # Optional
         portGroupName: <port-group-name> # Optional
@@ -580,13 +630,10 @@ spec:
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| `.spec.template.spec.vmTemplateName` | string | DCS virtual machine template name | Yes |
-| `.spec.template.spec.location` | object | Location where the VM will be created (auto-selected if not specified) | No |
-| `.spec.template.spec.location.type` | string | VM creation location type (currently only supports "folder") | Yes* |
-| `.spec.template.spec.location.name` | string | VM creation folder name | Yes* |
-| `.spec.template.spec.resource` | object | Compute resource selection for VM creation (auto-selected if not specified) | No |
-| `.spec.template.spec.resource.type` | string | Compute resource type: cluster or host | Yes* |
-| `.spec.template.spec.resource.name` | string | Compute resource name | Yes* |
+| `.spec.template.spec.vmTemplateName` | string | DCS VM Template name as registered on the DCS platform. | Yes |
+| `.spec.template.spec.location` | object | Places the cloned virtual machine under a DCS VM Folder for organizational grouping. If omitted, the virtual machine is not placed in any folder. See [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) for the VM Folder definition. | No |
+| `.spec.template.spec.location.type` | string | Set to `folder` for the standard workflow. The folder must already exist on the DCS platform. | Yes* |
+| `.spec.template.spec.location.name` | string | Name of the existing DCS VM Folder. | Yes* |
 | `.spec.template.spec.vmConfig` | object | Virtual machine configuration | Yes |
 | `.spec.template.spec.vmConfig.dvSwitchName` | string | Virtual machine switch name (uses template default if not specified) | No |
 | `.spec.template.spec.vmConfig.portGroupName` | string | Port group name (must belong to the specified switch, uses template default if not specified) | No |
@@ -601,6 +648,19 @@ spec:
 | `.spec.template.spec.ipHostPoolRef.name` | string | Referenced DCSIpHostnamePool name | Yes |
 
 \*Required when parent object is specified
+
+### Advanced: Multi-Cluster Deployment with Shared Storage \{#advanced-multi-cluster}
+
+The default workflow assumes that the DCS VM Template (`vmTemplateName`) and the cloned virtual machines live in the same DCS Cluster. For most deployments, this assumption is correct and the `spec.template.spec.location` field is set to a VM Folder for organizational grouping only.
+
+Deployments that span multiple DCS Clusters and want to clone from a single shared DCS VM Template into a different target DCS Cluster require the following conditions:
+
+- The DCS Datastore that holds the DCS VM Template must be visible to the target DCS Cluster. This is the case for SAN, IPSAN, NAS, or FusionStorage datastores configured for cross-cluster access; it is not the case for datastores backed by host-local disk.
+- The DCS-side network resources (distributed virtual switches and port groups) referenced by the `vmConfig` must also be visible to the target DCS Cluster.
+
+When both conditions are met, the cloned virtual machine can be placed under the target DCS Cluster by setting `spec.template.spec.location.type: cluster` and `spec.template.spec.location.name: <target-cluster-name>` instead of the default `type: folder` form. If the datastore is not shared across DCS Clusters, the clone task fails at the DCS platform side. The recommended alternative is to prepare a separate DCS VM Template inside each target DCS Cluster, so each `DCSMachineTemplate` references a template that already lives in the cluster where the virtual machines will run.
+
+Confirm cross-cluster datastore visibility with the DCS platform administrator before using this configuration.
 
 :::warning
 **Storage Requirements**

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -110,6 +110,8 @@ spec:
 
 The DCSMachineTemplate defines the specifications for worker node virtual machines, including VM templates, compute resources, storage configuration, and network settings.
 
+The fields in this resource reference several Huawei DCS platform concepts (DCS VM Template, DCS VM Folder, DCS Datastore, and related items). For the definitions of those concepts and how they map to Cluster API resources, see [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology).
+
 :::warning
 **Required Disk Configurations**
 The following disk mount points are mandatory. Do not remove them:
@@ -139,9 +141,6 @@ spec:
       location:
         type: folder
         name: <folder-name>
-      resource: # Optional, if not specified, uses template defaults
-        type: cluster # cluster | host. Optional
-        name: <cluster-name> # Optional
       vmConfig:
         dvSwitchName: <dv-switch-name> # Optional
         portGroupName: <port-group-name> # Optional
@@ -169,13 +168,10 @@ spec:
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| `.spec.template.spec.vmTemplateName` | string | DCS virtual machine template name | Yes |
-| `.spec.template.spec.location` | object | VM creation location (auto-selected if not specified) | No |
-| `.spec.template.spec.location.type` | string | Location type (currently supports "folder" only) | Yes* |
-| `.spec.template.spec.location.name` | string | Folder name for VM creation | Yes* |
-| `.spec.template.spec.resource` | object | Compute resource selection (auto-selected if not specified) | No |
-| `.spec.template.spec.resource.type` | string | Resource type: `cluster` or `host` | Yes* |
-| `.spec.template.spec.resource.name` | string | Compute resource name | Yes* |
+| `.spec.template.spec.vmTemplateName` | string | DCS VM Template name as registered on the DCS platform. | Yes |
+| `.spec.template.spec.location` | object | Places the cloned virtual machine under a DCS VM Folder for organizational grouping. If omitted, the virtual machine is not placed in any folder. See [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) for the VM Folder definition and [Infrastructure → Advanced: Multi-Cluster Deployment](../infrastructure/huawei-dcs.mdx#advanced-multi-cluster) for the multi-cluster use of this field. | No |
+| `.spec.template.spec.location.type` | string | Set to `folder` for the standard workflow. The folder must already exist on the DCS platform. | Yes* |
+| `.spec.template.spec.location.name` | string | Name of the existing DCS VM Folder. | Yes* |
 | `.spec.template.spec.vmConfig` | object | Virtual machine configuration | Yes |
 | `.spec.template.spec.vmConfig.dvSwitchName` | string | Virtual switch name (uses template default if not specified) | No |
 | `.spec.template.spec.vmConfig.portGroupName` | string | Port group name (must belong to the specified switch) | No |
@@ -960,8 +956,10 @@ See [Infrastructure → Troubleshooting: VM stuck in `creating`](../infrastructu
 - Confirming the symptom is a placement stall (not a slow boot).
 - Checking datastore free space.
 - Checking host CPU / memory utilisation and overcommit ratios.
-- Switching `DCSMachineTemplate.spec.template.spec.resource` from `type: cluster` to `type: host` when the DCS cluster has DRS disabled.
+- Coordinating with the DCS platform team to rebalance load when a single DCS Host is saturated.
 - Escalation path when the deploy task is genuinely deadlocked.
+
+For control-plane high availability across multiple physical hosts, see [Infrastructure → Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
 
 The same diagnostic applies whether the stuck node is the first control-plane node of a fresh cluster, a new worker added through `MachineDeployment` scaling, or a replacement worker created during a rolling update.
 

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -85,6 +85,181 @@ The DCS Provider implements the Cluster API infrastructure provider specificatio
 - **DCSMachineTemplate**: Defines VM templates for machine creation
 - **DCSIpHostnamePool**: Manages IP and hostname allocations for machines
 
+## Concepts and Terminology \{#concepts-and-terminology}
+
+Several Huawei DCS platform concepts have names that closely resemble Cluster API custom resource names. Two of them deserve special attention because the name collision is exact: a `DCS Cluster` (the DCS platform's pool of physical hosts) is not the same object as a `DCSCluster` custom resource (the Cluster API infrastructure resource that represents a Kubernetes cluster on top of DCS). Reading the two as the same thing leads to incorrect `DCSMachineTemplate` and `DCSCluster` configurations.
+
+This section enumerates the DCS platform concepts referenced by the provider, maps each concept to the Cluster API resource or field that references it, and clarifies the network and storage layering that is the most frequent source of configuration errors.
+
+### DCS Platform Object Hierarchy
+
+The DCS platform organizes its objects in a hierarchy. The provider works with the following layers (top to bottom):
+
+- **DCS Site** — the top-level scope of a single DCS deployment. Identified by a site ID such as `EC1C108C`.
+- Within a site:
+  - **DCS Clusters** — pools of physical hosts. A site contains one or more DCS Clusters.
+  - **DCS VM Folders** and **DCS Cluster Folders** — organizational labels (logical groupings) for virtual machines and clusters respectively.
+  - **DCS Datastores** and **DCS Datastore Clusters** — storage containers and groups of storage containers.
+  - **DCS Distributed Virtual Switches (DVS)** — virtual switches that span the site.
+- Within a DCS Cluster:
+  - **DCS Hosts** — physical servers (for example, `CNA-01`, `CNA-02`).
+- Within a DCS DVS:
+  - **DCS Port Groups** — network configuration entries that virtual machine NICs attach to.
+- Independent of the placement hierarchy:
+  - **DCS VM Templates** — virtual machines marked as templates, used as the source image for cloning.
+  - **DCS Volumes** — persistent disks created on DCS Datastores.
+
+The provider does not own any of these objects. It references them by name or URN from custom resource fields.
+
+### DCS Platform Concepts \{#dcs-concepts}
+
+#### DCS Site \{#dcs-site}
+
+The top-level container of a single DCS deployment. The site ID is supplied as `DCSCluster.spec.site` and is also stored in the cloud-credential `Secret`. All DCS API paths used by the provider include the site ID (`/service/sites/{siteId}/...`).
+
+#### DCS Cluster \{#dcs-cluster}
+
+A pool of physical hosts on the DCS platform. The DCS scheduler places virtual machines onto hosts that belong to a single DCS Cluster. A site can contain one or more DCS Clusters; a DCS Cluster contains one or more DCS Hosts. DCS Cluster names are visible in the DCS portal and are returned by the `GET /service/sites/{siteId}/clusters` API.
+
+The name `DCS Cluster` collides with the `DCSCluster` Cluster API custom resource. See [Cluster API Resource Mapping](#cluster-api-resource-mapping) below.
+
+#### DCS Host \{#dcs-host}
+
+A single physical server registered in a DCS Cluster. Names follow the local convention on the DCS platform (for example, `CNA-01`). Virtual machines run on hosts; the DCS scheduler chooses which host receives a new virtual machine, based on cluster-level policies (DRS, anti-affinity rules) and host capacity. The provider does not pin virtual machines to a specific DCS Host; the `DCSMachineTemplate` resource does not expose a host-binding field.
+
+#### DCS VM Folder \{#dcs-vm-folder}
+
+An organizational label inside a DCS Site that groups virtual machines. A VM Folder does not affect compute placement; a virtual machine grouped under VM Folder `foo` still runs on a DCS Host belonging to some DCS Cluster. The provider queries VM Folders through `GET /service/sites/{siteId}/folder?type=1`.
+
+VM Folders must be created on the DCS platform before being referenced from `DCSMachineTemplate.spec.template.spec.location` (with `type: folder`).
+
+#### DCS Cluster Folder \{#dcs-cluster-folder}
+
+An organizational label that groups DCS Clusters themselves, returned by the same `/folder` endpoint with a different `type` parameter. The provider does not query or reference DCS Cluster Folders. This concept is listed here only to prevent confusion with [DCS VM Folder](#dcs-vm-folder).
+
+#### DCS VM Template \{#dcs-vm-template}
+
+A virtual machine on the DCS platform that has been marked as a template (`isTemplate=true`). The provider clones from this template to create cluster nodes. A VM Template is identified by name (the value of `DCSMachine.spec.vmTemplateName`); the provider resolves the name to a URN by listing `GET /service/sites/{siteId}/vms?isTemplate=true&name=<name>`.
+
+A VM Template carries its own disk on a DCS Datastore and its own network configuration. The provider overwrites the network configuration (NIC port group, customization) when cloning; it does not overwrite the disk's storage type. The cloned virtual machine inherits the template's home DCS Cluster by default; see [Infrastructure → Advanced: Multi-Cluster Deployment](../../infrastructure/huawei-dcs.mdx#advanced-multi-cluster) for cross-cluster usage.
+
+#### DCS Datastore \{#dcs-datastore}
+
+A storage container on the DCS platform that holds the disks of virtual machines. Datastores can be backed by SAN, IPSAN, NAS, FusionStorage, or local disk. The storage backend determines whether a datastore is visible to one DCS Cluster or to several DCS Clusters: SAN, IPSAN, NAS, and FusionStorage typically support cross-cluster access; local disk does not.
+
+Datastores are referenced from disk specifications by either `datastoreName` or `datastoreUrn`; the provider resolves the name to a URN before sending the clone request.
+
+#### DCS Datastore Cluster \{#dcs-datastore-cluster}
+
+A group of DCS Datastores. When a disk specification references a Datastore Cluster (via `datastoreClusterName`), the DCS scheduler picks a member datastore that has free capacity. This is the recommended way to declare storage when the DCS administrator has configured a datastore cluster, because it tolerates single-datastore exhaustion.
+
+A DCS Datastore Cluster is **not** a DCS Cluster. The two names overlap because both use the word "cluster" but the underlying concepts are different: a DCS Cluster is a host pool, and a DCS Datastore Cluster is a datastore pool. Watch for this collision when reading platform documentation or talking to DCS administrators.
+
+#### DCS Distributed Virtual Switch (DVS) \{#dcs-dvs}
+
+A virtual switch on the DCS platform that spans one or more DCS Hosts. Virtual machine NICs attach to a DCS Port Group, which in turn belongs to a DCS DVS. The provider queries DVSs through `GET /service/sites/{siteId}/dvswitchs`.
+
+#### DCS Port Group \{#dcs-port-group}
+
+A network configuration entry on a DCS DVS. Each port group carries a VLAN configuration, security policies, and other network settings. The provider queries port groups through `GET {dvSwitchUri}/portgroups` (using the parent DVS URI) and references them by name (`portGroupName`) or URN (`portGroupUrn`).
+
+A virtual machine NIC must attach to exactly one DCS Port Group. Additional NICs require additional port-group references.
+
+#### DCS Volume \{#dcs-volume}
+
+A persistent disk on the DCS platform. Volumes live on DCS Datastores and are identified by a URN such as `urn:sites:EC1C108C:volumes:9841`. The provider creates volumes through `POST /service/sites/{siteId}/volumes` when `DCSIpHostnamePool.spec.pool[].persistentDisk[]` declares disks that must survive virtual machine replacement; it attaches the resulting volume to the virtual machine through the `attachvol` action.
+
+A DCS Volume is conceptually different from a Kubernetes `PersistentVolume`. A DCS Volume is a DCS-platform storage object attached at the hypervisor level; a Kubernetes `PersistentVolume` is a Kubernetes API object that represents storage available to pods. The provider only manages DCS Volumes; in-cluster `PersistentVolume` resources are managed separately by the workload's CSI driver.
+
+#### DCS Cloud Credential \{#dcs-cloud-credential}
+
+The authentication material used by the provider to call the DCS REST API. The provider obtains a session token by sending `X-Auth-User` and `X-Auth-Key` headers to `POST /service/session` and uses the returned `X-Auth-Token` header on subsequent requests. The credentials are stored as a Kubernetes `Secret` referenced from `DCSCluster.spec.credentialSecretRef`. The Secret contains `authUser`, `authKey`, `endpoint`, and `site` keys.
+
+### Cluster API Resource Mapping \{#cluster-api-resource-mapping}
+
+The following table disambiguates the DCS platform concepts whose names resemble Cluster API custom resources.
+
+| DCS platform concept | Cluster API resource with a similar name | Why they are not the same |
+|---|---|---|
+| DCS Cluster | `DCSCluster` (CRD) | A DCS Cluster is a pool of physical hosts on the DCS platform. `DCSCluster` is a Cluster API custom resource that represents the infrastructure side of a Kubernetes cluster running on top of the DCS platform. A single DCS Cluster can host the virtual machines of one or many Kubernetes clusters. |
+| DCS Host | Kubernetes Node | A DCS Host is a physical server registered on the DCS platform. A Kubernetes Node is a workload host inside a Kubernetes cluster running `kubelet`. The provider does not expose DCS Hosts to Kubernetes; the relationship between a Kubernetes Node and the DCS Host it runs on is decided by the DCS scheduler and is not represented in any custom resource. |
+| DCS VM Template | `DCSMachineTemplate` (CRD) | A DCS VM Template is an OS image template prepared by a DCS administrator on the DCS platform. `DCSMachineTemplate` is a Cluster API resource that references that template by name and adds Kubernetes-specific configuration (CPU, memory, disks, network). The `DCSMachineTemplate` does not contain image data; it points to a DCS VM Template by `vmTemplateName`. |
+| DCS Volume | Kubernetes `PersistentVolume` | A DCS Volume is a DCS-platform storage object attached at the hypervisor level. A Kubernetes `PersistentVolume` is a Kubernetes API object representing storage available to pods. The provider creates DCS Volumes (driven by `DCSIpHostnamePool.spec.pool[].persistentDisk[]`); Kubernetes `PersistentVolume` resources are managed independently by the workload's CSI driver. |
+| DCS Cloud Credential | Kubernetes `Secret` (referenced by `DCSCluster.spec.credentialSecretRef`) | A DCS Cloud Credential is the user/key pair issued by the DCS platform administrator. It is delivered to the provider as a Kubernetes `Secret` with the keys `authUser`, `authKey`, `endpoint`, and `site`. |
+
+The following concept does not collide with any Cluster API resource but is internally confusable because of the word "cluster":
+
+| DCS platform concept | Internally confusable with | Why they are not the same |
+|---|---|---|
+| DCS Datastore Cluster | DCS Cluster | A DCS Datastore Cluster is a group of DCS Datastores (storage). A DCS Cluster is a pool of DCS Hosts (compute). The two share the word "cluster" but belong to different layers of the DCS platform. |
+
+### Storage Concepts: Datastore, Datastore Cluster, and Volume \{#storage-concepts}
+
+The DCS platform exposes three storage-related concepts that the provider references separately:
+
+- A **DCS Datastore** is a single storage container. A virtual machine disk is pinned to one DCS Datastore.
+- A **DCS Datastore Cluster** is a group of DCS Datastores. A virtual machine disk that references a DCS Datastore Cluster is placed on one member datastore that has free capacity; the DCS scheduler picks the member.
+- A **DCS Volume** is a persistent disk object that lives on a DCS Datastore (or on a member datastore of a DCS Datastore Cluster). Volumes are created and attached to virtual machines through the provider when the `DCSIpHostnamePool` declares persistent disks; they survive virtual machine replacement.
+
+The relationship between the three:
+
+- A `DCSMachineTemplate` declares one or more disks under `vmConfig.dcsMachineDiskSpec[]`. Each disk binds to either a specific `datastoreName` or a `datastoreClusterName`. These template-level disks are created and destroyed together with the virtual machine.
+- A `DCSIpHostnamePool` entry can declare one or more `persistentDisk[]` items. Each item binds to either a specific `datastoreName` or a `datastoreClusterName`, and the provider creates a corresponding DCS Volume that survives virtual machine replacement.
+
+Cross-cluster visibility is determined by the underlying storage backend. SAN, IPSAN, NAS, and FusionStorage datastores are typically visible to several DCS Clusters; local-disk datastores are visible only to a single DCS Cluster. This visibility is what determines whether a single DCS VM Template can be cloned into more than one DCS Cluster.
+
+### Network Concepts: DVS, Port Group, and IP Identity \{#network-concepts}
+
+Network configuration on a DCS-backed Kubernetes cluster is split across two layers:
+
+- **DCS-side network plumbing (Layer 2)**: a virtual machine NIC must attach to a DCS Port Group, which belongs to a DCS Distributed Virtual Switch. The DVS and Port Group are DCS platform objects, created and administered on the DCS side. The provider references them by name (`dvSwitchName`, `portGroupName`) or by URN (`portGroupUrn`).
+- **Cluster-side network identity (Layer 3)**: the IP address, subnet mask, gateway, DNS server, and hostname assigned to the virtual machine are not DCS platform objects. They are declared in `DCSIpHostnamePool.spec.pool[]` entries (a Cluster API resource owned by the cluster operator) and are written into the virtual machine through cloud-init or Ignition during bootstrap.
+
+This split has two practical consequences:
+
+- The DCS platform team owns the DVS and Port Group definitions. The cluster operator owns the IP and hostname plan. The two are coordinated through the `DCSIpHostnamePool` resource, which references the DCS-side port group while declaring the cluster-side IP identity.
+- The provider does not call any DCS API to allocate or reserve IP addresses. Address conflicts must be avoided by the cluster operator when authoring `DCSIpHostnamePool` entries.
+
+The Cluster API resource `DCSIpHostnamePool` and the DCS platform's port group are distinct objects. The DCS platform does not have a native "IP pool" concept; the `DCSIpHostnamePool` resource is the only place where per-virtual-machine network identity is recorded.
+
+### Field-to-Concept Reference \{#field-to-concept-reference}
+
+The following tables map the most commonly used custom resource fields to the DCS platform concept they reference and to the source of the value.
+
+#### `DCSCluster` fields
+
+| Field | DCS platform concept | Value source |
+|---|---|---|
+| `spec.site` | [DCS Site](#dcs-site) | Site ID supplied by the DCS platform administrator. |
+| `spec.credentialSecretRef` | [DCS Cloud Credential](#dcs-cloud-credential) | Name of a Kubernetes `Secret` in the same namespace that holds the DCS user, key, endpoint, and site. |
+
+#### `DCSMachineTemplate` / `DCSMachine` fields
+
+| Field | DCS platform concept | Value source |
+|---|---|---|
+| `spec.template.spec.vmTemplateName` | [DCS VM Template](#dcs-vm-template) | Name of the template registered on the DCS platform (visible in the DCS portal). |
+| `spec.template.spec.location` (with `type: folder`) | [DCS VM Folder](#dcs-vm-folder) | Name of an existing VM Folder on the DCS platform. The folder must be created on the DCS side first. |
+| `spec.template.spec.location` (with `type: cluster`) | [DCS Cluster](#dcs-cluster) | Name of an existing DCS Cluster. Used only when the template's home cluster and the target cluster differ. See [Infrastructure → Advanced: Multi-Cluster Deployment](../../infrastructure/huawei-dcs.mdx#advanced-multi-cluster). |
+| `spec.template.spec.vmConfig.dvSwitchName` | [DCS DVS](#dcs-dvs) | Name of an existing DCS Distributed Virtual Switch. |
+| `spec.template.spec.vmConfig.portGroupName` | [DCS Port Group](#dcs-port-group) | Name of a port group that belongs to the referenced DCS DVS. |
+| `spec.template.spec.vmConfig.portGroupUrn` | [DCS Port Group](#dcs-port-group) | URN of an existing DCS Port Group. Mutually exclusive with `portGroupName`. |
+| `spec.template.spec.vmConfig.dcsMachineDiskSpec[].datastoreName` | [DCS Datastore](#dcs-datastore) | Name of a specific DCS Datastore. |
+| `spec.template.spec.vmConfig.dcsMachineDiskSpec[].datastoreClusterName` | [DCS Datastore Cluster](#dcs-datastore-cluster) | Name of a DCS Datastore Cluster that contains one or more datastores. Mutually exclusive with `datastoreName`. |
+| `spec.template.spec.vmConfig.dcsMachineDiskSpec[].datastoreUrn` | [DCS Datastore](#dcs-datastore) | URN of an existing DCS Datastore. Resolved internally from `datastoreName`. |
+| `spec.template.spec.vmConfig.cdRomDatastoreName` | [DCS Datastore](#dcs-datastore) | Name of a DCS Datastore that will hold the Ignition ISO. |
+| `spec.template.spec.vmConfig.cdRomDatastoreClusterName` | [DCS Datastore Cluster](#dcs-datastore-cluster) | Name of a DCS Datastore Cluster from which the Ignition ISO datastore is chosen. |
+
+#### `DCSIpHostnamePool` fields
+
+| Field | DCS platform concept | Value source |
+|---|---|---|
+| `spec.pool[].ip` / `mask` / `gateway` / `dns` / `hostname` | Cluster-side network identity (not a DCS platform concept) | Declared by the cluster operator; written into the virtual machine through cloud-init or Ignition. |
+| `spec.pool[].dvSwitchName` | [DCS DVS](#dcs-dvs) | Per-IP override of the DVS used for additional NICs. Falls back to the template-level DVS when omitted. |
+| `spec.pool[].portGroupName` / `portGroupUrn` | [DCS Port Group](#dcs-port-group) | Per-IP override of the port group used for additional NICs. |
+| `spec.pool[].persistentDisk[].datastoreName` | [DCS Datastore](#dcs-datastore) | Name of the DCS Datastore that will hold the persistent disk. |
+| `spec.pool[].persistentDisk[].datastoreClusterName` | [DCS Datastore Cluster](#dcs-datastore-cluster) | Name of the DCS Datastore Cluster that the persistent disk is created on. Mutually exclusive with `datastoreName`. |
+| `spec.pool[].persistentDisk[]` (the entry itself) | Creates a [DCS Volume](#dcs-volume) | The DCS Volume is created by the provider through `POST /service/sites/{siteId}/volumes` and attached to the virtual machine through the `attachvol` action. |
+
 ## Requirements
 
 - DCS platform with API access

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@alauda/doom": "^2.4.0"
+    "@alauda/doom": "^2.5.1"
   },
   "scripts": {
     "dev": "doom dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,13 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@alauda/doc-stream-sdk@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@alauda/doc-stream-sdk@npm:0.1.0"
+  checksum: 10c0/7626402b509a94d349d6833821649ea7b5ff05da6dc8ad8a30be123806be10b75ef6aa7c8d01c7fc0aad8ec4db31af965f247639a6150c169a991db16fe33d26
+  languageName: node
+  linkType: hard
+
 "@alauda/doom-export@npm:^0.4.1":
   version: 0.4.1
   resolution: "@alauda/doom-export@npm:0.4.1"
@@ -20,24 +27,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alauda/doom@npm:^2.4.0":
-  version: 2.4.0
-  resolution: "@alauda/doom@npm:2.4.0"
+"@alauda/doom@npm:^2.5.1":
+  version: 2.5.1
+  resolution: "@alauda/doom@npm:2.5.1"
   dependencies:
+    "@alauda/doc-stream-sdk": "npm:0.1.0"
     "@alauda/doom-export": "npm:^0.4.1"
     "@cspell/eslint-plugin": "npm:^10.0.0"
-    "@eslint-react/eslint-plugin": "npm:^4.2.3"
+    "@eslint-react/eslint-plugin": "npm:^5.7.6"
     "@eslint/js": "npm:^10.0.1"
-    "@inquirer/prompts": "npm:^8.4.1"
+    "@inquirer/prompts": "npm:^8.4.3"
     "@openapi-contrib/openapi-schema-to-json-schema": "npm:^5.1.0"
-    "@rsbuild/plugin-react": "npm:^1.4.6"
-    "@rsbuild/plugin-sass": "npm:^1.5.1"
-    "@rsbuild/plugin-svgr": "npm:^1.3.1"
+    "@rsbuild/plugin-react": "npm:^2.0.0"
+    "@rsbuild/plugin-sass": "npm:^1.5.2"
+    "@rsbuild/plugin-svgr": "npm:^2.0.2"
     "@rsbuild/plugin-yaml": "npm:^1.0.4"
-    "@rspress/core": "npm:2.0.8"
-    "@rspress/plugin-algolia": "npm:2.0.8"
-    "@rspress/plugin-sitemap": "npm:2.0.8"
-    "@rspress/shared": "npm:2.0.8"
+    "@rspress/core": "npm:2.0.11"
+    "@rspress/plugin-algolia": "npm:2.0.11"
+    "@rspress/plugin-sitemap": "npm:2.0.11"
+    "@rspress/shared": "npm:2.0.11"
     "@shikijs/transformers": "npm:^4.0.2"
     "@total-typescript/ts-reset": "npm:^0.6.1"
     "@types/react": "npm:^19.2.14"
@@ -45,11 +53,11 @@ __metadata:
     chokidar: "npm:^5.0.0"
     clsx: "npm:^2.1.1"
     commander: "npm:^14.0.3"
-    ejs: "npm:^5.0.1"
-    es-toolkit: "npm:^1.45.1"
-    eslint: "npm:^10.2.0"
+    ejs: "npm:^5.0.2"
+    es-toolkit: "npm:^1.46.1"
+    eslint: "npm:^10.3.0"
     eslint-plugin-mdx: "npm:^3.7.0"
-    globals: "npm:^17.4.0"
+    globals: "npm:^17.6.0"
     hastscript: "npm:^9.0.1"
     html-tag-names: "npm:^2.1.0"
     jsencrypt: "npm:^3.5.4"
@@ -59,14 +67,14 @@ __metadata:
     mdast-util-phrasing: "npm:^4.1.0"
     mdast-util-to-markdown: "npm:^2.1.2"
     mdast-util-to-string: "npm:^4.0.0"
-    mermaid: "npm:^11.14.0"
-    openai: "npm:^6.33.0"
+    mermaid: "npm:^11.15.0"
+    openai: "npm:^6.37.0"
     openapi-types: "npm:^12.1.3"
     p-ratelimit: "npm:^1.0.1"
     picomatch: "npm:^4.0.4"
     pluralize: "npm:^8.0.0"
     react-markdown: "npm:^10.1.0"
-    react-tooltip: "npm:^5.30.0"
+    react-tooltip: "npm:^6.0.2"
     rehype-raw: "npm:^7.0.0"
     rehype-sanitize: "npm:^6.0.0"
     remark-directive: "npm:^4.0.0"
@@ -81,23 +89,23 @@ __metadata:
     remark-mdx: "npm:^3.1.1"
     remark-message-control: "npm:^8.0.0"
     remark-stringify: "npm:^11.0.0"
-    simple-git: "npm:^3.35.2"
-    string-width: "npm:^8.2.0"
+    simple-git: "npm:^3.36.0"
+    string-width: "npm:^8.2.1"
     swagger2openapi: "npm:^7.0.8"
     tinyglobby: "npm:^0.2.16"
-    type-fest: "npm:^5.5.0"
-    typescript: "npm:^6.0.2"
-    typescript-eslint: "npm:^8.58.1"
+    type-fest: "npm:^5.6.0"
+    typescript: "npm:^6.0.3"
+    typescript-eslint: "npm:^8.59.3"
     unified: "npm:^11.0.5"
     unified-lint-rule: "npm:^3.0.1"
     unist-util-position: "npm:^5.0.0"
     unist-util-visit-parents: "npm:^6.0.2"
     x-fetch: "npm:^0.2.6"
-    yaml: "npm:^2.8.3"
+    yaml: "npm:^2.9.0"
     yoctocolors: "npm:^2.1.2"
   bin:
     doom: lib/cli/index.js
-  checksum: 10c0/2a92fa0d8efeaf8b640340ac387752f45691b1ab5bbe4618542433f24a321cf66090f9f2162d6c74ca9ed05507172272b37468b02db86d412b395e24f6d67bd9
+  checksum: 10c0/c7f317b39f2d58aac13ff7cfefab8873b5ba59a5449600df141b584a38957ac146e5aaae2188a64b31a733c98dc1146c2bc0d3bd460c087ee4906800f9257b51
   languageName: node
   linkType: hard
 
@@ -331,45 +339,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chevrotain/cst-dts-gen@npm:11.1.2":
-  version: 11.1.2
-  resolution: "@chevrotain/cst-dts-gen@npm:11.1.2"
-  dependencies:
-    "@chevrotain/gast": "npm:11.1.2"
-    "@chevrotain/types": "npm:11.1.2"
-    lodash-es: "npm:4.17.23"
-  checksum: 10c0/372a9573a404a1d717c92875024588a53d1eb078f12d2cd1d79d9c2c888c9b429eb62bbc85501b8ff168c14b22a675da99d97bb39b0a774e9fee000dc60fd8ff
-  languageName: node
-  linkType: hard
-
-"@chevrotain/gast@npm:11.1.2":
-  version: 11.1.2
-  resolution: "@chevrotain/gast@npm:11.1.2"
-  dependencies:
-    "@chevrotain/types": "npm:11.1.2"
-    lodash-es: "npm:4.17.23"
-  checksum: 10c0/540bfc9270d752f398b29efe9c89bb907d2984a47db4308a943e50c1cbd261ee13ecbef15c0e07808cf476d835bc36e65854db0bd214c277296cc14013eca8f4
-  languageName: node
-  linkType: hard
-
-"@chevrotain/regexp-to-ast@npm:11.1.2":
-  version: 11.1.2
-  resolution: "@chevrotain/regexp-to-ast@npm:11.1.2"
-  checksum: 10c0/645f02ac94cb33e04c10547b197762c6936c7b7668966240684795ce131cb515a76b63e0cc500e787d669f1a36bd2f902ec518f27843ec857ecf9043c717527e
-  languageName: node
-  linkType: hard
-
-"@chevrotain/types@npm:11.1.2":
+"@chevrotain/types@npm:~11.1.1":
   version: 11.1.2
   resolution: "@chevrotain/types@npm:11.1.2"
   checksum: 10c0/c0c4679a3d407df34e18d5adfa7ac599b4a2bfddbf68da6e43678b9b3e16ab911de7766b37b9fc466261c3dead3db1b620e2e344f800fa9f0f381720475eda8f
-  languageName: node
-  linkType: hard
-
-"@chevrotain/utils@npm:11.1.2":
-  version: 11.1.2
-  resolution: "@chevrotain/utils@npm:11.1.2"
-  checksum: 10c0/72989e7051781b9084252486712844c55e3b454318c7da4a5f6ded28dcd3947ba2882773a6bf09b7e744599e8c8025df8d3de0d487121734e6edb66999450438
   languageName: node
   linkType: hard
 
@@ -951,9 +924,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docsearch/core@npm:4.6.2":
-  version: 4.6.2
-  resolution: "@docsearch/core@npm:4.6.2"
+"@docsearch/core@npm:4.6.3":
+  version: 4.6.3
+  resolution: "@docsearch/core@npm:4.6.3"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
     react: ">= 16.8.0 < 20.0.0"
@@ -965,24 +938,24 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 10c0/daeda4af110bef09a094853c6e67e13f5183eaeabdc91b3b8ca008e02f34cbe8b16a812d5d0618ba4ff7dca64e0ca7da26cc8dfcba437a61305a6e9e2de7b1b1
+  checksum: 10c0/3abf3c78f4f0df3a4129d553f77ffb0a23f6eca6bde350448f42ba51178bfbba3c2f6e42e83a07e73fa0cd3643ea9f4bad5fd7a5ebc910010fa12da6a8bf7f97
   languageName: node
   linkType: hard
 
-"@docsearch/css@npm:4.6.2, @docsearch/css@npm:^4.6.2":
-  version: 4.6.2
-  resolution: "@docsearch/css@npm:4.6.2"
-  checksum: 10c0/2f86dcaa90871eec1b8f71de2ec2a7c3e64fac21167d4ee5b83e25df54706cb9709327dc41ca49cdde441b731bb3024c4afe67b2705736e0e11610e0ae4cdad2
+"@docsearch/css@npm:4.6.3, @docsearch/css@npm:^4.6.3":
+  version: 4.6.3
+  resolution: "@docsearch/css@npm:4.6.3"
+  checksum: 10c0/10c1282f102332915eaced15b16422d6aeb6b845311483e73d0f789fdc9c0913278adfa9f6ab29c856d769eafd1598d3271d6ef7059d74bec9d3f3c53a29f132
   languageName: node
   linkType: hard
 
-"@docsearch/react@npm:^4.6.2":
-  version: 4.6.2
-  resolution: "@docsearch/react@npm:4.6.2"
+"@docsearch/react@npm:^4.6.3":
+  version: 4.6.3
+  resolution: "@docsearch/react@npm:4.6.3"
   dependencies:
     "@algolia/autocomplete-core": "npm:1.19.2"
-    "@docsearch/core": "npm:4.6.2"
-    "@docsearch/css": "npm:4.6.2"
+    "@docsearch/core": "npm:4.6.3"
+    "@docsearch/css": "npm:4.6.3"
   peerDependencies:
     "@types/react": ">= 16.8.0 < 20.0.0"
     react: ">= 16.8.0 < 20.0.0"
@@ -997,11 +970,11 @@ __metadata:
       optional: true
     search-insights:
       optional: true
-  checksum: 10c0/33f6ddc1d6f648e0b80f86435c80654a59ddff9deb6a9236b863438a9cbc1b0283fa30437819e01d861451c88ea88990f7115e8b669a5d8ae7534decb71b085b
+  checksum: 10c0/47e764c50fa99931aff47e93108a9f34cbeed0edcdbce3034e5475790e068ee9e5e24fdd6c650fb9c8c3bfb0f1fc4fdd95148a1abda9d854d9fb2ccbf628b09e
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:^1.7.1":
+"@emnapi/core@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/core@npm:1.10.0"
   dependencies:
@@ -1011,7 +984,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.7.1":
+"@emnapi/runtime@npm:1.10.0":
   version: 1.10.0
   resolution: "@emnapi/runtime@npm:1.10.0"
   dependencies:
@@ -1047,108 +1020,118 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:4.2.3":
-  version: 4.2.3
-  resolution: "@eslint-react/ast@npm:4.2.3"
+"@eslint-react/ast@npm:5.7.9":
+  version: 5.7.9
+  resolution: "@eslint-react/ast@npm:5.7.9"
   dependencies:
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/typescript-estree": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     string-ts: "npm:^2.3.1"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/0cb4ade8f103e689f8d02c469cf2a3ade1fee96d1cc2344040b7dffab9087202494caa03a6a05390be63a96482c4a34bedfa44161e3f3092ca646943f3eb912b
+  checksum: 10c0/e1e0258eb6c21e94bc8af860e6140170d8a31b13b00c9de9604cfbd5b67bd6984a2d99a51e2b3b26c3a6e45aa1dfd7a3c9f67da6f0a79b87cc0342e8cfc78d9a
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:4.2.3":
-  version: 4.2.3
-  resolution: "@eslint-react/core@npm:4.2.3"
+"@eslint-react/core@npm:5.7.9":
+  version: 5.7.9
+  resolution: "@eslint-react/core@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/jsx": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/jsx": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@eslint-react/var": "npm:5.7.9"
+    "@typescript-eslint/scope-manager": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/1cc2d94b50998013b482a4bcaf61badb2e41a432ee8c155215242f121b0e3a27f73c23b2a86b386d56dc7bdf177d687a9b5d79093a46d459154419f1a06167e8
+  checksum: 10c0/dd4d71e54c48ce123caccafd1c5025b4c0eefa977f30b2161205389d6fb7e70e095c2be86c8fb9dc5773487786221dae3f8fd56417b31b3fc2cf8aab05fe4365
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^4.2.3":
-  version: 4.2.3
-  resolution: "@eslint-react/eslint-plugin@npm:4.2.3"
+"@eslint-react/eslint-plugin@npm:^5.7.6":
+  version: 5.7.9
+  resolution: "@eslint-react/eslint-plugin@npm:5.7.9"
   dependencies:
-    "@eslint-react/shared": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/type-utils": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
-    eslint-plugin-react-dom: "npm:4.2.3"
-    eslint-plugin-react-jsx: "npm:4.2.3"
-    eslint-plugin-react-naming-convention: "npm:4.2.3"
-    eslint-plugin-react-rsc: "npm:4.2.3"
-    eslint-plugin-react-web-api: "npm:4.2.3"
-    eslint-plugin-react-x: "npm:4.2.3"
-    ts-api-utils: "npm:^2.5.0"
+    "@eslint-react/shared": "npm:5.7.9"
+    eslint-plugin-react-dom: "npm:5.7.9"
+    eslint-plugin-react-jsx: "npm:5.7.9"
+    eslint-plugin-react-naming-convention: "npm:5.7.9"
+    eslint-plugin-react-rsc: "npm:5.7.9"
+    eslint-plugin-react-web-api: "npm:5.7.9"
+    eslint-plugin-react-x: "npm:5.7.9"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/a2e0050e56d96140c252e473cf48debc2a4f648cca65bda6a25ec669f1cc0ca216463517b6716c2d9a0f48f62654c7057c6f450e69f7090f191224430fd9f693
+  checksum: 10c0/69f6269ce88a604bd9c9e4c9586ba989564a5c070ec6d88bcc131b1013bef6f2860842f833c1132e4fa2c109dfee94bbb92d088e62884fcef98c7c704d292164
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:4.2.3":
-  version: 4.2.3
-  resolution: "@eslint-react/jsx@npm:4.2.3"
+"@eslint-react/eslint@npm:5.7.9":
+  version: 5.7.9
+  resolution: "@eslint-react/eslint@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@typescript-eslint/utils": "npm:^8.59.3"
+  peerDependencies:
+    eslint: ^10.3.0
+    typescript: "*"
+  checksum: 10c0/514f516d8d75e3d68d4a221689990beeaa38c1361a2953f793135d4df55c506aaa55a0578547552c60c820f68d27368e1aca6cd105f6f201a1680a7f89285bce
+  languageName: node
+  linkType: hard
+
+"@eslint-react/jsx@npm:5.7.9":
+  version: 5.7.9
+  resolution: "@eslint-react/jsx@npm:5.7.9"
+  dependencies:
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@eslint-react/var": "npm:5.7.9"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/2456a42ed1c385eb95cc7b198f3ac7310e71726f7d833f21f7f54015e81e8e942356aab6a0813dc9e9dae7e1b33df5fe90cfc0228d9b921c396d93ad320beb44
+  checksum: 10c0/c9509a76bf9d9d517d1809e3a8e3479f8ea162d715f1bcfa3b900c4a2b8a359c7080bb3f4cb893aa8620d69cf28b4a3ab5ce39d07113b8cb9552f98dd33c6fd9
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:4.2.3":
-  version: 4.2.3
-  resolution: "@eslint-react/shared@npm:4.2.3"
+"@eslint-react/shared@npm:5.7.9":
+  version: 5.7.9
+  resolution: "@eslint-react/shared@npm:5.7.9"
   dependencies:
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     ts-pattern: "npm:^5.9.0"
-    zod: "npm:^4.3.6"
+    zod: "npm:^4.4.3"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/4c0f9d58705de9ccf9ca45873ce20963b5184335261e033ca5d88f0457028b023d0fdbc770adb941ba2e0b73ac11d25656e3cb7f6fb8afa479c39912975d204f
+  checksum: 10c0/e7f841df4972f3b21048e13ef8b28a6081c12b76819667a7964a00df8cbe1efa20e8049f6f07ca660f45ee2076c6ebf9469d47ef9f3f3b8ce263bebbf421696d
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:4.2.3":
-  version: 4.2.3
-  resolution: "@eslint-react/var@npm:4.2.3"
+"@eslint-react/var@npm:5.7.9":
+  version: 5.7.9
+  resolution: "@eslint-react/var@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@typescript-eslint/scope-manager": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/455d47f4e9ebc881252ec03fa7b79598143b66806f0e262452854ff17fc2c02efc05d9dc5a8397f6515c4505f0c1d71f5aa0241c95255827a6763419562e98a0
+  checksum: 10c0/30c6992b8b29dec08aa83f076744422229c7e0e9a15de5727c1cb0e4fb9498f20b53aadbf5e53a97eb22a13ea5008a9c510d56f521a91cd98e4b9e44303d4043
   languageName: node
   linkType: hard
 
@@ -1163,12 +1146,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "@eslint/config-helpers@npm:0.5.5"
+"@eslint/config-helpers@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@eslint/config-helpers@npm:0.6.0"
   dependencies:
     "@eslint/core": "npm:^1.2.1"
-  checksum: 10c0/18889c062cd6bdbd4cd92fe57318c44465ea66184aa0ba204a4420712c66764c64093a7905b6c2ffde23e51b268ca2cec1a39c605d336bebf17ee1ba4f0fc0bb
+  checksum: 10c0/f9af20e8b60b0ba27edb74b8eb40c0c5d51a9bf9baf9e053bb57833a87cb0a1c49b4dfaad88fc24d49c907ad1324c8a0b668684fa9c321351dac4bc9155ec10a
   languageName: node
   linkType: hard
 
@@ -1233,7 +1216,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/dom@npm:^1.6.1":
+"@floating-ui/dom@npm:1.7.6":
   version: 1.7.6
   resolution: "@floating-ui/dom@npm:1.7.6"
   dependencies:
@@ -1313,12 +1296,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/checkbox@npm:^5.1.4":
-  version: 5.1.4
-  resolution: "@inquirer/checkbox@npm:5.1.4"
+"@inquirer/checkbox@npm:^5.1.5":
+  version: 5.1.5
+  resolution: "@inquirer/checkbox@npm:5.1.5"
   dependencies:
     "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/figures": "npm:^2.0.5"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
@@ -1326,28 +1309,28 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/38d6c8b49c392307c29fbb252d5dd09a819aecc34c83f01a7652efa09d7b8b901c448216496eda3962e319209243297ec575eff4e081a758bb08adb805f7e3d4
+  checksum: 10c0/6cf3bfbc0e39b80b8a37b69e49231c22616877b31b77507a55be5363d14b33e91cd3c1eb4ebf0ba89435ab5ef8204ce634579a23ab7b186ee8c71d54a7c959ee
   languageName: node
   linkType: hard
 
-"@inquirer/confirm@npm:^6.0.12":
-  version: 6.0.12
-  resolution: "@inquirer/confirm@npm:6.0.12"
+"@inquirer/confirm@npm:^6.0.13":
+  version: 6.0.13
+  resolution: "@inquirer/confirm@npm:6.0.13"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/36e9b1ef60e08562f07bcbcd78ba0a681b2fa3e5f54fa5e12303fc5982e8ba875ed782c24161e2295028b2b404ba690e841837303d16eeeb28df7aa9eb8aa835
+  checksum: 10c0/59f3c484f405b3ffe2e97a9e4927111d71d317ea84fa14dc0ffd2d7c902f934ad31f48b380765937f5ff85722ece475edcde8a64b8018c21f2ee3e33082cee8b
   languageName: node
   linkType: hard
 
-"@inquirer/core@npm:^11.1.9":
-  version: 11.1.9
-  resolution: "@inquirer/core@npm:11.1.9"
+"@inquirer/core@npm:^11.1.10":
+  version: 11.1.10
+  resolution: "@inquirer/core@npm:11.1.10"
   dependencies:
     "@inquirer/ansi": "npm:^2.0.5"
     "@inquirer/figures": "npm:^2.0.5"
@@ -1361,15 +1344,15 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/f7b162ce5f67fb75aab00a3668fdd8c8629aec790087840ea66ee8ead6009ab2066bec9cbf5bcc394ccdf130e6139051d6bace334b3a66c4f05349585213172c
+  checksum: 10c0/d1d4081cbb0bd3dc15a3c95c58560a4836079a14161c407bc20f9a1b0fdb93c2228daf61aa60acab7023bc78df1b85875fde94308dcac2c6bd0ffd24b5f05190
   languageName: node
   linkType: hard
 
-"@inquirer/editor@npm:^5.1.1":
-  version: 5.1.1
-  resolution: "@inquirer/editor@npm:5.1.1"
+"@inquirer/editor@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "@inquirer/editor@npm:5.1.2"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/external-editor": "npm:^3.0.0"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
@@ -1377,22 +1360,22 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/d9506fc4d16362ee060df0c8aa722ee85eae79e0be373253ecc49d0f51569f886bf0d09da9ae9910e3d5f79dca10767a5c1711c799af41c668b2a97866470221
+  checksum: 10c0/5b24700b8d4339d4b9b5fe5991d4c35843c1977595bfc0ab242e95a2bd8c2463c9039050f3b7821e8f49786926c5b68ba4cb20d6d887292fc0b12ccb03bd3ca2
   languageName: node
   linkType: hard
 
-"@inquirer/expand@npm:^5.0.13":
-  version: 5.0.13
-  resolution: "@inquirer/expand@npm:5.0.13"
+"@inquirer/expand@npm:^5.0.14":
+  version: 5.0.14
+  resolution: "@inquirer/expand@npm:5.0.14"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/108055f24dc4348a4981003003ca41fe793c7b3292ff80f583a1e1f1097bee64a0c2e5795cae969bcf77d4f34f03a3feeaa6315363eb01554f1c1eae6769c9f5
+  checksum: 10c0/efdc9a93d57397f415529ed2b969de6fa78c2ab98901a89efd73f1cfc79eba3ea899c621a63a458c530ca4142c89fd61cfeb873384e906f9cc33c022a5a3f5be
   languageName: node
   linkType: hard
 
@@ -1418,95 +1401,95 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@inquirer/input@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "@inquirer/input@npm:5.0.12"
+"@inquirer/input@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "@inquirer/input@npm:5.0.13"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/bb8273925c774bc5dffd93d6edc9e24391ab03c3ddd0c604987abbb74a7efcf03ca10b3bd0607ccf6613369e004417b14cf3c031327601118cff2cc98c5098e6
+  checksum: 10c0/df2d67a6f0a1b4cc22dfdc1e78f833560f613647bd75374d4664601b7947106dd977aceb8440a19a17204b58c11611e6084096eae3eb1873260f1f1d029a8a0a
   languageName: node
   linkType: hard
 
-"@inquirer/number@npm:^4.0.12":
-  version: 4.0.12
-  resolution: "@inquirer/number@npm:4.0.12"
+"@inquirer/number@npm:^4.0.13":
+  version: 4.0.13
+  resolution: "@inquirer/number@npm:4.0.13"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/e933967d9879792775d4ac8f4abcc9c2f263107a1e3c1cdd5ce85dd446a03bed2f6cb01c41ed1a3b45b80f385eb3a991d1442703d9816416c79c0ca6f20e57f3
+  checksum: 10c0/9185d15c8b0ab820dc0456e7db6f189ae84bf8d5f5bce19398f3a858fca0276e66a53922a4ab118dbae65f1f4f6a29f06f3d34c6436ae9e095a98e9862590e2b
   languageName: node
   linkType: hard
 
-"@inquirer/password@npm:^5.0.12":
-  version: 5.0.12
-  resolution: "@inquirer/password@npm:5.0.12"
+"@inquirer/password@npm:^5.0.13":
+  version: 5.0.13
+  resolution: "@inquirer/password@npm:5.0.13"
   dependencies:
     "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/e1399196f01ff5fadc1d3e1bc6946a4f53a5753ccf8e39b2f11f1dae5c51fdb85e33ef44760d83c5b58dacc442de603f32e9c991b2e5f2f8a2a451ff62e1fe48
+  checksum: 10c0/e06aa6ae4344e3e37630655c443001bcf4421b1e4821c15987fc747b8d0362d536a52a115d25d02b023bb7091fc88630a65d7b0ac02e15a2f70d933f6a863da3
   languageName: node
   linkType: hard
 
-"@inquirer/prompts@npm:^8.4.1":
-  version: 8.4.2
-  resolution: "@inquirer/prompts@npm:8.4.2"
+"@inquirer/prompts@npm:^8.4.3":
+  version: 8.4.3
+  resolution: "@inquirer/prompts@npm:8.4.3"
   dependencies:
-    "@inquirer/checkbox": "npm:^5.1.4"
-    "@inquirer/confirm": "npm:^6.0.12"
-    "@inquirer/editor": "npm:^5.1.1"
-    "@inquirer/expand": "npm:^5.0.13"
-    "@inquirer/input": "npm:^5.0.12"
-    "@inquirer/number": "npm:^4.0.12"
-    "@inquirer/password": "npm:^5.0.12"
-    "@inquirer/rawlist": "npm:^5.2.8"
-    "@inquirer/search": "npm:^4.1.8"
-    "@inquirer/select": "npm:^5.1.4"
+    "@inquirer/checkbox": "npm:^5.1.5"
+    "@inquirer/confirm": "npm:^6.0.13"
+    "@inquirer/editor": "npm:^5.1.2"
+    "@inquirer/expand": "npm:^5.0.14"
+    "@inquirer/input": "npm:^5.0.13"
+    "@inquirer/number": "npm:^4.0.13"
+    "@inquirer/password": "npm:^5.0.13"
+    "@inquirer/rawlist": "npm:^5.2.9"
+    "@inquirer/search": "npm:^4.1.9"
+    "@inquirer/select": "npm:^5.1.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/0519d6a52e195e24b03949afda1ad7fc2ae752c72a7ba554d4bdbbac844fd47dc83d79e67f732c6bf3c56a407e3171b92bd3b0dc334fd35eea446a889d1100f7
+  checksum: 10c0/fd77efb0b12a9293d6533cf332a1af10f69fefa97202c3790c2a7695a06c443ed5d4877d05efe512803e4a98cce0fa46fed9d372149512c2eccbfcf23f1c44bd
   languageName: node
   linkType: hard
 
-"@inquirer/rawlist@npm:^5.2.8":
-  version: 5.2.8
-  resolution: "@inquirer/rawlist@npm:5.2.8"
+"@inquirer/rawlist@npm:^5.2.9":
+  version: 5.2.9
+  resolution: "@inquirer/rawlist@npm:5.2.9"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
     "@types/node": ">=18"
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/35b0a9e29972342669365af70ea8feebc4e13ce688ce53c1fae723cbd02a7082294553eeb49ee443f5e993c1a97be31fcbe366f7cb573c075557316717792527
+  checksum: 10c0/10f1a23e5222a932d9965490beb8b37551b2c68dcb281290d8f0099dc0778b49d4ca671ad8b346c802cbff29924faffd01b62dc88f297020e3d1061eb00b7f78
   languageName: node
   linkType: hard
 
-"@inquirer/search@npm:^4.1.8":
-  version: 4.1.8
-  resolution: "@inquirer/search@npm:4.1.8"
+"@inquirer/search@npm:^4.1.9":
+  version: 4.1.9
+  resolution: "@inquirer/search@npm:4.1.9"
   dependencies:
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/figures": "npm:^2.0.5"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
@@ -1514,16 +1497,16 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/7281c59e8953aa4663c5afe3d6a3b558ec3e97867569f29dcc0a67e89ff05b37f374ac34ebc7356a7137f76a5172d52c60469cadcc323cc733b4d635b5cf3334
+  checksum: 10c0/0e0cd6f2f312cecfa02f7d5556a7ccf5cbffff442fbdd0828f320e0a0239b63d24db5e31e05ec77d2a969900ad40b2d115f6496b2c9c47561a15dc504298d9dc
   languageName: node
   linkType: hard
 
-"@inquirer/select@npm:^5.1.4":
-  version: 5.1.4
-  resolution: "@inquirer/select@npm:5.1.4"
+"@inquirer/select@npm:^5.1.5":
+  version: 5.1.5
+  resolution: "@inquirer/select@npm:5.1.5"
   dependencies:
     "@inquirer/ansi": "npm:^2.0.5"
-    "@inquirer/core": "npm:^11.1.9"
+    "@inquirer/core": "npm:^11.1.10"
     "@inquirer/figures": "npm:^2.0.5"
     "@inquirer/type": "npm:^4.0.5"
   peerDependencies:
@@ -1531,7 +1514,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/node":
       optional: true
-  checksum: 10c0/30b6b061acd08f3f4cfde08a626446d308271e32569acec03f8c87a17e04c21aeccbecf354c8b254a2decfbe7d2189d8ae4443bf10d0be4a2aedeb4e850574c2
+  checksum: 10c0/871e05266c00151031798dc659acaed3d9c76d0040a25204cbcc99f7104559db1a8bc2a73ee04318a01f06f879a3d7e5986db50f563aeca23ae4cd5e8cff6057
   languageName: node
   linkType: hard
 
@@ -1675,23 +1658,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mermaid-js/parser@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@mermaid-js/parser@npm:1.1.0"
+"@mermaid-js/parser@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@mermaid-js/parser@npm:1.1.1"
   dependencies:
-    langium: "npm:^4.0.0"
-  checksum: 10c0/449e594a1f9ff1e24da7eb66b7d85694f1c48bdf1d27e798e0e182659e907fd3438a69bf30754807a8a8e286ab3173fa1b8e43ee102be31e30ee7632b9bc1d03
+    "@chevrotain/types": "npm:~11.1.1"
+  checksum: 10c0/66414d9d66f3a86a6751427cb8890a00beaaee2b7eba34c21b34b60cdaf9237d21e9b50b9bf1f560a01a600ee332d33b949fd8f12cbda3238aba50edc0dfdf15
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.1"
+"@napi-rs/wasm-runtime@npm:1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
   dependencies:
-    "@emnapi/core": "npm:^1.7.1"
-    "@emnapi/runtime": "npm:^1.7.1"
     "@tybys/wasm-util": "npm:^0.10.1"
-  checksum: 10c0/04d57b67e80736e41fe44674a011878db0a8ad893f4d44abb9d3608debb7c174224cba2796ed5b0c1d367368159f3ca6be45f1c59222f70e32ddc880f803d447
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
   languageName: node
   linkType: hard
 
@@ -2002,12 +1986,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rsbuild/core@npm:2.0.0-beta.11":
-  version: 2.0.0-beta.11
-  resolution: "@rsbuild/core@npm:2.0.0-beta.11"
+"@rsbuild/core@npm:^2.0.5":
+  version: 2.0.6
+  resolution: "@rsbuild/core@npm:2.0.6"
   dependencies:
-    "@rspack/core": "npm:2.0.0-beta.9"
-    "@swc/helpers": "npm:^0.5.20"
+    "@rspack/core": "npm:~2.0.3"
+    "@swc/helpers": "npm:^0.5.21"
   peerDependencies:
     core-js: ">= 3.0.0"
   peerDependenciesMeta:
@@ -2015,59 +1999,59 @@ __metadata:
       optional: true
   bin:
     rsbuild: bin/rsbuild.js
-  checksum: 10c0/78855ba14c0dbd8d65af2ac3152bb4e82b334ca822403e528fbf7c8191a0d3a45405f9b92eba55a1ffbbacd7b3f36bb7a3fcb7cb9a9c6f23f3642bfa0618b9cd
+  checksum: 10c0/51c161ee113f16819bd120526829b6a7c2d40b7db088da96e798e1b0ce80fcf8745d97e99f4d8c0f926e3048526d214e723862763054d94d9782164c1d22ae83
   languageName: node
   linkType: hard
 
-"@rsbuild/plugin-react@npm:^1.4.6, @rsbuild/plugin-react@npm:~1.4.6":
-  version: 1.4.6
-  resolution: "@rsbuild/plugin-react@npm:1.4.6"
+"@rsbuild/plugin-react@npm:^2.0.0, @rsbuild/plugin-react@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "@rsbuild/plugin-react@npm:2.0.0"
   dependencies:
-    "@rspack/plugin-react-refresh": "npm:^1.6.1"
+    "@rspack/plugin-react-refresh": "npm:2.0.0"
     react-refresh: "npm:^0.18.0"
   peerDependencies:
-    "@rsbuild/core": ^1.0.0 || ^2.0.0-0
+    "@rsbuild/core": ^2.0.0-0
   peerDependenciesMeta:
     "@rsbuild/core":
       optional: true
-  checksum: 10c0/e878c565ecdb23a1b08050adcd05e06c2c07dd8fc06be3d4de52b4976f593c27a823c42a2fbd21628ff70a24ad00f00171e889615a5b291a3bc02834e009f96f
+  checksum: 10c0/8d56bcdf876da942d16a279c6702b56021a133962e6ce013cfda25bd1b83053aa1ac3663408b972f7d345578eca04555ed2371d5a56057e6ee4fd4ee5362c8e1
   languageName: node
   linkType: hard
 
-"@rsbuild/plugin-sass@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "@rsbuild/plugin-sass@npm:1.5.1"
+"@rsbuild/plugin-sass@npm:^1.5.2":
+  version: 1.5.2
+  resolution: "@rsbuild/plugin-sass@npm:1.5.2"
   dependencies:
     deepmerge: "npm:^4.3.1"
     loader-utils: "npm:^2.0.4"
-    postcss: "npm:^8.5.8"
-    reduce-configs: "npm:^1.1.1"
-    sass-embedded: "npm:^1.97.3"
+    postcss: "npm:^8.5.10"
+    reduce-configs: "npm:^1.1.2"
+    sass-embedded: "npm:^1.99.0"
   peerDependencies:
     "@rsbuild/core": ^1.3.0 || ^2.0.0-0
   peerDependenciesMeta:
     "@rsbuild/core":
       optional: true
-  checksum: 10c0/b26be920fa975e4d17e7db82b82f8004f553c5eea383cf9ba82ee147c3e4f567cf651bee62532477785c45b82ed75d1b621fcea3f6ea6a2ddd65571c34f050b1
+  checksum: 10c0/843d4b0a1039b232aeffc04dbe579fa1e48959f6c896781c2b0817ef0ae135955a24579332ff8ffb16b5702c40cd9ed302f901e527160a5b5b417e5c54cb6cd4
   languageName: node
   linkType: hard
 
-"@rsbuild/plugin-svgr@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "@rsbuild/plugin-svgr@npm:1.3.1"
+"@rsbuild/plugin-svgr@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@rsbuild/plugin-svgr@npm:2.0.2"
   dependencies:
-    "@rsbuild/plugin-react": "npm:^1.4.6"
+    "@rsbuild/plugin-react": "npm:^2.0.0"
     "@svgr/core": "npm:8.1.0"
     "@svgr/plugin-jsx": "npm:8.1.0"
     "@svgr/plugin-svgo": "npm:8.1.0"
     deepmerge: "npm:^4.3.1"
     loader-utils: "npm:^3.3.1"
   peerDependencies:
-    "@rsbuild/core": ^1.0.0 || ^2.0.0-0
+    "@rsbuild/core": ^2.0.0-0
   peerDependenciesMeta:
     "@rsbuild/core":
       optional: true
-  checksum: 10c0/7862a45b38b64a8820c1354da89cf5f062553137c47e9a8ac89030befeebca47da54dff7dac54a28a87ea2e15b36e14471da1f567b5c5af3ea62311e2991573f
+  checksum: 10c0/cbac516ff7a6f3a613d03c72a6b2b56698a483c757284235967852843e3b41ff60723b9aa7478e8c617ae8a9b1e479f5b9df5ea2f9485aa62f3ea5729c73ba54
   languageName: node
   linkType: hard
 
@@ -2083,92 +2067,94 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-arm64@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-darwin-arm64@npm:2.0.0-beta.9"
+"@rspack/binding-darwin-arm64@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-darwin-arm64@npm:2.0.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-x64@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-darwin-x64@npm:2.0.0-beta.9"
+"@rspack/binding-darwin-x64@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-darwin-x64@npm:2.0.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-gnu@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.0.0-beta.9"
+"@rspack/binding-linux-arm64-gnu@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.0.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-musl@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-linux-arm64-musl@npm:2.0.0-beta.9"
+"@rspack/binding-linux-arm64-musl@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-linux-arm64-musl@npm:2.0.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-gnu@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-linux-x64-gnu@npm:2.0.0-beta.9"
+"@rspack/binding-linux-x64-gnu@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-linux-x64-gnu@npm:2.0.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-musl@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-linux-x64-musl@npm:2.0.0-beta.9"
+"@rspack/binding-linux-x64-musl@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-linux-x64-musl@npm:2.0.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-wasm32-wasi@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-wasm32-wasi@npm:2.0.0-beta.9"
+"@rspack/binding-wasm32-wasi@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-wasm32-wasi@npm:2.0.3"
   dependencies:
-    "@napi-rs/wasm-runtime": "npm:1.1.1"
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:1.1.4"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-arm64-msvc@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.0.0-beta.9"
+"@rspack/binding-win32-arm64-msvc@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.0.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-ia32-msvc@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.0.0-beta.9"
+"@rspack/binding-win32-ia32-msvc@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.0.3"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-x64-msvc@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding-win32-x64-msvc@npm:2.0.0-beta.9"
+"@rspack/binding-win32-x64-msvc@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding-win32-x64-msvc@npm:2.0.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/binding@npm:2.0.0-beta.9"
+"@rspack/binding@npm:2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/binding@npm:2.0.3"
   dependencies:
-    "@rspack/binding-darwin-arm64": "npm:2.0.0-beta.9"
-    "@rspack/binding-darwin-x64": "npm:2.0.0-beta.9"
-    "@rspack/binding-linux-arm64-gnu": "npm:2.0.0-beta.9"
-    "@rspack/binding-linux-arm64-musl": "npm:2.0.0-beta.9"
-    "@rspack/binding-linux-x64-gnu": "npm:2.0.0-beta.9"
-    "@rspack/binding-linux-x64-musl": "npm:2.0.0-beta.9"
-    "@rspack/binding-wasm32-wasi": "npm:2.0.0-beta.9"
-    "@rspack/binding-win32-arm64-msvc": "npm:2.0.0-beta.9"
-    "@rspack/binding-win32-ia32-msvc": "npm:2.0.0-beta.9"
-    "@rspack/binding-win32-x64-msvc": "npm:2.0.0-beta.9"
+    "@rspack/binding-darwin-arm64": "npm:2.0.3"
+    "@rspack/binding-darwin-x64": "npm:2.0.3"
+    "@rspack/binding-linux-arm64-gnu": "npm:2.0.3"
+    "@rspack/binding-linux-arm64-musl": "npm:2.0.3"
+    "@rspack/binding-linux-x64-gnu": "npm:2.0.3"
+    "@rspack/binding-linux-x64-musl": "npm:2.0.3"
+    "@rspack/binding-wasm32-wasi": "npm:2.0.3"
+    "@rspack/binding-win32-arm64-msvc": "npm:2.0.3"
+    "@rspack/binding-win32-ia32-msvc": "npm:2.0.3"
+    "@rspack/binding-win32-x64-msvc": "npm:2.0.3"
   dependenciesMeta:
     "@rspack/binding-darwin-arm64":
       optional: true
@@ -2190,15 +2176,15 @@ __metadata:
       optional: true
     "@rspack/binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/246eebd14a5573351b03b71b6d55fac7dde8106e00d8d99eb8b91e2324bb5f35ecc8e99d001ca367e64f7ba8795cdab2dd420eceebd094ef6c0b84614deb8daa
+  checksum: 10c0/7089971775d41224f2299189ae253eefff3533970b34008202f3e6b72776c9e238efc3412aca68aa95fec9c0f1155b25d96d40581332ecd0e35514718f5c612c
   languageName: node
   linkType: hard
 
-"@rspack/core@npm:2.0.0-beta.9":
-  version: 2.0.0-beta.9
-  resolution: "@rspack/core@npm:2.0.0-beta.9"
+"@rspack/core@npm:~2.0.3":
+  version: 2.0.3
+  resolution: "@rspack/core@npm:2.0.3"
   dependencies:
-    "@rspack/binding": "npm:2.0.0-beta.9"
+    "@rspack/binding": "npm:2.0.3"
   peerDependencies:
     "@module-federation/runtime-tools": ^0.24.1 || ^2.0.0
     "@swc/helpers": ">=0.5.1"
@@ -2207,59 +2193,51 @@ __metadata:
       optional: true
     "@swc/helpers":
       optional: true
-  checksum: 10c0/9bea496ef3b528d78e60f66a28f5c4bd70228d16176de393287fe733dcaf84a3a37703fb8fd5274d28a2bf8fe1b3b66f71688e2e265d8e6b62ae372e64d846a1
+  checksum: 10c0/767a1545f19cfc983994684c1725bcc4cefffc49095f7194376f840d1137cd4f9f93c40e58e091757da57a517f9219fd316c0e5c080f2b6040b11be976e6988b
   languageName: node
   linkType: hard
 
-"@rspack/plugin-react-refresh@npm:^1.6.1":
-  version: 1.6.1
-  resolution: "@rspack/plugin-react-refresh@npm:1.6.1"
-  dependencies:
-    error-stack-parser: "npm:^2.1.4"
-    html-entities: "npm:^2.6.0"
+"@rspack/plugin-react-refresh@npm:2.0.0":
+  version: 2.0.0
+  resolution: "@rspack/plugin-react-refresh@npm:2.0.0"
   peerDependencies:
+    "@rspack/core": ^2.0.0-0
     react-refresh: ">=0.10.0 <1.0.0"
-    webpack-hot-middleware: 2.x
   peerDependenciesMeta:
-    webpack-hot-middleware:
+    "@rspack/core":
       optional: true
-  checksum: 10c0/4e6ca235fcf9ddebd86894827ba85df8e97a6f3b97a925876549aa07ac995ffeba954ebe52075110b7e98aef648df730dced8faa0c31d86689eaffcb097cae12
+  checksum: 10c0/ee8e6492c0772536abb98ab5ec92d0e4ad092613a3a6085542f0b354131eef48f4d7cbe9a8cf9a9389d5e51d623d08a2c07594c8add5ad5fb54fd5543150ead1
   languageName: node
   linkType: hard
 
-"@rspress/core@npm:2.0.8":
-  version: 2.0.8
-  resolution: "@rspress/core@npm:2.0.8"
+"@rspress/core@npm:2.0.11":
+  version: 2.0.11
+  resolution: "@rspress/core@npm:2.0.11"
   dependencies:
     "@mdx-js/mdx": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"
-    "@rsbuild/core": "npm:2.0.0-beta.11"
-    "@rsbuild/plugin-react": "npm:~1.4.6"
-    "@rspress/shared": "npm:2.0.8"
+    "@rsbuild/core": "npm:^2.0.5"
+    "@rsbuild/plugin-react": "npm:~2.0.0"
+    "@rspress/shared": "npm:2.0.11"
     "@shikijs/rehype": "npm:^4.0.2"
     "@types/unist": "npm:^3.0.3"
-    "@unhead/react": "npm:^2.1.12"
+    "@unhead/react": "npm:^2.1.15"
     body-scroll-lock: "npm:4.0.0-beta.0"
-    cac: "npm:^7.0.0"
-    chokidar: "npm:^3.6.0"
     clsx: "npm:2.1.1"
     copy-to-clipboard: "npm:^3.3.3"
     flexsearch: "npm:0.8.212"
-    github-slugger: "npm:^2.0.0"
     hast-util-heading-rank: "npm:^3.0.0"
     hast-util-to-jsx-runtime: "npm:^2.3.6"
-    lodash-es: "npm:^4.17.23"
     mdast-util-mdx: "npm:^3.0.0"
     mdast-util-mdxjs-esm: "npm:^2.0.1"
     medium-zoom: "npm:1.1.0"
     nprogress: "npm:^0.2.0"
-    picocolors: "npm:^1.1.1"
-    react: "npm:^19.2.4"
-    react-dom: "npm:^19.2.4"
+    react: "npm:^19.2.6"
+    react-dom: "npm:^19.2.6"
     react-lazy-with-preload: "npm:^2.2.1"
     react-reconciler: "npm:0.33.0"
     react-render-to-markdown: "npm:19.0.1"
-    react-router-dom: "npm:^7.13.2"
+    react-router-dom: "npm:^7.15.0"
     rehype-external-links: "npm:^3.0.0"
     rehype-raw: "npm:^7.0.0"
     remark-cjk-friendly: "npm:^2.0.1"
@@ -2270,49 +2248,45 @@ __metadata:
     remark-stringify: "npm:^11.0.0"
     scroll-into-view-if-needed: "npm:^3.1.0"
     shiki: "npm:^4.0.2"
-    tinyglobby: "npm:^0.2.15"
-    tinypool: "npm:^1.1.1"
     unified: "npm:^11.0.5"
     unist-util-remove: "npm:^4.0.0"
-    unist-util-visit: "npm:^5.0.0"
+    unist-util-visit: "npm:^5.1.0"
     unist-util-visit-children: "npm:^3.0.0"
   bin:
     rspress: bin/rspress.js
-  checksum: 10c0/10255982ea226a41087c04975aa1bdc64f9e5ea3d39ac39909b0078840cc1314c83231b4ccc75b46e6a9bb6cfad2e828d16a39f705cb38a02c585efcc7711f44
+  checksum: 10c0/962d0ce4b401d6b82e9e0acedcc615832c29b76fbef8af983af343a08df5ffc85134cb3670dcc410ecb7ad192e858f5f7730256580e5754d2b42f248bee2ab32
   languageName: node
   linkType: hard
 
-"@rspress/plugin-algolia@npm:2.0.8":
-  version: 2.0.8
-  resolution: "@rspress/plugin-algolia@npm:2.0.8"
+"@rspress/plugin-algolia@npm:2.0.11":
+  version: 2.0.11
+  resolution: "@rspress/plugin-algolia@npm:2.0.11"
   dependencies:
-    "@docsearch/css": "npm:^4.6.2"
-    "@docsearch/react": "npm:^4.6.2"
+    "@docsearch/css": "npm:^4.6.3"
+    "@docsearch/react": "npm:^4.6.3"
   peerDependencies:
-    "@rspress/core": ^2.0.8
-  checksum: 10c0/fe25afffe62e5e577036e7746c41ab3fa0364964cdecdf40ae35d28fc8300b0c9d35b3690d89453f8d90d8bfd0eb344ad90aca1bf4b1c4124fd32cf8f1bec7cc
+    "@rspress/core": ^2.0.10
+  checksum: 10c0/3693fa981c78b4e93816b08524b1e715ca8c03aa400461f271e405842f0a6f586e801b9560714398725fdbde60fc4cb7a0722213d93fe16e79cdb4d8f18ad6c2
   languageName: node
   linkType: hard
 
-"@rspress/plugin-sitemap@npm:2.0.8":
-  version: 2.0.8
-  resolution: "@rspress/plugin-sitemap@npm:2.0.8"
+"@rspress/plugin-sitemap@npm:2.0.11":
+  version: 2.0.11
+  resolution: "@rspress/plugin-sitemap@npm:2.0.11"
   peerDependencies:
-    "@rspress/core": ^2.0.8
-  checksum: 10c0/8862b3c27c99e92bd77566f2d6611e308a5d8a95eb1bc8288af4c590dda1ca474ec6229b30bae7c98773a4a5076d2432294e0ac0a41bfd7d968a6ae153c2f1f8
+    "@rspress/core": ^2.0.10
+  checksum: 10c0/4583ceaa147713877f4ebaf5e74529d5569254b039d0bb7cd2be33f02c533bd4a82c4181d787da8e59c9adefdc4188337c0a277ee00f302f15f8f515cf5f2eb4
   languageName: node
   linkType: hard
 
-"@rspress/shared@npm:2.0.8":
-  version: 2.0.8
-  resolution: "@rspress/shared@npm:2.0.8"
+"@rspress/shared@npm:2.0.11":
+  version: 2.0.11
+  resolution: "@rspress/shared@npm:2.0.11"
   dependencies:
-    "@rsbuild/core": "npm:2.0.0-beta.11"
+    "@rsbuild/core": "npm:^2.0.5"
     "@shikijs/rehype": "npm:^4.0.2"
-    gray-matter: "npm:4.0.3"
-    lodash-es: "npm:^4.17.23"
     unified: "npm:^11.0.5"
-  checksum: 10c0/cfcebcce8b1d14f810cbfd691a6c9d886843c56a852e51197af937e21f3d0111f144d8b988f1bcd09584ac8927dd65a47baefa36ff93e2b3ecda028aee8dc844
+  checksum: 10c0/2d396c95019f8af01165e9506f4edc6033eb6e6609d6fa359c3a5b3a982cc15b39931eacb041cee67f4b16fdee896ccae0371a8ff4a139bf98b686015d48b115
   languageName: node
   linkType: hard
 
@@ -2576,7 +2550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:^0.5.20":
+"@swc/helpers@npm:^0.5.21":
   version: 0.5.21
   resolution: "@swc/helpers@npm:0.5.21"
   dependencies:
@@ -3029,112 +3003,105 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.59.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.0"
+"@typescript-eslint/eslint-plugin@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.3"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.59.0"
-    "@typescript-eslint/type-utils": "npm:8.59.0"
-    "@typescript-eslint/utils": "npm:8.59.0"
-    "@typescript-eslint/visitor-keys": "npm:8.59.0"
+    "@typescript-eslint/scope-manager": "npm:8.59.3"
+    "@typescript-eslint/type-utils": "npm:8.59.3"
+    "@typescript-eslint/utils": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
     ignore: "npm:^7.0.5"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.59.0
+    "@typescript-eslint/parser": ^8.59.3
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/f98171ecad6a5106fe978df155f4b65a72dfdadfcd663651b633b61480b543e74796baa224a1393e323f9514901604fe6302323c4b80b79f7a98512a01bc6461
+  checksum: 10c0/c316ba4af95c7408c65279005099386c1547c184929b7027a1041a2450537d5ce7bd9276e0d6774ae384f9e4482e392dc3305686442d64777c448d76f39fd665
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.59.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/parser@npm:8.59.0"
+"@typescript-eslint/parser@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/parser@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.59.0"
-    "@typescript-eslint/types": "npm:8.59.0"
-    "@typescript-eslint/typescript-estree": "npm:8.59.0"
-    "@typescript-eslint/visitor-keys": "npm:8.59.0"
+    "@typescript-eslint/scope-manager": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/996a7b43f8a515ebbd06455c9f53065c561c8519bc4f634d6783b92832aa69e47945478d1601a87582f9f7b303becc172d5d7f776e201b2a2d375bc762ad4015
+  checksum: 10c0/a5e16163e6fdeff411272e8fa2e26b48c28aae3003ff2a6b52e7c7727061170afde11261feefba0b578399774a6c9b26e5d58d593e66b25f88a4552e6012d9e2
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.59.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/project-service@npm:8.59.0"
+"@typescript-eslint/project-service@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/project-service@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.59.0"
-    "@typescript-eslint/types": "npm:^8.59.0"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.59.3"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/ffba9595a427235bbeb0e5c7db3486f8d01dd8f8686964b4f82084e82008c49b897d01c4d331f33a9ce29edae70a9286f6fdedec4bf9037d732d9c9e86ebc7ea
+  checksum: 10c0/14caf773ce7198e097e7cf1ba65b0dfd0553696b5ffc1842f0f5bbc877450d1aab599dd0209b1bca66e4a03ba176051dfa13e30005b8f0a96453d7a01e8d8ba6
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.59.0, @typescript-eslint/scope-manager@npm:^8.58.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.59.0"
+"@typescript-eslint/scope-manager@npm:8.59.3, @typescript-eslint/scope-manager@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.0"
-    "@typescript-eslint/visitor-keys": "npm:8.59.0"
-  checksum: 10c0/d372f08be190d01e6d237932dc0d77808a9dc0a34fe8f690a3eac496d6e2f93c030c6ccb5000b35e825a6cfc4d9ca69a00f2ccda334115a9865a9d02cd603e52
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+  checksum: 10c0/716c342e3e4963431696f4a68c616e0afdb619a94fabf448d032a9a676d75d39d60926cd6b47ccd712c722f7cf549a2f623f97049017f36e953dd9b7b348e9bd
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.59.0, @typescript-eslint/tsconfig-utils@npm:^8.59.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.0"
+"@typescript-eslint/tsconfig-utils@npm:8.59.3, @typescript-eslint/tsconfig-utils@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/ab482c22f23774d24b3048c9fcdc5e0b94137064b3af901f4b0327da2270c2b2961c19165ccf8bdeaedfa83138be98c5cd8edcdc89deb6187baf6438cd8584b0
+  checksum: 10c0/326c07ae30e04734b28830ff74fbc8478f58671f0111a540854064d5a1cd15ed22056453165200ce342de9758e4ce45c827068017701dfb8390ec1c6b3c990ab
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.59.0, @typescript-eslint/type-utils@npm:^8.58.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/type-utils@npm:8.59.0"
+"@typescript-eslint/type-utils@npm:8.59.3, @typescript-eslint/type-utils@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/type-utils@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.0"
-    "@typescript-eslint/typescript-estree": "npm:8.59.0"
-    "@typescript-eslint/utils": "npm:8.59.0"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/utils": "npm:8.59.3"
     debug: "npm:^4.4.3"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/e2f2176a9bce81c19b53accf4e9189c60b1b84717cf129a6d003a2271019e30d410d2ccdc0fc6a37cbb8274a1b297d7d30a116189110f9d24a86391ee24a9fef
+  checksum: 10c0/ff0dfb47fafe6046c0cf08b1790db41dc8e0b93dfa5bdd69f78d1cb58880b85bfb7930079c417664498a203b894381b228141efc27f427d1969c6aecc25e63b9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.59.0, @typescript-eslint/types@npm:^8.59.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/types@npm:8.59.0"
-  checksum: 10c0/2750b1e21290dffe90a424fe05c2bab701f60a7b51b5e0921ed14bb1a5fc29ff3fe8f286817d2287e93ff78e33e6626f6ce26d0bc79a729bd608deda77a9bdde
+"@typescript-eslint/types@npm:8.59.3, @typescript-eslint/types@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/types@npm:8.59.3"
+  checksum: 10c0/3f7836ce108c3098935180221abce6d9dbf3583216b895525b0a1fc8d0207ebe1ba9e571dbb45eddacd14ef99563350b9b51df3091258211f8d267f02b9a80c1
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:^8.58.0":
-  version: 8.58.0
-  resolution: "@typescript-eslint/types@npm:8.58.0"
-  checksum: 10c0/f2fe1321758a04591c20d77caba956ae76b77cff0b976a0224b37077d80b1ebd826874d15ec79c3a3b7d57ee5679e5d10756db1b082bde3d51addbd3a8431d38
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.59.0, @typescript-eslint/typescript-estree@npm:^8.58.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.59.0"
+"@typescript-eslint/typescript-estree@npm:8.59.3, @typescript-eslint/typescript-estree@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.59.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.59.0"
-    "@typescript-eslint/types": "npm:8.59.0"
-    "@typescript-eslint/visitor-keys": "npm:8.59.0"
+    "@typescript-eslint/project-service": "npm:8.59.3"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/visitor-keys": "npm:8.59.3"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -3142,32 +3109,32 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/82d3dfb4de591d9a39d2c4dafc13f14b4940f5b116fb3db311935137aa7e34c9dce3209aaeace118070847b2355df7c185ff1e0f2a36232c3aea9b5fa2652f98
+  checksum: 10c0/d23d4efa17ebfceaca741e0656f4cc69f6429fad0bba87fa79cf08b6b67e487282241fd4211ae69d1b9eae1e5746db849e2e29518a385ee981a55f297db58906
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.59.0, @typescript-eslint/utils@npm:^8.58.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/utils@npm:8.59.0"
+"@typescript-eslint/utils@npm:8.59.3, @typescript-eslint/utils@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/utils@npm:8.59.3"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.59.0"
-    "@typescript-eslint/types": "npm:8.59.0"
-    "@typescript-eslint/typescript-estree": "npm:8.59.0"
+    "@typescript-eslint/scope-manager": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/eca4e5a18ae8e8c4360b05758fa142465daef3a9dffe4d78b15607b4680698eece96f899bce1e8d83427da74ddfbca80a95456727b8b9239816528978180b047
+  checksum: 10c0/a8299781be03e43f9a0f4006e607cfaa1094e2d5b1a208e7f2b994841884f08b557ce51d97d128b892b335a99b1bffa151eb4c0173aafec5d012783656e222f0
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.59.0":
-  version: 8.59.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.59.0"
+"@typescript-eslint/visitor-keys@npm:8.59.3":
+  version: 8.59.3
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.0"
+    "@typescript-eslint/types": "npm:8.59.3"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/09ec24c9c9d0a3ccb57bb2ab3dfd8deca124339aba6621503285c22765a4dfc89bf3d31e337dd647b1cdf89bac384e3a62e0f5b8c1d5a93d16d1f417144e3226
+  checksum: 10c0/124c1ecece3f1ea954a05b150f8ec89b1c790276baa6e60c542a006cf3e14ce2c6152f95f06740e73609c36c6db0eeba98caba572d19db0befaef8aaba6f9569
   languageName: node
   linkType: hard
 
@@ -3178,14 +3145,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unhead/react@npm:^2.1.12":
-  version: 2.1.13
-  resolution: "@unhead/react@npm:2.1.13"
+"@unhead/react@npm:^2.1.15":
+  version: 2.1.15
+  resolution: "@unhead/react@npm:2.1.15"
   dependencies:
-    unhead: "npm:2.1.13"
+    unhead: "npm:2.1.15"
   peerDependencies:
     react: ">=18.3.1"
-  checksum: 10c0/1c3f892839028d264ca30967fc08383390d377f72fe15144ca17519b291af6cfad61ca7b2e7bb24cd7ad42375da87a4a3ffb7733e81a3ed3f95a60c8c3c935ae
+  checksum: 10c0/0a341187a86b9ac38065b521cad124bc0f8092052507551ffbc2d9538598c0dfcd0be7c473a9d117c20949aae0a02fced271a9b81d3826a6d62c0c69e1b4482b
   languageName: node
   linkType: hard
 
@@ -3292,25 +3259,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:~3.1.2":
-  version: 3.1.3
-  resolution: "anymatch@npm:3.1.3"
-  dependencies:
-    normalize-path: "npm:^3.0.0"
-    picomatch: "npm:^2.0.4"
-  checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
-  languageName: node
-  linkType: hard
-
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
-  languageName: node
-  linkType: hard
-
 "argparse@npm:^2.0.1":
   version: 2.0.1
   resolution: "argparse@npm:2.0.1"
@@ -3371,13 +3319,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-extensions@npm:^2.0.0":
-  version: 2.3.0
-  resolution: "binary-extensions@npm:2.3.0"
-  checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
-  languageName: node
-  linkType: hard
-
 "birecord@npm:^0.1.1":
   version: 0.1.1
   resolution: "birecord@npm:0.1.1"
@@ -3417,15 +3358,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:~3.0.2":
-  version: 3.0.3
-  resolution: "braces@npm:3.0.3"
-  dependencies:
-    fill-range: "npm:^7.1.1"
-  checksum: 10c0/7c6dfd30c338d2997ba77500539227b9d1f85e388a5f43220865201e407e076783d0881f2d297b9f80951b4c957fcf0b51c1d2d24227631643c3f7c284b0aa04
-  languageName: node
-  linkType: hard
-
 "browserslist@npm:^4.24.0":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
@@ -3445,13 +3377,6 @@ __metadata:
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
   checksum: 10c0/124fff9d66d691a86d3b062eff4663fe437a9d9ee4b47b1b9e97f5a5d14f6d5399345db80f796827be7c95e70a8e765dd404b7c3ff3b3324f98e9b0c8826cc34
-  languageName: node
-  linkType: hard
-
-"cac@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "cac@npm:7.0.0"
-  checksum: 10c0/e9da33cb9f0425546ae92a450d479276f9969a050fe64f5d6fedf058bdd87f22a370797fe1c158e07655fa9fc183749df7cb2037431e3772faa7bee9919fb763
   languageName: node
   linkType: hard
 
@@ -3543,50 +3468,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chevrotain-allstar@npm:~0.3.1":
-  version: 0.3.1
-  resolution: "chevrotain-allstar@npm:0.3.1"
-  dependencies:
-    lodash-es: "npm:^4.17.21"
-  peerDependencies:
-    chevrotain: ^11.0.0
-  checksum: 10c0/5cadedffd3114eb06b15fd3939bb1aa6c75412dbd737fe302b52c5c24334f9cb01cee8edc1d1067d98ba80dddf971f1d0e94b387de51423fc6cf3c5d8b7ef27a
-  languageName: node
-  linkType: hard
-
-"chevrotain@npm:~11.1.1":
-  version: 11.1.2
-  resolution: "chevrotain@npm:11.1.2"
-  dependencies:
-    "@chevrotain/cst-dts-gen": "npm:11.1.2"
-    "@chevrotain/gast": "npm:11.1.2"
-    "@chevrotain/regexp-to-ast": "npm:11.1.2"
-    "@chevrotain/types": "npm:11.1.2"
-    "@chevrotain/utils": "npm:11.1.2"
-    lodash-es: "npm:4.17.23"
-  checksum: 10c0/7f0b5780035c582d4c620c81e1fbb58c9f41a69f1c7efdae96819c7bc0928ddb4f046bb8239e71539f383b3b8ce460bd11f44b5fb5107e1d45a0cc91bd6a4198
-  languageName: node
-  linkType: hard
-
-"chokidar@npm:^3.6.0":
-  version: 3.6.0
-  resolution: "chokidar@npm:3.6.0"
-  dependencies:
-    anymatch: "npm:~3.1.2"
-    braces: "npm:~3.0.2"
-    fsevents: "npm:~2.3.2"
-    glob-parent: "npm:~5.1.2"
-    is-binary-path: "npm:~2.1.0"
-    is-glob: "npm:~4.0.1"
-    normalize-path: "npm:~3.0.0"
-    readdirp: "npm:~3.6.0"
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: 10c0/8361dcd013f2ddbe260eacb1f3cb2f2c6f2b0ad118708a343a5ed8158941a39cb8fb1d272e0f389712e74ee90ce8ba864eece9e0e62b9705cb468a2f6d917462
-  languageName: node
-  linkType: hard
-
 "chokidar@npm:^4.0.0":
   version: 4.0.3
   resolution: "chokidar@npm:4.0.3"
@@ -3616,13 +3497,6 @@ __metadata:
   version: 4.4.0
   resolution: "ci-info@npm:4.4.0"
   checksum: 10c0/44156201545b8dde01aa8a09ee2fe9fc7a73b1bef9adbd4606c9f61c8caeeb73fb7a575c88b0443f7b4edb5ee45debaa59ed54ba5f99698339393ca01349eb3a
-  languageName: node
-  linkType: hard
-
-"classnames@npm:^2.3.0":
-  version: 2.5.1
-  resolution: "classnames@npm:2.5.1"
-  checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
   languageName: node
   linkType: hard
 
@@ -4537,12 +4411,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ejs@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "ejs@npm:5.0.1"
+"ejs@npm:^5.0.2":
+  version: 5.0.2
+  resolution: "ejs@npm:5.0.2"
   bin:
     ejs: bin/cli.js
-  checksum: 10c0/7791e4d621e1c050b4310b87b75b43bb18de20cbe4560ee4640693ec052a19ae884df838ed4e391c26ec25530af90b58c35a3465462b6b1734e4b084ce45f872
+  checksum: 10c0/6377ba83487e9e818dd77ab92d67a5f6c0d093689fa500aa0654305f4c19af13a30a606cc6286b8dfef1cf8aae89a71130af16aca5b72dc500a4a44ac3aa13bf
   languageName: node
   linkType: hard
 
@@ -4627,15 +4501,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"error-stack-parser@npm:^2.1.4":
-  version: 2.1.4
-  resolution: "error-stack-parser@npm:2.1.4"
-  dependencies:
-    stackframe: "npm:^1.3.4"
-  checksum: 10c0/7679b780043c98b01fc546725484e0cfd3071bf5c906bbe358722972f04abf4fc3f0a77988017665bab367f6ef3fc2d0185f7528f45966b83e7c99c02d5509b9
-  languageName: node
-  linkType: hard
-
 "es-toolkit@npm:^1.45.1":
   version: 1.45.1
   resolution: "es-toolkit@npm:1.45.1"
@@ -4645,6 +4510,18 @@ __metadata:
     prettier-plugin-sort-re-exports@0.0.1:
       unplugged: true
   checksum: 10c0/b19180c778af8fe2fb450e8e05a5793166c91e0aa66b87d9fcfcc5618bd33e6ceec9c103e074458d32b2044972dc4fc63631b3b615834fde261917e9561f6f59
+  languageName: node
+  linkType: hard
+
+"es-toolkit@npm:^1.46.1":
+  version: 1.46.1
+  resolution: "es-toolkit@npm:1.46.1"
+  dependenciesMeta:
+    "@trivago/prettier-plugin-sort-imports@4.3.0":
+      unplugged: true
+    prettier-plugin-sort-re-exports@0.0.1:
+      unplugged: true
+  checksum: 10c0/6a4c3dd0ddc2138fa13d983d93ebaf8061759c52c2cf7c3101315139fc1fca826d253daa67fe85ad880c03cc4c092bd53a83a7cbf58b4721c251479122ba5303
   languageName: node
   linkType: hard
 
@@ -4746,130 +4623,121 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:4.2.3":
-  version: 4.2.3
-  resolution: "eslint-plugin-react-dom@npm:4.2.3"
+"eslint-plugin-react-dom@npm:5.7.9":
+  version: 5.7.9
+  resolution: "eslint-plugin-react-dom@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/core": "npm:4.2.3"
-    "@eslint-react/jsx": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/jsx": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     compare-versions: "npm:^6.1.1"
-    ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/2eea5ccb22851467635b25f33eef50dc5ac7dd165171bde5e50ba27e8c878382423ec86663b296a7c52ba84e8b0870fec510cd1361078efbfff9423ec9f9d45c
+  checksum: 10c0/d4d76d6ef31ff147ab32aff6f583b00e97225e5b9a6250943ccee77598867e92ee57d6563d1b7e2f8f66f25cea815865ab031cf7cf81cc5766955e2e50e9bfe4
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-jsx@npm:4.2.3":
-  version: 4.2.3
-  resolution: "eslint-plugin-react-jsx@npm:4.2.3"
+"eslint-plugin-react-jsx@npm:5.7.9":
+  version: 5.7.9
+  resolution: "eslint-plugin-react-jsx@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/core": "npm:4.2.3"
-    "@eslint-react/jsx": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
-    compare-versions: "npm:^6.1.1"
-    ts-pattern: "npm:^5.9.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/core": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/jsx": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/4ae344c462a96ba72b096c0395b2a919d7205fce73abb31cd988cd05a869594ca20b67df1a1d16fc335cb1e37be237a2caede4ebf00eaf8c3ca7adbfb7419fab
+  checksum: 10c0/1d788ebfb75476bc4078778efd22ac6c6c65f70b5f3d130005c8871f38884792ac73ddb1c34bf904cf01710ff93cef7fb20b085f871cb1b33874c5ba7fca7a6d
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:4.2.3":
-  version: 4.2.3
-  resolution: "eslint-plugin-react-naming-convention@npm:4.2.3"
+"eslint-plugin-react-naming-convention@npm:5.7.9":
+  version: 5.7.9
+  resolution: "eslint-plugin-react-naming-convention@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/core": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/type-utils": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
-    compare-versions: "npm:^6.1.1"
-    string-ts: "npm:^2.3.1"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/core": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/var": "npm:5.7.9"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/a48fd669a895e188d9b24064728768552b63c06c3fc51d3fe09e6b57bf97fbcd94232ab114ed49593862606a1cc9f8a9141e1ba4cfb2dc04dfaf87808e918eba
+  checksum: 10c0/4422741fb8c66b2414011bd9dd4eda69c2c8aff990c2a7e5cc4a0778d327f5e0b6bf7aad41d829cbb5db9b9d7be967443343f3bc89ef1beca9c40e8892120ad8
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-rsc@npm:4.2.3":
-  version: 4.2.3
-  resolution: "eslint-plugin-react-rsc@npm:4.2.3"
+"eslint-plugin-react-rsc@npm:5.7.9":
+  version: 5.7.9
+  resolution: "eslint-plugin-react-rsc@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/type-utils": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
-    ts-pattern: "npm:^5.9.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/core": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@eslint-react/var": "npm:5.7.9"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/8454afdf2f763b7b952b305372cd3081751a33a82a796428ba4694afaefa36e340589920475285273f94a3f1062e851993f3f3bb9736e4f65c5ca120bc773c17
+  checksum: 10c0/64e446bbb02ce4d12a6e798ac1e49b5ff5c823adf2739d3b3faec6341c6eb46fa84e8da2119148d2736f9a8fc1d053108fbb8db1ddd1c2ef58117620dc26ba6a
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:4.2.3":
-  version: 4.2.3
-  resolution: "eslint-plugin-react-web-api@npm:4.2.3"
+"eslint-plugin-react-web-api@npm:5.7.9":
+  version: 5.7.9
+  resolution: "eslint-plugin-react-web-api@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/core": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/core": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@eslint-react/var": "npm:5.7.9"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/0d29679164815301587a4d998b25588690c3ba6a60f7c0b7ccb0e7670916422df99464226335c185fbcbd4fa96ff5c3206415f0bce4d4e37330099e8767f335d
+  checksum: 10c0/5f1ffd2ecdff27135b272988bd082e2395bcc9eed878b8dfd20a40e62a6cac8510770d049622e0b64692ae383b93eaeea07fc0147e92dc22bbf1a66a3fd4cd30
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:4.2.3":
-  version: 4.2.3
-  resolution: "eslint-plugin-react-x@npm:4.2.3"
+"eslint-plugin-react-x@npm:5.7.9":
+  version: 5.7.9
+  resolution: "eslint-plugin-react-x@npm:5.7.9"
   dependencies:
-    "@eslint-react/ast": "npm:4.2.3"
-    "@eslint-react/core": "npm:4.2.3"
-    "@eslint-react/jsx": "npm:4.2.3"
-    "@eslint-react/shared": "npm:4.2.3"
-    "@eslint-react/var": "npm:4.2.3"
-    "@typescript-eslint/scope-manager": "npm:^8.58.0"
-    "@typescript-eslint/type-utils": "npm:^8.58.0"
-    "@typescript-eslint/types": "npm:^8.58.0"
-    "@typescript-eslint/utils": "npm:^8.58.0"
+    "@eslint-react/ast": "npm:5.7.9"
+    "@eslint-react/core": "npm:5.7.9"
+    "@eslint-react/eslint": "npm:5.7.9"
+    "@eslint-react/jsx": "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.7.9"
+    "@eslint-react/var": "npm:5.7.9"
+    "@typescript-eslint/scope-manager": "npm:^8.59.3"
+    "@typescript-eslint/type-utils": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.3"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.3.1"
     ts-api-utils: "npm:^2.5.0"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
-    eslint: ^10.0.0
+    eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/d196e8594ce5ae16fd1a8150def1730ea10172ecfbdb5d7317d5bac69d15f0a2b30aeb30c187cec7a4ad8ffbea7a4355ee4118739a1c900e406907df5dc4987b
+  checksum: 10c0/7352d2cecfce56719dc80a0bb42def91d03fb880957d44d5e7af0d1305e8485ca6cd075c47bf5473de89679a63442165387877746826207f58ae60caac663c36
   languageName: node
   linkType: hard
 
@@ -4906,14 +4774,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^10.2.0":
-  version: 10.2.1
-  resolution: "eslint@npm:10.2.1"
+"eslint@npm:^10.3.0":
+  version: 10.4.0
+  resolution: "eslint@npm:10.4.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.8.0"
     "@eslint-community/regexpp": "npm:^4.12.2"
     "@eslint/config-array": "npm:^0.23.5"
-    "@eslint/config-helpers": "npm:^0.5.5"
+    "@eslint/config-helpers": "npm:^0.6.0"
     "@eslint/core": "npm:^1.2.1"
     "@eslint/plugin-kit": "npm:^0.7.1"
     "@humanfs/node": "npm:^0.16.6"
@@ -4947,7 +4815,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/176795a3794a785502fa5cd14a9609264c2be5405552d20fed3e499bd465c29639c91ac44619ae66787b0fb7494e72d112550a2136a735d92a26bc6a7af4915c
+  checksum: 10c0/6bf644dc08fa5a6b23157d23a4a4638d45823d03a67da1daac8dc1085b03934fa98013efd2eac2cd6ec90fe88d36b336bdf38d5f000325f22d823a15f2031426
   languageName: node
   linkType: hard
 
@@ -4973,7 +4841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0, esprima@npm:^4.0.1":
+"esprima@npm:^4.0.1":
   version: 4.0.1
   resolution: "esprima@npm:4.0.1"
   bin:
@@ -5097,15 +4965,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend-shallow@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "extend-shallow@npm:2.0.1"
-  dependencies:
-    is-extendable: "npm:^0.1.0"
-  checksum: 10c0/ee1cb0a18c9faddb42d791b2d64867bd6cfd0f3affb711782eb6e894dd193e2934a7f529426aac7c8ddb31ac5d38000a00aa2caf08aa3dfc3e1c8ff6ba340bd9
-  languageName: node
-  linkType: hard
-
 "extend@npm:^3.0.0":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
@@ -5203,15 +5062,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fill-range@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "fill-range@npm:7.1.1"
-  dependencies:
-    to-regex-range: "npm:^5.0.1"
-  checksum: 10c0/b75b691bbe065472f38824f694c2f7449d7f5004aa950426a2c28f0306c60db9b880c0b0e4ed819997ffb882d1da02cfcfc819bddc94d71627f5269682edf018
-  languageName: node
-  linkType: hard
-
 "find-up@npm:^5.0.0":
   version: 5.0.0
   resolution: "find-up@npm:5.0.0"
@@ -5281,7 +5131,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:2.3.2, fsevents@npm:~2.3.2":
+"fsevents@npm:2.3.2":
   version: 2.3.2
   resolution: "fsevents@npm:2.3.2"
   dependencies:
@@ -5291,7 +5141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>, fsevents@patch:fsevents@npm%3A~2.3.2#optional!builtin<compat/fsevents>":
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
   version: 2.3.2
   resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
   dependencies:
@@ -5335,28 +5185,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"github-slugger@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "github-slugger@npm:2.0.0"
-  checksum: 10c0/21b912b6b1e48f1e5a50b2292b48df0ff6abeeb0691b161b3d93d84f4ae6b1acd6ae23702e914af7ea5d441c096453cf0f621b72d57893946618d21dd1a1c486
-  languageName: node
-  linkType: hard
-
 "glob-parent@npm:^6.0.2":
   version: 6.0.2
   resolution: "glob-parent@npm:6.0.2"
   dependencies:
     is-glob: "npm:^4.0.3"
   checksum: 10c0/317034d88654730230b3f43bb7ad4f7c90257a426e872ea0bf157473ac61c99bf5d205fad8f0185f989be8d2fa6d3c7dce1645d99d545b6ea9089c39f838e7f8
-  languageName: node
-  linkType: hard
-
-"glob-parent@npm:~5.1.2":
-  version: 5.1.2
-  resolution: "glob-parent@npm:5.1.2"
-  dependencies:
-    is-glob: "npm:^4.0.1"
-  checksum: 10c0/cab87638e2112bee3f839ef5f6e0765057163d39c66be8ec1602f3823da4692297ad4e972de876ea17c44d652978638d2fd583c6713d0eb6591706825020c9ee
   languageName: node
   linkType: hard
 
@@ -5396,10 +5230,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globals@npm:^17.4.0":
-  version: 17.4.0
-  resolution: "globals@npm:17.4.0"
-  checksum: 10c0/2be9e8c2b9035836f13d420b22f0247a328db82967d3bebfc01126d888ed609305f06c05895914e969653af5c6ba35fd7a0920f3e6c869afa60666c810630feb
+"globals@npm:^17.6.0":
+  version: 17.6.0
+  resolution: "globals@npm:17.6.0"
+  checksum: 10c0/cf94fb4329cc5c68cf81018fd68324f413181ee169f0235b0b33b82bc93fe7825a21beea951f83a80e8e4bbdad9c0c80515a145b5fd4b5cb52f2a80db899a93f
   languageName: node
   linkType: hard
 
@@ -5421,18 +5255,6 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10c0/386d011a553e02bc594ac2ca0bd6d9e4c22d7fa8cfbfc448a6d148c59ea881b092db9dbe3547ae4b88e55f1b01f7c4a2ecc53b310c042793e63aa44cf6c257f2
-  languageName: node
-  linkType: hard
-
-"gray-matter@npm:4.0.3":
-  version: 4.0.3
-  resolution: "gray-matter@npm:4.0.3"
-  dependencies:
-    js-yaml: "npm:^3.13.1"
-    kind-of: "npm:^6.0.2"
-    section-matter: "npm:^1.0.0"
-    strip-bom-string: "npm:^1.0.0"
-  checksum: 10c0/e38489906dad4f162ca01e0dcbdbed96d1a53740cef446b9bf76d80bec66fa799af07776a18077aee642346c5e1365ed95e4c91854a12bf40ba0d4fb43a625a6
   languageName: node
   linkType: hard
 
@@ -5865,15 +5687,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-binary-path@npm:~2.1.0":
-  version: 2.1.0
-  resolution: "is-binary-path@npm:2.1.0"
-  dependencies:
-    binary-extensions: "npm:^2.0.0"
-  checksum: 10c0/a16eaee59ae2b315ba36fad5c5dcaf8e49c3e27318f8ab8fa3cdb8772bf559c8d1ba750a589c2ccb096113bb64497084361a25960899cb6172a6925ab6123d38
-  languageName: node
-  linkType: hard
-
 "is-buffer@npm:^2.0.0":
   version: 2.0.5
   resolution: "is-buffer@npm:2.0.5"
@@ -5895,13 +5708,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-extendable@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "is-extendable@npm:0.1.1"
-  checksum: 10c0/dd5ca3994a28e1740d1e25192e66eed128e0b2ff161a7ea348e87ae4f616554b486854de423877a2a2c171d5f7cd6e8093b91f54533bc88a59ee1c9838c43879
-  languageName: node
-  linkType: hard
-
 "is-extglob@npm:^2.1.1":
   version: 2.1.1
   resolution: "is-extglob@npm:2.1.1"
@@ -5916,7 +5722,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-glob@npm:^4.0.0, is-glob@npm:^4.0.1, is-glob@npm:^4.0.3, is-glob@npm:~4.0.1":
+"is-glob@npm:^4.0.0, is-glob@npm:^4.0.3":
   version: 4.0.3
   resolution: "is-glob@npm:4.0.3"
   dependencies:
@@ -5929,13 +5735,6 @@ __metadata:
   version: 2.0.1
   resolution: "is-hexadecimal@npm:2.0.1"
   checksum: 10c0/3eb60fe2f1e2bbc760b927dcad4d51eaa0c60138cf7fc671803f66353ad90c301605b502c7ea4c6bb0548e1c7e79dfd37b73b632652e3b76030bba603a7e9626
-  languageName: node
-  linkType: hard
-
-"is-number@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "is-number@npm:7.0.0"
-  checksum: 10c0/b4686d0d3053146095ccd45346461bc8e53b80aeb7671cc52a4de02dbbf7dc0d1d2a986e2fe4ae206984b4d34ef37e8b795ebc4f4295c978373e6575e295d811
   languageName: node
   linkType: hard
 
@@ -5991,18 +5790,6 @@ __metadata:
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 10c0/e248708d377aa058eacf2037b07ded847790e6de892bbad3dac0abba2e759cb9f121b00099a65195616badcb6eca8d14d975cb3e89eb1cfda644756402c8aeed
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
   languageName: node
   linkType: hard
 
@@ -6104,26 +5891,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"kind-of@npm:^6.0.0, kind-of@npm:^6.0.2":
-  version: 6.0.3
-  resolution: "kind-of@npm:6.0.3"
-  checksum: 10c0/61cdff9623dabf3568b6445e93e31376bee1cdb93f8ba7033d86022c2a9b1791a1d9510e026e6465ebd701a6dd2f7b0808483ad8838341ac52f003f512e0b4c4
-  languageName: node
-  linkType: hard
-
-"langium@npm:^4.0.0":
-  version: 4.2.1
-  resolution: "langium@npm:4.2.1"
-  dependencies:
-    chevrotain: "npm:~11.1.1"
-    chevrotain-allstar: "npm:~0.3.1"
-    vscode-languageserver: "npm:~9.0.1"
-    vscode-languageserver-textdocument: "npm:~1.0.11"
-    vscode-uri: "npm:~3.1.0"
-  checksum: 10c0/19ddf79cc3c435ec70f8eb50de255571711db7cea89d171cf80bc97e7ed73d4d0bb6b4215899df8369fa6d0e17f442f30af4ec2e9657041bf2f93be1310ba50a
-  languageName: node
-  linkType: hard
-
 "layout-base@npm:^1.0.0":
   version: 1.0.2
   resolution: "layout-base@npm:1.0.2"
@@ -6199,7 +5966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:4.17.23, lodash-es@npm:^4.17.21, lodash-es@npm:^4.17.23":
+"lodash-es@npm:^4.17.21":
   version: 4.17.23
   resolution: "lodash-es@npm:4.17.23"
   checksum: 10c0/3150fb6660c14c7a6b5f23bd11597d884b140c0e862a17fdb415aaa5ef7741523182904a6b7929f04e5f60a11edb5a79499eb448734381c99ffb3c4734beeddd
@@ -6590,13 +6357,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mermaid@npm:^11.14.0":
-  version: 11.14.0
-  resolution: "mermaid@npm:11.14.0"
+"mermaid@npm:^11.15.0":
+  version: 11.15.0
+  resolution: "mermaid@npm:11.15.0"
   dependencies:
     "@braintree/sanitize-url": "npm:^7.1.1"
     "@iconify/utils": "npm:^3.0.2"
-    "@mermaid-js/parser": "npm:^1.1.0"
+    "@mermaid-js/parser": "npm:^1.1.1"
     "@types/d3": "npm:^7.4.3"
     "@upsetjs/venn.js": "npm:^2.0.0"
     cytoscape: "npm:^3.33.1"
@@ -6607,15 +6374,15 @@ __metadata:
     dagre-d3-es: "npm:7.0.14"
     dayjs: "npm:^1.11.19"
     dompurify: "npm:^3.3.1"
+    es-toolkit: "npm:^1.45.1"
     katex: "npm:^0.16.25"
     khroma: "npm:^2.1.0"
-    lodash-es: "npm:^4.17.23"
     marked: "npm:^16.3.0"
     roughjs: "npm:^4.6.6"
     stylis: "npm:^4.3.6"
     ts-dedent: "npm:^2.2.0"
-    uuid: "npm:^11.1.0"
-  checksum: 10c0/2075b72d4496418ec28aa7e7d8d1b4ddcd408209940fad1efa3dc5fe98b465f38d7b5d998dc0ba3c56de639df5cc73c6395e04a9e7b18a451e2633b57a74c019
+    uuid: "npm:^11.1.0 || ^12 || ^13 || ^14.0.0"
+  checksum: 10c0/9085b47c30b66a1e94e07c93951d9e53e5c89ec8c9fff8814233bddeecf6b8eaf9036d3168e4d1360c3f5d07cd051c666da96860eb0f22f064bd749499a0c83f
   languageName: node
   linkType: hard
 
@@ -7400,13 +7167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-path@npm:^3.0.0, normalize-path@npm:~3.0.0":
-  version: 3.0.0
-  resolution: "normalize-path@npm:3.0.0"
-  checksum: 10c0/e008c8142bcc335b5e38cf0d63cfd39d6cf2d97480af9abdbe9a439221fd4d749763bab492a8ee708ce7a194bb00c9da6d0a115018672310850489137b3da046
-  languageName: node
-  linkType: hard
-
 "npm-install-checks@npm:^6.0.0":
   version: 6.3.0
   resolution: "npm-install-checks@npm:6.3.0"
@@ -7539,9 +7299,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^6.33.0":
-  version: 6.34.0
-  resolution: "openai@npm:6.34.0"
+"openai@npm:^6.37.0":
+  version: 6.38.0
+  resolution: "openai@npm:6.38.0"
   peerDependencies:
     ws: ^8.18.0
     zod: ^3.25 || ^4.0
@@ -7552,7 +7312,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: 10c0/0d9652aea4b07d9be0f48fc30510c1caa05c24891ce5cdd6286df34b4d03f7a39ee289ff507e7c1a4c9cc2727a0ea799f1d545313ececd9979e4b3688583a1b5
+  checksum: 10c0/5557c3f4c33c4232939763bce0f1d548596a7d1dfdb24a59f5177a972a369e583f196cd67e9352e6ca6379ad842e44d83f3ef993c0f320888b457bad878203ba
   languageName: node
   linkType: hard
 
@@ -7801,13 +7561,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4, picomatch@npm:^2.2.1":
-  version: 2.3.2
-  resolution: "picomatch@npm:2.3.2"
-  checksum: 10c0/a554d1709e59be97d1acb9eaedbbc700a5c03dbd4579807baed95100b00420bc729335440ef15004ae2378984e2487a7c1cebd743cfdb72b6fa9ab69223c0d61
-  languageName: node
-  linkType: hard
-
 "picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
@@ -7874,14 +7627,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.8":
-  version: 8.5.8
-  resolution: "postcss@npm:8.5.8"
+"postcss@npm:^8.5.10":
+  version: 8.5.14
+  resolution: "postcss@npm:8.5.14"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/dd918f7127ee7c60a0295bae2e72b3787892296e1d1c3c564d7a2a00c68d8df83cadc3178491259daa19ccc54804fb71ed8c937c6787e08d8bd4bedf8d17044c
+  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
   languageName: node
   linkType: hard
 
@@ -7946,14 +7699,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^19.2.4":
-  version: 19.2.4
-  resolution: "react-dom@npm:19.2.4"
+"react-dom@npm:^19.2.6":
+  version: 19.2.6
+  resolution: "react-dom@npm:19.2.6"
   dependencies:
     scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^19.2.4
-  checksum: 10c0/f0c63f1794dedb154136d4d0f59af00b41907f4859571c155940296808f4b94bf9c0c20633db75b5b2112ec13d8d7dd4f9bf57362ed48782f317b11d05a44f35
+    react: ^19.2.6
+  checksum: 10c0/dbf2aef67857c03a612bc9316a4562e5066f43fa04bf28f7f0734963fc1350da2c9f8eb973930655453281079f30cc8222bab383dbec4b5097084e2c081e3334
   languageName: node
   linkType: hard
 
@@ -8015,21 +7768,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.13.2":
-  version: 7.14.1
-  resolution: "react-router-dom@npm:7.14.1"
+"react-router-dom@npm:^7.15.0":
+  version: 7.15.1
+  resolution: "react-router-dom@npm:7.15.1"
   dependencies:
-    react-router: "npm:7.14.1"
+    react-router: "npm:7.15.1"
   peerDependencies:
     react: ">=18"
     react-dom: ">=18"
-  checksum: 10c0/aa454069e43263c812424a92fc9c099083034e438f9747efc45558885ec48b3dba46ab55bf84b164feac08c24a65e6ac91a3f8a137fd5e79077c95b8c14ca50a
+  checksum: 10c0/d8421566cfa75a53ff85e172a9485be6681f917160de15be6582eb9ca382d187688529c84453e3fb845514e8f784638f5099784859be3740235aa030afb38b5b
   languageName: node
   linkType: hard
 
-"react-router@npm:7.14.1":
-  version: 7.14.1
-  resolution: "react-router@npm:7.14.1"
+"react-router@npm:7.15.1":
+  version: 7.15.1
+  resolution: "react-router@npm:7.15.1"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -8039,27 +7792,27 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10c0/57b86accdc50b917509e4b21f821dd432807e3f62b5e978d0d5174fc7da3798ce57ce896cbf70a8ba8f6f3d53515a07021e759829908239b4eee34c804695120
+  checksum: 10c0/3daff5404c7de1429447e735f1ee7e070d4f11632f589cec70c5171f2357be9cada2162f780bc9061eb153646109ad6e80c2d10a6b27256593f28a66945f4c76
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^5.30.0":
-  version: 5.30.0
-  resolution: "react-tooltip@npm:5.30.0"
+"react-tooltip@npm:^6.0.2":
+  version: 6.0.3
+  resolution: "react-tooltip@npm:6.0.3"
   dependencies:
-    "@floating-ui/dom": "npm:^1.6.1"
-    classnames: "npm:^2.3.0"
+    "@floating-ui/dom": "npm:1.7.6"
+    clsx: "npm:2.1.1"
   peerDependencies:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
-  checksum: 10c0/a942ac78f4c3cf7adfeb97630bf68390683772a37a351cc84b21cef3e3c10991fca8a6ff84e9a410f0cb267ec83de3e19509b9dfaf7ec0d83478a0402621a238
+  checksum: 10c0/f8ecdd2797535eb4ba5d197e02856e854e8b47b3747750a712ac9384da55d7d934f48ff0b2f57d48255dbefc2127c0c7434c8cb1ae27d41cdfd7b029c6011bbc
   languageName: node
   linkType: hard
 
-"react@npm:^19.2.4":
-  version: 19.2.4
-  resolution: "react@npm:19.2.4"
-  checksum: 10c0/cd2c9ff67a720799cc3b38a516009986f7fc4cb8d3e15716c6211cf098d1357ee3e348ab05ad0600042bbb0fd888530ba92e329198c92eafa0994f5213396596
+"react@npm:^19.2.6":
+  version: 19.2.6
+  resolution: "react@npm:19.2.6"
+  checksum: 10c0/66afde33b9a9ee87b1e1cae39d8e7e040d1262e719524fd70660c4d4ce79929c532ac19fc3df5a911edaf02768fdf2c49de4ede1ba99bc6aad72796e0e26e798
   languageName: node
   linkType: hard
 
@@ -8095,15 +7848,6 @@ __metadata:
   version: 5.0.0
   resolution: "readdirp@npm:5.0.0"
   checksum: 10c0/faf1ec57cff2020f473128da3f8d2a57813cc3a08a36c38cae1c9af32c1579906cc50ba75578043b35bade77e945c098233665797cf9730ba3613a62d6e79219
-  languageName: node
-  linkType: hard
-
-"readdirp@npm:~3.6.0":
-  version: 3.6.0
-  resolution: "readdirp@npm:3.6.0"
-  dependencies:
-    picomatch: "npm:^2.2.1"
-  checksum: 10c0/6fa848cf63d1b82ab4e985f4cf72bd55b7dcfd8e0a376905804e48c3634b7e749170940ba77b32804d5fe93b3cc521aa95a8d7e7d725f830da6d93f3669ce66b
   languageName: node
   linkType: hard
 
@@ -8157,10 +7901,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reduce-configs@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "reduce-configs@npm:1.1.1"
-  checksum: 10c0/f13127379e402c93ec9e99c143633af3bdcebe70fddd346f7e30dc2174188667a68543417116e76d0d8df5c127cdea53ed0ca5987a522cf5db3904024d2e5742
+"reduce-configs@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "reduce-configs@npm:1.1.2"
+  checksum: 10c0/dfd1c11e8e01b7ffef4469747a49f9f4f03442fddb2dab8a85fff094fd90eb8dd130fabba4e7fdd30272cae1e06d43d690b8cf01684ef17e821b3d0aad47dc3f
   languageName: node
   linkType: hard
 
@@ -8479,7 +8223,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@alauda/doom": "npm:^2.4.0"
+    "@alauda/doom": "npm:^2.5.1"
   languageName: unknown
   linkType: soft
 
@@ -8655,7 +8399,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass-embedded@npm:^1.97.3":
+"sass-embedded@npm:^1.99.0":
   version: 1.99.0
   resolution: "sass-embedded@npm:1.99.0"
   dependencies:
@@ -8764,16 +8508,6 @@ __metadata:
   dependencies:
     compute-scroll-into-view: "npm:^3.0.2"
   checksum: 10c0/1f46b090e1e04fcfdef1e384f6d7e615f9f84d4176faf4dbba7347cc0a6e491e5d578eaf4dbe9618dd3d8d38efafde58535b3e00f2a21ce4178c14be364850ff
-  languageName: node
-  linkType: hard
-
-"section-matter@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "section-matter@npm:1.0.0"
-  dependencies:
-    extend-shallow: "npm:^2.0.1"
-    kind-of: "npm:^6.0.0"
-  checksum: 10c0/8007f91780adc5aaa781a848eaae50b0f680bbf4043b90cf8a96778195b8fab690c87fe7a989e02394ce69890e330811ec8dab22397d384673ce59f7d750641d
   languageName: node
   linkType: hard
 
@@ -8897,7 +8631,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.35.2":
+"simple-git@npm:^3.36.0":
   version: 3.36.0
   resolution: "simple-git@npm:3.36.0"
   dependencies:
@@ -9017,26 +8751,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10c0/ecadcfe4c771890140da5023d43e190b7566d9cf8b2d238600f31bec0fc653f328da4450eb04bd59a431771a8e9cc0e118f0aa3974b683a4981b4e07abc2a5bb
-  languageName: node
-  linkType: hard
-
 "ssri@npm:^13.0.0":
   version: 13.0.1
   resolution: "ssri@npm:13.0.1"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/cf6408a18676c57ff2ed06b8a20dc64bb3e748e5c7e095332e6aecaa2b8422b1e94a739a8453bf65156a8a47afe23757ba4ab52d3ea3b62322dc40875763e17a
-  languageName: node
-  linkType: hard
-
-"stackframe@npm:^1.3.4":
-  version: 1.3.4
-  resolution: "stackframe@npm:1.3.4"
-  checksum: 10c0/18410f7a1e0c5d211a4effa83bdbf24adbe8faa8c34db52e1cd3e89837518c592be60b60d8b7270ac53eeeb8b807cd11b399a41667f6c9abb41059c3ccc8a989
   languageName: node
   linkType: hard
 
@@ -9080,13 +8800,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "string-width@npm:8.2.0"
+"string-width@npm:^8.2.1":
+  version: 8.2.1
+  resolution: "string-width@npm:8.2.1"
   dependencies:
     get-east-asian-width: "npm:^1.5.0"
     strip-ansi: "npm:^7.1.2"
-  checksum: 10c0/d8915428b43519b0f494da6590dbe4491857d8a12e40250e50fc01fbb616ffd8400a436bbe25712255ee129511fe0414c49d3b6b9627e2bc3a33dcec1d2eda02
+  checksum: 10c0/d467b4eaf4c40a01bb438a2620e77badd2456ffd5131c9973abe4f3acf7c802d5b21f3b6a00a5e33a7fc28ca8f9c103226e01bac61e9f259659c6f46d78e353a
   languageName: node
   linkType: hard
 
@@ -9124,13 +8844,6 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.2.2"
   checksum: 10c0/544d13b7582f8254811ea97db202f519e189e59d35740c46095897e254e4f1aa9fe1524a83ad6bc5ad67d4dd6c0281d2e0219ed62b880a6238a16a17d375f221
-  languageName: node
-  linkType: hard
-
-"strip-bom-string@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "strip-bom-string@npm:1.0.0"
-  checksum: 10c0/5c5717e2643225aa6a6d659d34176ab2657037f1fe2423ac6fcdb488f135e14fef1022030e426d8b4d0989e09adbd5c3288d5d3b9c632abeefd2358dfc512bca
   languageName: node
   linkType: hard
 
@@ -9304,22 +9017,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinypool@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "tinypool@npm:1.1.1"
-  checksum: 10c0/bf26727d01443061b04fa863f571016950888ea994ba0cd8cba3a1c51e2458d84574341ab8dbc3664f1c3ab20885c8cf9ff1cc4b18201f04c2cde7d317fff69b
-  languageName: node
-  linkType: hard
-
-"to-regex-range@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "to-regex-range@npm:5.0.1"
-  dependencies:
-    is-number: "npm:^7.0.0"
-  checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
-  languageName: node
-  linkType: hard
-
 "toggle-selection@npm:^1.0.6":
   version: 1.0.6
   resolution: "toggle-selection@npm:1.0.6"
@@ -9401,7 +9098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^5.5.0":
+"type-fest@npm:^5.6.0":
   version: 5.6.0
   resolution: "type-fest@npm:5.6.0"
   dependencies:
@@ -9417,22 +9114,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.58.1":
-  version: 8.59.0
-  resolution: "typescript-eslint@npm:8.59.0"
+"typescript-eslint@npm:^8.59.3":
+  version: 8.59.3
+  resolution: "typescript-eslint@npm:8.59.3"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.59.0"
-    "@typescript-eslint/parser": "npm:8.59.0"
-    "@typescript-eslint/typescript-estree": "npm:8.59.0"
-    "@typescript-eslint/utils": "npm:8.59.0"
+    "@typescript-eslint/eslint-plugin": "npm:8.59.3"
+    "@typescript-eslint/parser": "npm:8.59.3"
+    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/utils": "npm:8.59.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/b14b4bf6878e9745d92c0bc2b3c68ea29e8e524037a10e05873ad58b0dd1961313c05f406273b99c4128fd49bde2d9b3233bcec636896e9a70ed8167a3d0a9c5
+  checksum: 10c0/7bd251921d583be5a29565118a5babc068e7c1e893d30a0dbea4215ed20cebcad186b419ba747e001b48339e18c4a2cf6c936e013a77b225692f7f48331839f6
   languageName: node
   linkType: hard
 
-"typescript@npm:^6.0.2":
+"typescript@npm:^6.0.3":
   version: 6.0.3
   resolution: "typescript@npm:6.0.3"
   bin:
@@ -9442,7 +9139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^6.0.2#optional!builtin<compat/typescript>":
+"typescript@patch:typescript@npm%3A^6.0.3#optional!builtin<compat/typescript>":
   version: 6.0.3
   resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
@@ -9475,12 +9172,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unhead@npm:2.1.13":
-  version: 2.1.13
-  resolution: "unhead@npm:2.1.13"
+"unhead@npm:2.1.15":
+  version: 2.1.15
+  resolution: "unhead@npm:2.1.15"
   dependencies:
     hookable: "npm:^6.0.1"
-  checksum: 10c0/69244dcf8d9a23edbaed1a6115e97ac5c49ec68446e88cf7ec0ac82e1cdbdacef44fc017913622e454da3e30ad6b8b17ebef30bc47c765ecc73cb363739a847a
+  checksum: 10c0/ab266e9cda44d0b528ae3b62ce9136cb4f81bd2aa1e2d66431cefe6b41151a811971951e05b4d81e6adea105b65901d9091dffa29d646f1be6246691606b2407
   languageName: node
   linkType: hard
 
@@ -9778,12 +9475,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^11.1.0":
-  version: 11.1.0
-  resolution: "uuid@npm:11.1.0"
+"uuid@npm:^11.1.0 || ^12 || ^13 || ^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
   bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/34aa51b9874ae398c2b799c88a127701408cd581ee89ec3baa53509dd8728cbb25826f2a038f9465f8b7be446f0fbf11558862965b18d21c993684297628d4d3
+    uuid: dist-node/bin/uuid
+  checksum: 10c0/a57ae7794c45005c1a9208989196c5baf79a7679c30f43c1bee9033a2c4d113a2cea216fa6fcc9663b08b0d55635df1a7c6eb7e7f3d21c3e50688c698fa39a50
   languageName: node
   linkType: hard
 
@@ -9899,49 +9596,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vscode-jsonrpc@npm:8.2.0":
-  version: 8.2.0
-  resolution: "vscode-jsonrpc@npm:8.2.0"
-  checksum: 10c0/0789c227057a844f5ead55c84679206227a639b9fb76e881185053abc4e9848aa487245966cc2393fcb342c4541241b015a1a2559fddd20ac1e68945c95344e6
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver-protocol@npm:3.17.5":
-  version: 3.17.5
-  resolution: "vscode-languageserver-protocol@npm:3.17.5"
-  dependencies:
-    vscode-jsonrpc: "npm:8.2.0"
-    vscode-languageserver-types: "npm:3.17.5"
-  checksum: 10c0/5f38fd80da9868d706eaa4a025f4aff9c3faad34646bcde1426f915cbd8d7e8b6c3755ce3fef6eebd256ba3145426af1085305f8a76e34276d2e95aaf339a90b
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver-textdocument@npm:^1.0.12, vscode-languageserver-textdocument@npm:~1.0.11":
+"vscode-languageserver-textdocument@npm:^1.0.12":
   version: 1.0.12
   resolution: "vscode-languageserver-textdocument@npm:1.0.12"
   checksum: 10c0/534349894b059602c4d97615a1147b6c4c031141c2093e59657f54e38570f5989c21b376836f13b9375419869242e9efb4066643208b21ab1e1dee111a0f00fb
   languageName: node
   linkType: hard
 
-"vscode-languageserver-types@npm:3.17.5":
-  version: 3.17.5
-  resolution: "vscode-languageserver-types@npm:3.17.5"
-  checksum: 10c0/1e1260de79a2cc8de3e46f2e0182cdc94a7eddab487db5a3bd4ee716f67728e685852707d72c059721ce500447be9a46764a04f0611e94e4321ffa088eef36f8
-  languageName: node
-  linkType: hard
-
-"vscode-languageserver@npm:~9.0.1":
-  version: 9.0.1
-  resolution: "vscode-languageserver@npm:9.0.1"
-  dependencies:
-    vscode-languageserver-protocol: "npm:3.17.5"
-  bin:
-    installServerIntoExtension: bin/installServerIntoExtension
-  checksum: 10c0/8a0838d77c98a211c76e54bd3a6249fc877e4e1a73322673fb0e921168d8e91de4f170f1d4ff7e8b6289d0698207afc6aba6662d4c1cd8e4bd7cae96afd6b0c2
-  languageName: node
-  linkType: hard
-
-"vscode-uri@npm:^3.1.0, vscode-uri@npm:~3.1.0":
+"vscode-uri@npm:^3.1.0":
   version: 3.1.0
   resolution: "vscode-uri@npm:3.1.0"
   checksum: 10c0/5f6c9c10fd9b1664d71fab4e9fbbae6be93c7f75bb3a1d9d74399a88ab8649e99691223fd7cef4644376cac6e94fa2c086d802521b9a8e31c5af3e60f0f35624
@@ -10109,6 +9771,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10c0/f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
@@ -10145,10 +9816,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^4.3.6":
-  version: 4.3.6
-  resolution: "zod@npm:4.3.6"
-  checksum: 10c0/860d25a81ab41d33aa25f8d0d07b091a04acb426e605f396227a796e9e800c44723ed96d0f53a512b57be3d1520f45bf69c0cb3b378a232a00787a2609625307
+"zod@npm:^4.4.3":
+  version: 4.4.3
+  resolution: "zod@npm:4.4.3"
+  checksum: 10c0/7ea31b558e88f9faf44f31dd185e2e1cbf51fed3081787fb96cc2534749b50c0acfc6da7f0922a7353ed092dd358c7d50c28ea96c94d04af64191bd33152eca3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Correct DCSMachineTemplate field documentation: remove the misleading `spec.resource` field from product docs (verified to be dead code), and rewrite the host-placement section to point users to DCS-side anti-affinity for cross-host control-plane HA instead of the previous incorrect guidance.
- Add a Concepts and Terminology section to `docs/en/overview/providers/huawei-dcs.mdx` covering 12 DCS platform concepts, with explicit disambiguation of the DCS Cluster vs DCSCluster CRD name collision and similar pairs.
- Add a setup preamble that defines `${DCS_BASE}` / `${SITE}` / `${TOKEN}` for the existing read-only diagnostic snippets so they can actually be executed.

## Context

A customer-facing question about DCSMachineTemplate's `spec.location` and `spec.resource` fields triggered a deeper review of the existing docs. Empirical verification revealed several inaccuracies:

1. **`spec.resource` is fully dead code.** Exhaustive grep of `cluster-api-provider-dcs` shows the field is resolved by `PreCreateHandle` (Name → URN lookup), but the resolved URN is never consumed downstream. The hardcoded `IsBindingHost: false` plus the absence of any `hostUrn` field in the clone request body means the resolved value cannot reach the DCS API. A live DCS API clone test confirmed identical behavior with and without `spec.resource`. The previous troubleshooting step that advised switching to `type: host` for HA had no effect on the underlying VM scheduling.

2. **`spec.location.type=folder` works correctly** (live DCS API + DCS portal verification): the cloned VM appears in the named VM Folder. The provider's behavior here matches the documented intent.

3. **`spec.location.type=cluster` is supported by the DCS API** (cross-cluster placement) but constrained at the DCS storage layer: the target DCS Cluster must be able to reach the DCS Datastore that holds the VM Template. This is the case for SAN / IPSAN / NAS / FusionStorage datastores; not for local-disk datastores.

4. **Cross-host control-plane HA is not supported by the provider.** Neither host pinning nor Cluster API `FailureDomain` spreading is implemented. The supported workaround is to configure DCS-side VM anti-affinity (the 互斥虚拟机 / Mutually Exclusive Virtual Machines rule).

5. **Terminology gap.** Docs use `DCS Cluster` (a DCS platform host pool), `DCS Host`, `DCS VM Folder`, `DCS Datastore`, etc., without defining them. Customers conflate `DCS Cluster` with the `DCSCluster` Cluster API CRD; similar pairs apply to `DCS VM Template` vs `DCSMachineTemplate` CRD and `DCS Datastore Cluster` vs `DCS Cluster` (both contain the word "cluster" but refer to different layers).

## Key Decisions

- **Remove `spec.resource` from product docs entirely** rather than mark it deprecated. Any documentation of the field implies it does something. Since it has no observable effect, keeping it in docs misleads customers. Provider-side deprecation of the CRD field is out of scope for this PR.
- **Inline Concepts and Terminology into `overview/providers/huawei-dcs.mdx`** rather than create a new file. A dedicated file under `infrastructure/` would break the one-provider-per-entry left-nav rhythm; a file under `apis/` would not render because that directory is reserved for `<K8sCrd>` auto-rendered pages. The Provider overview page is the semantically correct home for platform concepts and has enough headroom (~110 → ~285 lines).
- **Preserve 互斥虚拟机 alongside its English translation.** Customers see the literal Chinese term in the DCS portal UI, so retaining searchability outweighs the otherwise English-only content rule. The surrounding prose remains English.
- **Document `spec.location.type=cluster` only as Advanced**, paired with the explicit datastore-visibility prerequisite. Live empirical confirmation requires a multi-DCS-Cluster environment, which the available test environment does not have; the storage prerequisite gates the feature to operators with shared storage anyway.
- **Defer the full DCS anti-affinity runbook.** Configuring 互斥虚拟机 rules is operations-side work that needs verification in a live DCS portal session before being documented as official guidance. This PR introduces the customer-facing entry point and the constraint statement without committing to step-by-step DCS UI instructions that have not been validated.
- **Add the diagnostic-snippet setup preamble in the same PR** even though the affected snippets predate these changes. The bash snippets that use `${DCS_BASE}` / `${SITE}` / `${TOKEN}` were previously undocumented; fixing them alongside the related cleanup avoids leaving a known usability gap behind.

## Empirical Verification

- `spec.resource` dead-code claim: exhaustive `grep -rn` of `provider-dcs/api/v1beta1/`, `pkg/`, `internal/` for `Resource.Urn`, `Spec.Resource`, etc. — all writes found in `PreCreateHandle`; no downstream readers exist.
- `spec.location.type=folder`: cloned a test VM via the DCS clone API with `parentObjUrn` pointing at the `hchan-1` VM Folder; verified in the DCS portal that the VM appeared under `hchan-1`. Test VM deleted after verification.
- `spec.location` omitted: cloned a second test VM via the same API with `parentObjUrn` omitted; verified the VM appeared directly under `ManagementCluster` (no folder). Test VM deleted after verification.
- Existing customer DCSMachineTemplates that set `spec.resource.type=cluster`: the resulting VMs are scattered across hosts in `ManagementCluster` with no spread enforcement, consistent with the dead-code interpretation.

## Test Plan

- [ ] Run `yarn dev` locally and confirm the rendered output:
  - [ ] `overview/providers/huawei-dcs.mdx` shows the new `Concepts and Terminology` section with all sub-anchors reachable
  - [ ] `infrastructure/huawei-dcs.mdx` no longer mentions `spec.resource`; the new `Cross-Host High Availability` and `Advanced: Multi-Cluster Deployment` subsections render correctly; the `Running the diagnostic snippets` preamble appears before the first bash snippet
  - [ ] `manage-nodes/huawei-dcs.mdx` no longer mentions `spec.resource`; cross-links to the new infrastructure subsections work
- [ ] Verify left navigation under `Infrastructure` still shows two entries (Huawei DCS, Huawei Cloud Stack) with no insertion between them
- [ ] Verify left navigation under `Overview > Providers` is unchanged in structure
- [ ] Click through every internal link in the new content to confirm anchors resolve correctly

## Related

- A companion PR will be opened against `release-1.0` to back-port this change.
- Provider-side follow-up (out of scope for this PR): mark `Spec.Resource` deprecated in the CRD, or implement Cluster API `FailureDomain` support for cross-host HA in a future provider release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Huawei DCS infrastructure documentation with clearer guidance on platform concepts and diagnostic procedures.
  * Updated worker node management documentation with improved field mappings and placement requirements.
  * Added sections on multi-cluster deployments and cross-host high availability.
  * Improved troubleshooting guidance for VM provisioning issues and diagnostic steps.
  * New provider documentation with concepts and terminology reference.

* **Chores**
  * Updated development dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/immutable-infra-docs/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->