### PR TITLE
docs(huawei-dcs): remove dead spec.resource, add platform terminology (release-1.0 backport)

### DIFF
--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -25,6 +25,11 @@ On Huawei DCS, the IP pool also carries any disks that must survive VM replaceme
 All infrastructure resources must be deployed in the `cpaas-system` namespace to ensure proper integration with the platform as business clusters.
 :::
 
+:::info
+**DCS platform concepts**
+If terms such as `DCS Cluster`, `DCS Host`, `DCS VM Folder`, or `DCS VM Template` are unfamiliar, or if it is not clear how they relate to the `DCSCluster` and `DCSMachineTemplate` custom resources, read [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) first.
+:::
+
 ## Cloud Credentials \{#cloud-credentials}
 
 Cloud credentials store the DCS platform access information required for cluster operations.
@@ -346,6 +351,47 @@ spec:
 
 Before authoring `DCSMachineTemplate` resources, verify that the target DCS site, datastore, and compute cluster have enough free capacity to host the planned VMs, and that the DCS-side scheduling policy can place new VMs on the available hosts. Skipping these checks is the single most common cause of VMs that appear to hang in `creating` state with no error returned by the DCS API.
 
+### Running the diagnostic snippets \{#diagnostic-prereqs}
+
+The capacity and placement checks below use read-only DCS REST calls. Before running any snippet, set the following environment variables in your shell:
+
+| Variable | Meaning | How to obtain |
+|---|---|---|
+| `DCS_BASE` | DCS REST API base URL, including scheme and port. The DCS REST API is published on port 7443 (separate from the 8443 web portal). | Ask the DCS platform administrator for the API endpoint. The same value is stored in the cloud-credential `Secret` under the `endpoint` key. |
+| `SITE` | DCS site ID (uppercase alphanumeric, for example `EC1C108C`). | Stored in the cloud-credential `Secret` under the `site` key, and also visible as `DCSCluster.spec.site`. |
+| `TOKEN` | Short-lived `X-Auth-Token` returned by `POST /service/session`. The token is valid for approximately 30 minutes of idle time. | Run the session command shown below. The DCS user and key are stored in the cloud-credential `Secret` under `authUser` and `authKey`. |
+
+Set the three variables once at the start of the diagnostic session:
+
+```bash
+# Replace the placeholders with values appropriate for your environment.
+export DCS_BASE='https://<dcs-api-host>:7443'
+export SITE='<site-id>'
+
+# Read the user and key from the cloud-credential Secret without printing them.
+DCS_USER="$(kubectl -n cpaas-system get secret <credential-secret-name> -o jsonpath='{.data.authUser}' | base64 -d)"
+DCS_KEY="$(kubectl -n cpaas-system get secret <credential-secret-name> -o jsonpath='{.data.authKey}' | base64 -d)"
+
+# Acquire a session token. The response header X-AUTH-TOKEN carries the value used by subsequent calls.
+HEADERS="$(mktemp)"
+curl -k -sS -D "$HEADERS" -o /dev/null -X POST "${DCS_BASE}/service/session" \
+  -H "X-Auth-User: $DCS_USER" \
+  -H "X-Auth-Key: $DCS_KEY" \
+  -H 'X-ENCRYPT-ALGORITHM: 1' \
+  -H 'X-Auth-UserType: 2' \
+  -H 'version: 8.1'
+export TOKEN="$(grep -i '^X-AUTH-TOKEN:' "$HEADERS" | tail -n1 | cut -d' ' -f2- | tr -d '\r\n ')"
+rm -f "$HEADERS"
+unset DCS_USER DCS_KEY
+```
+
+:::warning
+**Token handling**
+Do not log the token to a file or to shell history. The session token grants the same privileges as the underlying DCS user, which is typically an administrator.
+:::
+
+Reuse `$DCS_BASE`, `$SITE`, and `$TOKEN` in every subsequent diagnostic snippet on this page. Refresh the token by re-running the `POST /service/session` command when the API begins returning `errorCode: 10000002` (session expired or not logged in).
+
 ### Choosing a datastore \{#choosing-datastore}
 
 Each `DCSMachineDiskSpec` entry binds a disk to a DCS datastore through one of two mutually exclusive fields:
@@ -370,14 +416,14 @@ for ds in json.load(sys.stdin).get('datastores',[]) or []:
 
 Each `DCSMachineTemplate` cp / worker pair commonly needs the system disk (template-default, often ~80 GB) plus the explicit data disks declared in the spec, so a single control-plane node with `etcd 10G + kubelet 100G + containerd 100G + /var/cpaas 100G` consumes roughly 390 GB before the template's system disk. A datastore used above ~70 % is a strong signal to pick a different datastore — even if the absolute free space looks large, fragmentation and reservations can cause new VM placement to stall.
 
-### Host placement requirements \{#host-placement}
+### Host placement and high availability \{#host-placement}
 
-A `DCSMachineTemplate.spec.template.spec.resource` field controls how DCS picks the physical host for the cloned VM:
+Host placement on the DCS platform is performed by the DCS scheduler. The DCS Provider does not expose a way to pin a virtual machine to a specific DCS Host through `DCSMachineTemplate`. Virtual machines cloned from the same template can therefore land on the same physical host.
 
-- `type: cluster` + `name: <cluster-name>` — lets the DCS cluster scheduler pick a host automatically. Requires the DCS cluster to have **DRS enabled** (or an equivalent balancer policy) so the scheduler can place new VMs on under-utilized hosts.
-- `type: host` + `name: <host-name>` — pins every cloned VM to one specific host. Use this when DRS is disabled, or when the platform has uneven host capacity and you must steer new VMs onto a specific host with free CPU and memory.
+Two consequences follow from this:
 
-If the DCS cluster has DRS disabled and the existing hosts are unevenly loaded (for example, one host is severely CPU-over-committed while another is mostly idle), the `type: cluster` mode can leave the deploy task stalled because the scheduler cannot pick a host that simultaneously satisfies the cluster's overcommit and reservation policies. Switching to `type: host` and pointing at a known-healthy host removes that ambiguity.
+- **Capacity hot spots**: If the DCS cluster has uneven host load (for example, one host is severely CPU-over-committed while another is mostly idle), the DCS scheduler may refuse new placements on the over-committed host. The deploy task can stall until the load is rebalanced on the DCS side or DRS is enabled. Use the snippet below to confirm whether host load is the cause.
+- **No automatic spread for control plane**: Control-plane virtual machines from a single `DCSMachineTemplate` are not automatically distributed across multiple physical hosts. For high-availability deployments, configure VM-VM anti-affinity on the DCS platform side as described in [Cross-Host High Availability for Control Plane](#cross-host-ha) below.
 
 To check current host load before applying a new template:
 
@@ -390,7 +436,15 @@ for h in json.load(sys.stdin).get('hosts',[]) or []:
   print(f\"{h.get('name','?'):10} status={h.get('status','?'):10} cpuUsed/total={h.get('cpuUsedCores','?')}/{h.get('cpuTotalCores','?')}c memUsed={h.get('memUsedSizeMB','?')}MB cpuMuxRatio={h.get('cpuMuxRatio','?')}\")"
 ```
 
-A `cpuMuxRatio` (CPU allocation / physical cores) above ~3× on every host in the cluster, combined with DRS disabled, indicates the cluster is already saturated and will likely refuse new placements until either DRS is enabled or the load is rebalanced manually.
+A `cpuMuxRatio` (CPU allocation / physical cores) above ~3× on every host in the cluster indicates the cluster is already saturated and will likely refuse new placements until the load is rebalanced on the DCS side.
+
+### Cross-Host High Availability for Control Plane \{#cross-host-ha}
+
+The DCS Provider does not currently implement host pinning or Cluster API `FailureDomain` spreading. As a result, the three control-plane virtual machines of a Kubernetes cluster created through this provider can be placed on the same physical DCS Host. If that host fails, the entire Kubernetes control plane is unavailable until the host recovers.
+
+To force control-plane virtual machines onto different physical hosts, configure a VM-VM anti-affinity rule on the DCS platform side. The DCS platform calls this feature 互斥虚拟机 (Mutually Exclusive Virtual Machines). The rule is configured under the DCS Cluster's compute resource scheduling settings, lists the control-plane virtual machines by name, and instructs the DCS scheduler to keep those virtual machines on different hosts.
+
+A full operational runbook for this configuration is being prepared and will be published as a separate document. Until it is available, follow the DCS / FusionCompute platform documentation, or contact the DCS platform support team. Two prerequisites apply on the DCS side: the target cluster must have enough healthy hosts (typically at least one host per control-plane virtual machine), and the cluster must have DRS enabled if the rule should also be honoured during runtime rebalancing.
 
 ### Troubleshooting: VM stuck in `creating` \{#stuck-creating}
 
@@ -411,7 +465,7 @@ Diagnostic ladder, in order:
 
 2. **Check datastore free space** and **host load** using the snippets in [Choosing a datastore](#choosing-datastore) and [Host placement requirements](#host-placement). Datastore above 70 % used, or all hosts at high `cpuMuxRatio`, are the leading causes.
 
-3. **If DRS is disabled on the DCS cluster**, switch the relevant `DCSMachineTemplate.spec.template.spec.resource` to `type: host` + an explicit healthy host name, delete the stuck `Machine`, and let the controller re-derive a fresh `DCSMachine` against the new template.
+3. **Rebalance load on the DCS side**. If a single host is saturated while others have free capacity, ask the DCS platform team to rebalance the load (manual `Migrate` or DRS-driven rebalance) before retrying. The DCS Provider does not expose a per-template host pin, so this remediation is owned by the DCS platform team.
 
 4. **If the DCS-side deploy task is genuinely deadlocked** (cancellable but unresponsive to ACP-driven `DeleteVm`), escalate to a DCS administrator with portal-admin credentials to cancel the task. The 7443 REST API does not expose a task-cancel endpoint for non-admin users, so the recovery path is owned by the DCS platform team, not by ACP.
 
@@ -470,8 +524,7 @@ metadata:
 | Name | text | Yes | Unique identifier for the template (1-63 characters, lowercase letters, numbers, and hyphens only) |
 | Type | dropdown | Yes | Control Plane or Worker Node |
 | VM Template Name | dropdown | Yes | From ConfigMap, shows OS Version and Kubernetes Version |
-| Location | dropdown | No | DCS platform location (datacenter, rack, etc.) |
-| Resource | dropdown | No | DCS platform resource pool or cluster |
+| Location | dropdown | No | DCS VM Folder used to group the cloned virtual machines on the DCS platform. See [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) for the VM Folder definition. The folder must be created on the DCS platform first. |
 | Specs | - | Yes | CPU and memory specifications |
 | Specs.CPU | number | Yes | CPU cores (integer) |
 | Specs.Mem | number | Yes | Memory size in MB (displayed as GB in list view) |
@@ -523,7 +576,7 @@ If multiple VM templates have the same Kubernetes version, select the template w
 
 #### Managing Machine Templates
 
-**Viewing Templates**: Navigate to Clusters → Virtual Machine → Machine Templates to view all templates with their VM Template Name, Resource, Location, Specs, and IP Pool.
+**Viewing Templates**: Navigate to Clusters → Virtual Machine → Machine Templates to view all templates with their VM Template Name, Location, Specs, and IP Pool.
 
 **Updating Templates**: Click **Update** to modify specifications. Note that the Name field cannot be changed after creation.
 
@@ -546,9 +599,6 @@ spec:
       location:
         type: folder
         name: <folder-name>
-      resource: # Optional, if not specified, uses template defaults
-        type: cluster # cluster | host
-        name: <cluster-name>
       vmConfig:
         dvSwitchName: <dv-switch-name> # Optional
         portGroupName: <port-group-name> # Optional
@@ -580,13 +630,10 @@ spec:
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| `.spec.template.spec.vmTemplateName` | string | DCS virtual machine template name | Yes |
-| `.spec.template.spec.location` | object | Location where the VM will be created (auto-selected if not specified) | No |
-| `.spec.template.spec.location.type` | string | VM creation location type (currently only supports "folder") | Yes* |
-| `.spec.template.spec.location.name` | string | VM creation folder name | Yes* |
-| `.spec.template.spec.resource` | object | Compute resource selection for VM creation (auto-selected if not specified) | No |
-| `.spec.template.spec.resource.type` | string | Compute resource type: cluster or host | Yes* |
-| `.spec.template.spec.resource.name` | string | Compute resource name | Yes* |
+| `.spec.template.spec.vmTemplateName` | string | DCS VM Template name as registered on the DCS platform. | Yes |
+| `.spec.template.spec.location` | object | Places the cloned virtual machine under a DCS VM Folder for organizational grouping. If omitted, the virtual machine is not placed in any folder. See [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) for the VM Folder definition. | No |
+| `.spec.template.spec.location.type` | string | Set to `folder` for the standard workflow. The folder must already exist on the DCS platform. | Yes* |
+| `.spec.template.spec.location.name` | string | Name of the existing DCS VM Folder. | Yes* |
 | `.spec.template.spec.vmConfig` | object | Virtual machine configuration | Yes |
 | `.spec.template.spec.vmConfig.dvSwitchName` | string | Virtual machine switch name (uses template default if not specified) | No |
 | `.spec.template.spec.vmConfig.portGroupName` | string | Port group name (must belong to the specified switch, uses template default if not specified) | No |
@@ -601,6 +648,19 @@ spec:
 | `.spec.template.spec.ipHostPoolRef.name` | string | Referenced DCSIpHostnamePool name | Yes |
 
 \*Required when parent object is specified
+
+### Advanced: Multi-Cluster Deployment with Shared Storage \{#advanced-multi-cluster}
+
+The default workflow assumes that the DCS VM Template (`vmTemplateName`) and the cloned virtual machines live in the same DCS Cluster. For most deployments, this assumption is correct and the `spec.template.spec.location` field is set to a VM Folder for organizational grouping only.
+
+Deployments that span multiple DCS Clusters and want to clone from a single shared DCS VM Template into a different target DCS Cluster require the following conditions:
+
+- The DCS Datastore that holds the DCS VM Template must be visible to the target DCS Cluster. This is the case for SAN, IPSAN, NAS, or FusionStorage datastores configured for cross-cluster access; it is not the case for datastores backed by host-local disk.
+- The DCS-side network resources (distributed virtual switches and port groups) referenced by the `vmConfig` must also be visible to the target DCS Cluster.
+
+When both conditions are met, the cloned virtual machine can be placed under the target DCS Cluster by setting `spec.template.spec.location.type: cluster` and `spec.template.spec.location.name: <target-cluster-name>` instead of the default `type: folder` form. If the datastore is not shared across DCS Clusters, the clone task fails at the DCS platform side. The recommended alternative is to prepare a separate DCS VM Template inside each target DCS Cluster, so each `DCSMachineTemplate` references a template that already lives in the cluster where the virtual machines will run.
+
+Confirm cross-cluster datastore visibility with the DCS platform administrator before using this configuration.
 
 :::warning
 **Storage Requirements**

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -110,6 +110,8 @@ spec:
 
 The DCSMachineTemplate defines the specifications for worker node virtual machines, including VM templates, compute resources, storage configuration, and network settings.
 
+The fields in this resource reference several Huawei DCS platform concepts (DCS VM Template, DCS VM Folder, DCS Datastore, and related items). For the definitions of those concepts and how they map to Cluster API resources, see [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology).
+
 :::warning
 **Required Disk Configurations**
 The following disk mount points are mandatory. Do not remove them:
@@ -139,9 +141,6 @@ spec:
       location:
         type: folder
         name: <folder-name>
-      resource: # Optional, if not specified, uses template defaults
-        type: cluster # cluster | host. Optional
-        name: <cluster-name> # Optional
       vmConfig:
         dvSwitchName: <dv-switch-name> # Optional
         portGroupName: <port-group-name> # Optional
@@ -169,13 +168,10 @@ spec:
 
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
-| `.spec.template.spec.vmTemplateName` | string | DCS virtual machine template name | Yes |
-| `.spec.template.spec.location` | object | VM creation location (auto-selected if not specified) | No |
-| `.spec.template.spec.location.type` | string | Location type (currently supports "folder" only) | Yes* |
-| `.spec.template.spec.location.name` | string | Folder name for VM creation | Yes* |
-| `.spec.template.spec.resource` | object | Compute resource selection (auto-selected if not specified) | No |
-| `.spec.template.spec.resource.type` | string | Resource type: `cluster` or `host` | Yes* |
-| `.spec.template.spec.resource.name` | string | Compute resource name | Yes* |
+| `.spec.template.spec.vmTemplateName` | string | DCS VM Template name as registered on the DCS platform. | Yes |
+| `.spec.template.spec.location` | object | Places the cloned virtual machine under a DCS VM Folder for organizational grouping. If omitted, the virtual machine is not placed in any folder. See [Huawei DCS Concepts and Terminology](../overview/providers/huawei-dcs.mdx#concepts-and-terminology) for the VM Folder definition and [Infrastructure → Advanced: Multi-Cluster Deployment](../infrastructure/huawei-dcs.mdx#advanced-multi-cluster) for the multi-cluster use of this field. | No |
+| `.spec.template.spec.location.type` | string | Set to `folder` for the standard workflow. The folder must already exist on the DCS platform. | Yes* |
+| `.spec.template.spec.location.name` | string | Name of the existing DCS VM Folder. | Yes* |
 | `.spec.template.spec.vmConfig` | object | Virtual machine configuration | Yes |
 | `.spec.template.spec.vmConfig.dvSwitchName` | string | Virtual switch name (uses template default if not specified) | No |
 | `.spec.template.spec.vmConfig.portGroupName` | string | Port group name (must belong to the specified switch) | No |
@@ -960,8 +956,10 @@ See [Infrastructure → Troubleshooting: VM stuck in `creating`](../infrastructu
 - Confirming the symptom is a placement stall (not a slow boot).
 - Checking datastore free space.
 - Checking host CPU / memory utilisation and overcommit ratios.
-- Switching `DCSMachineTemplate.spec.template.spec.resource` from `type: cluster` to `type: host` when the DCS cluster has DRS disabled.
+- Coordinating with the DCS platform team to rebalance load when a single DCS Host is saturated.
 - Escalation path when the deploy task is genuinely deadlocked.
+
+For control-plane high availability across multiple physical hosts, see [Infrastructure → Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
 
 The same diagnostic applies whether the stuck node is the first control-plane node of a fresh cluster, a new worker added through `MachineDeployment` scaling, or a replacement worker created during a rolling update.
 

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -85,6 +85,181 @@ The DCS Provider implements the Cluster API infrastructure provider specificatio
 - **DCSMachineTemplate**: Defines VM templates for machine creation
 - **DCSIpHostnamePool**: Manages IP and hostname allocations for machines
 
+## Concepts and Terminology \{#concepts-and-terminology}
+
+Several Huawei DCS platform concepts have names that closely resemble Cluster API custom resource names. Two of them deserve special attention because the name collision is exact: a `DCS Cluster` (the DCS platform's pool of physical hosts) is not the same object as a `DCSCluster` custom resource (the Cluster API infrastructure resource that represents a Kubernetes cluster on top of DCS). Reading the two as the same thing leads to incorrect `DCSMachineTemplate` and `DCSCluster` configurations.
+
+This section enumerates the DCS platform concepts referenced by the provider, maps each concept to the Cluster API resource or field that references it, and clarifies the network and storage layering that is the most frequent source of configuration errors.
+
+### DCS Platform Object Hierarchy
+
+The DCS platform organizes its objects in a hierarchy. The provider works with the following layers (top to bottom):
+
+- **DCS Site** — the top-level scope of a single DCS deployment. Identified by a site ID such as `EC1C108C`.
+- Within a site:
+  - **DCS Clusters** — pools of physical hosts. A site contains one or more DCS Clusters.
+  - **DCS VM Folders** and **DCS Cluster Folders** — organizational labels (logical groupings) for virtual machines and clusters respectively.
+  - **DCS Datastores** and **DCS Datastore Clusters** — storage containers and groups of storage containers.
+  - **DCS Distributed Virtual Switches (DVS)** — virtual switches that span the site.
+- Within a DCS Cluster:
+  - **DCS Hosts** — physical servers (for example, `CNA-01`, `CNA-02`).
+- Within a DCS DVS:
+  - **DCS Port Groups** — network configuration entries that virtual machine NICs attach to.
+- Independent of the placement hierarchy:
+  - **DCS VM Templates** — virtual machines marked as templates, used as the source image for cloning.
+  - **DCS Volumes** — persistent disks created on DCS Datastores.
+
+The provider does not own any of these objects. It references them by name or URN from custom resource fields.
+
+### DCS Platform Concepts \{#dcs-concepts}
+
+#### DCS Site \{#dcs-site}
+
+The top-level container of a single DCS deployment. The site ID is supplied as `DCSCluster.spec.site` and is also stored in the cloud-credential `Secret`. All DCS API paths used by the provider include the site ID (`/service/sites/{siteId}/...`).
+
+#### DCS Cluster \{#dcs-cluster}
+
+A pool of physical hosts on the DCS platform. The DCS scheduler places virtual machines onto hosts that belong to a single DCS Cluster. A site can contain one or more DCS Clusters; a DCS Cluster contains one or more DCS Hosts. DCS Cluster names are visible in the DCS portal and are returned by the `GET /service/sites/{siteId}/clusters` API.
+
+The name `DCS Cluster` collides with the `DCSCluster` Cluster API custom resource. See [Cluster API Resource Mapping](#cluster-api-resource-mapping) below.
+
+#### DCS Host \{#dcs-host}
+
+A single physical server registered in a DCS Cluster. Names follow the local convention on the DCS platform (for example, `CNA-01`). Virtual machines run on hosts; the DCS scheduler chooses which host receives a new virtual machine, based on cluster-level policies (DRS, anti-affinity rules) and host capacity. The provider does not pin virtual machines to a specific DCS Host; the `DCSMachineTemplate` resource does not expose a host-binding field.
+
+#### DCS VM Folder \{#dcs-vm-folder}
+
+An organizational label inside a DCS Site that groups virtual machines. A VM Folder does not affect compute placement; a virtual machine grouped under VM Folder `foo` still runs on a DCS Host belonging to some DCS Cluster. The provider queries VM Folders through `GET /service/sites/{siteId}/folder?type=1`.
+
+VM Folders must be created on the DCS platform before being referenced from `DCSMachineTemplate.spec.template.spec.location` (with `type: folder`).
+
+#### DCS Cluster Folder \{#dcs-cluster-folder}
+
+An organizational label that groups DCS Clusters themselves, returned by the same `/folder` endpoint with a different `type` parameter. The provider does not query or reference DCS Cluster Folders. This concept is listed here only to prevent confusion with [DCS VM Folder](#dcs-vm-folder).
+
+#### DCS VM Template \{#dcs-vm-template}
+
+A virtual machine on the DCS platform that has been marked as a template (`isTemplate=true`). The provider clones from this template to create cluster nodes. A VM Template is identified by name (the value of `DCSMachine.spec.vmTemplateName`); the provider resolves the name to a URN by listing `GET /service/sites/{siteId}/vms?isTemplate=true&name=<name>`.
+
+A VM Template carries its own disk on a DCS Datastore and its own network configuration. The provider overwrites the network configuration (NIC port group, customization) when cloning; it does not overwrite the disk's storage type. The cloned virtual machine inherits the template's home DCS Cluster by default; see [Infrastructure → Advanced: Multi-Cluster Deployment](../../infrastructure/huawei-dcs.mdx#advanced-multi-cluster) for cross-cluster usage.
+
+#### DCS Datastore \{#dcs-datastore}
+
+A storage container on the DCS platform that holds the disks of virtual machines. Datastores can be backed by SAN, IPSAN, NAS, FusionStorage, or local disk. The storage backend determines whether a datastore is visible to one DCS Cluster or to several DCS Clusters: SAN, IPSAN, NAS, and FusionStorage typically support cross-cluster access; local disk does not.
+
+Datastores are referenced from disk specifications by either `datastoreName` or `datastoreUrn`; the provider resolves the name to a URN before sending the clone request.
+
+#### DCS Datastore Cluster \{#dcs-datastore-cluster}
+
+A group of DCS Datastores. When a disk specification references a Datastore Cluster (via `datastoreClusterName`), the DCS scheduler picks a member datastore that has free capacity. This is the recommended way to declare storage when the DCS administrator has configured a datastore cluster, because it tolerates single-datastore exhaustion.
+
+A DCS Datastore Cluster is **not** a DCS Cluster. The two names overlap because both use the word "cluster" but the underlying concepts are different: a DCS Cluster is a host pool, and a DCS Datastore Cluster is a datastore pool. Watch for this collision when reading platform documentation or talking to DCS administrators.
+
+#### DCS Distributed Virtual Switch (DVS) \{#dcs-dvs}
+
+A virtual switch on the DCS platform that spans one or more DCS Hosts. Virtual machine NICs attach to a DCS Port Group, which in turn belongs to a DCS DVS. The provider queries DVSs through `GET /service/sites/{siteId}/dvswitchs`.
+
+#### DCS Port Group \{#dcs-port-group}
+
+A network configuration entry on a DCS DVS. Each port group carries a VLAN configuration, security policies, and other network settings. The provider queries port groups through `GET {dvSwitchUri}/portgroups` (using the parent DVS URI) and references them by name (`portGroupName`) or URN (`portGroupUrn`).
+
+A virtual machine NIC must attach to exactly one DCS Port Group. Additional NICs require additional port-group references.
+
+#### DCS Volume \{#dcs-volume}
+
+A persistent disk on the DCS platform. Volumes live on DCS Datastores and are identified by a URN such as `urn:sites:EC1C108C:volumes:9841`. The provider creates volumes through `POST /service/sites/{siteId}/volumes` when `DCSIpHostnamePool.spec.pool[].persistentDisk[]` declares disks that must survive virtual machine replacement; it attaches the resulting volume to the virtual machine through the `attachvol` action.
+
+A DCS Volume is conceptually different from a Kubernetes `PersistentVolume`. A DCS Volume is a DCS-platform storage object attached at the hypervisor level; a Kubernetes `PersistentVolume` is a Kubernetes API object that represents storage available to pods. The provider only manages DCS Volumes; in-cluster `PersistentVolume` resources are managed separately by the workload's CSI driver.
+
+#### DCS Cloud Credential \{#dcs-cloud-credential}
+
+The authentication material used by the provider to call the DCS REST API. The provider obtains a session token by sending `X-Auth-User` and `X-Auth-Key` headers to `POST /service/session` and uses the returned `X-Auth-Token` header on subsequent requests. The credentials are stored as a Kubernetes `Secret` referenced from `DCSCluster.spec.credentialSecretRef`. The Secret contains `authUser`, `authKey`, `endpoint`, and `site` keys.
+
+### Cluster API Resource Mapping \{#cluster-api-resource-mapping}
+
+The following table disambiguates the DCS platform concepts whose names resemble Cluster API custom resources.
+
+| DCS platform concept | Cluster API resource with a similar name | Why they are not the same |
+|---|---|---|
+| DCS Cluster | `DCSCluster` (CRD) | A DCS Cluster is a pool of physical hosts on the DCS platform. `DCSCluster` is a Cluster API custom resource that represents the infrastructure side of a Kubernetes cluster running on top of the DCS platform. A single DCS Cluster can host the virtual machines of one or many Kubernetes clusters. |
+| DCS Host | Kubernetes Node | A DCS Host is a physical server registered on the DCS platform. A Kubernetes Node is a workload host inside a Kubernetes cluster running `kubelet`. The provider does not expose DCS Hosts to Kubernetes; the relationship between a Kubernetes Node and the DCS Host it runs on is decided by the DCS scheduler and is not represented in any custom resource. |
+| DCS VM Template | `DCSMachineTemplate` (CRD) | A DCS VM Template is an OS image template prepared by a DCS administrator on the DCS platform. `DCSMachineTemplate` is a Cluster API resource that references that template by name and adds Kubernetes-specific configuration (CPU, memory, disks, network). The `DCSMachineTemplate` does not contain image data; it points to a DCS VM Template by `vmTemplateName`. |
+| DCS Volume | Kubernetes `PersistentVolume` | A DCS Volume is a DCS-platform storage object attached at the hypervisor level. A Kubernetes `PersistentVolume` is a Kubernetes API object representing storage available to pods. The provider creates DCS Volumes (driven by `DCSIpHostnamePool.spec.pool[].persistentDisk[]`); Kubernetes `PersistentVolume` resources are managed independently by the workload's CSI driver. |
+| DCS Cloud Credential | Kubernetes `Secret` (referenced by `DCSCluster.spec.credentialSecretRef`) | A DCS Cloud Credential is the user/key pair issued by the DCS platform administrator. It is delivered to the provider as a Kubernetes `Secret` with the keys `authUser`, `authKey`, `endpoint`, and `site`. |
+
+The following concept does not collide with any Cluster API resource but is internally confusable because of the word "cluster":
+
+| DCS platform concept | Internally confusable with | Why they are not the same |
+|---|---|---|
+| DCS Datastore Cluster | DCS Cluster | A DCS Datastore Cluster is a group of DCS Datastores (storage). A DCS Cluster is a pool of DCS Hosts (compute). The two share the word "cluster" but belong to different layers of the DCS platform. |
+
+### Storage Concepts: Datastore, Datastore Cluster, and Volume \{#storage-concepts}
+
+The DCS platform exposes three storage-related concepts that the provider references separately:
+
+- A **DCS Datastore** is a single storage container. A virtual machine disk is pinned to one DCS Datastore.
+- A **DCS Datastore Cluster** is a group of DCS Datastores. A virtual machine disk that references a DCS Datastore Cluster is placed on one member datastore that has free capacity; the DCS scheduler picks the member.
+- A **DCS Volume** is a persistent disk object that lives on a DCS Datastore (or on a member datastore of a DCS Datastore Cluster). Volumes are created and attached to virtual machines through the provider when the `DCSIpHostnamePool` declares persistent disks; they survive virtual machine replacement.
+
+The relationship between the three:
+
+- A `DCSMachineTemplate` declares one or more disks under `vmConfig.dcsMachineDiskSpec[]`. Each disk binds to either a specific `datastoreName` or a `datastoreClusterName`. These template-level disks are created and destroyed together with the virtual machine.
+- A `DCSIpHostnamePool` entry can declare one or more `persistentDisk[]` items. Each item binds to either a specific `datastoreName` or a `datastoreClusterName`, and the provider creates a corresponding DCS Volume that survives virtual machine replacement.
+
+Cross-cluster visibility is determined by the underlying storage backend. SAN, IPSAN, NAS, and FusionStorage datastores are typically visible to several DCS Clusters; local-disk datastores are visible only to a single DCS Cluster. This visibility is what determines whether a single DCS VM Template can be cloned into more than one DCS Cluster.
+
+### Network Concepts: DVS, Port Group, and IP Identity \{#network-concepts}
+
+Network configuration on a DCS-backed Kubernetes cluster is split across two layers:
+
+- **DCS-side network plumbing (Layer 2)**: a virtual machine NIC must attach to a DCS Port Group, which belongs to a DCS Distributed Virtual Switch. The DVS and Port Group are DCS platform objects, created and administered on the DCS side. The provider references them by name (`dvSwitchName`, `portGroupName`) or by URN (`portGroupUrn`).
+- **Cluster-side network identity (Layer 3)**: the IP address, subnet mask, gateway, DNS server, and hostname assigned to the virtual machine are not DCS platform objects. They are declared in `DCSIpHostnamePool.spec.pool[]` entries (a Cluster API resource owned by the cluster operator) and are written into the virtual machine through cloud-init or Ignition during bootstrap.
+
+This split has two practical consequences:
+
+- The DCS platform team owns the DVS and Port Group definitions. The cluster operator owns the IP and hostname plan. The two are coordinated through the `DCSIpHostnamePool` resource, which references the DCS-side port group while declaring the cluster-side IP identity.
+- The provider does not call any DCS API to allocate or reserve IP addresses. Address conflicts must be avoided by the cluster operator when authoring `DCSIpHostnamePool` entries.
+
+The Cluster API resource `DCSIpHostnamePool` and the DCS platform's port group are distinct objects. The DCS platform does not have a native "IP pool" concept; the `DCSIpHostnamePool` resource is the only place where per-virtual-machine network identity is recorded.
+
+### Field-to-Concept Reference \{#field-to-concept-reference}
+
+The following tables map the most commonly used custom resource fields to the DCS platform concept they reference and to the source of the value.
+
+#### `DCSCluster` fields
+
+| Field | DCS platform concept | Value source |
+|---|---|---|
+| `spec.site` | [DCS Site](#dcs-site) | Site ID supplied by the DCS platform administrator. |
+| `spec.credentialSecretRef` | [DCS Cloud Credential](#dcs-cloud-credential) | Name of a Kubernetes `Secret` in the same namespace that holds the DCS user, key, endpoint, and site. |
+
+#### `DCSMachineTemplate` / `DCSMachine` fields
+
+| Field | DCS platform concept | Value source |
+|---|---|---|
+| `spec.template.spec.vmTemplateName` | [DCS VM Template](#dcs-vm-template) | Name of the template registered on the DCS platform (visible in the DCS portal). |
+| `spec.template.spec.location` (with `type: folder`) | [DCS VM Folder](#dcs-vm-folder) | Name of an existing VM Folder on the DCS platform. The folder must be created on the DCS side first. |
+| `spec.template.spec.location` (with `type: cluster`) | [DCS Cluster](#dcs-cluster) | Name of an existing DCS Cluster. Used only when the template's home cluster and the target cluster differ. See [Infrastructure → Advanced: Multi-Cluster Deployment](../../infrastructure/huawei-dcs.mdx#advanced-multi-cluster). |
+| `spec.template.spec.vmConfig.dvSwitchName` | [DCS DVS](#dcs-dvs) | Name of an existing DCS Distributed Virtual Switch. |
+| `spec.template.spec.vmConfig.portGroupName` | [DCS Port Group](#dcs-port-group) | Name of a port group that belongs to the referenced DCS DVS. |
+| `spec.template.spec.vmConfig.portGroupUrn` | [DCS Port Group](#dcs-port-group) | URN of an existing DCS Port Group. Mutually exclusive with `portGroupName`. |
+| `spec.template.spec.vmConfig.dcsMachineDiskSpec[].datastoreName` | [DCS Datastore](#dcs-datastore) | Name of a specific DCS Datastore. |
+| `spec.template.spec.vmConfig.dcsMachineDiskSpec[].datastoreClusterName` | [DCS Datastore Cluster](#dcs-datastore-cluster) | Name of a DCS Datastore Cluster that contains one or more datastores. Mutually exclusive with `datastoreName`. |
+| `spec.template.spec.vmConfig.dcsMachineDiskSpec[].datastoreUrn` | [DCS Datastore](#dcs-datastore) | URN of an existing DCS Datastore. Resolved internally from `datastoreName`. |
+| `spec.template.spec.vmConfig.cdRomDatastoreName` | [DCS Datastore](#dcs-datastore) | Name of a DCS Datastore that will hold the Ignition ISO. |
+| `spec.template.spec.vmConfig.cdRomDatastoreClusterName` | [DCS Datastore Cluster](#dcs-datastore-cluster) | Name of a DCS Datastore Cluster from which the Ignition ISO datastore is chosen. |
+
+#### `DCSIpHostnamePool` fields
+
+| Field | DCS platform concept | Value source |
+|---|---|---|
+| `spec.pool[].ip` / `mask` / `gateway` / `dns` / `hostname` | Cluster-side network identity (not a DCS platform concept) | Declared by the cluster operator; written into the virtual machine through cloud-init or Ignition. |
+| `spec.pool[].dvSwitchName` | [DCS DVS](#dcs-dvs) | Per-IP override of the DVS used for additional NICs. Falls back to the template-level DVS when omitted. |
+| `spec.pool[].portGroupName` / `portGroupUrn` | [DCS Port Group](#dcs-port-group) | Per-IP override of the port group used for additional NICs. |
+| `spec.pool[].persistentDisk[].datastoreName` | [DCS Datastore](#dcs-datastore) | Name of the DCS Datastore that will hold the persistent disk. |
+| `spec.pool[].persistentDisk[].datastoreClusterName` | [DCS Datastore Cluster](#dcs-datastore-cluster) | Name of the DCS Datastore Cluster that the persistent disk is created on. Mutually exclusive with `datastoreName`. |
+| `spec.pool[].persistentDisk[]` (the entry itself) | Creates a [DCS Volume](#dcs-volume) | The DCS Volume is created by the provider through `POST /service/sites/{siteId}/volumes` and attached to the virtual machine through the `attachvol` action. |
+
 ## Requirements
 
 - DCS platform with API access


### PR DESCRIPTION
## Summary

Back-port of #75 to `release-1.0`.

- Correct DCSMachineTemplate field documentation: remove the misleading `spec.resource` field from product docs (verified to be dead code), and rewrite the host-placement section to point users to DCS-side anti-affinity for cross-host control-plane HA instead of the previous incorrect guidance.
- Add a Concepts and Terminology section to `docs/en/overview/providers/huawei-dcs.mdx` covering 12 DCS platform concepts, with explicit disambiguation of the DCS Cluster vs DCSCluster CRD name collision and similar pairs.
- Add a setup preamble that defines `${DCS_BASE}` / `${SITE}` / `${TOKEN}` for the existing read-only diagnostic snippets so they can actually be executed.

## Back-port Notes

- Cherry-pick of `9ad648a` from `#75`. Only the three documentation files (`docs/en/overview/providers/huawei-dcs.mdx`, `docs/en/infrastructure/huawei-dcs.mdx`, `docs/en/manage-nodes/huawei-dcs.mdx`) are carried over.
- `package.json` / `yarn.lock` changes from the source commit are intentionally dropped on `release-1.0`. The doom dependency bump (`@alauda/doom` 2.4.0 → 2.5.1) was a side effect of local preview prep on `master`; back-porting documentation content to a stable release branch should not move a dev dependency.
- Conflict resolution: `git checkout --ours` on `package.json` and `yarn.lock` to keep the `release-1.0` baseline. The three documentation files cherry-picked cleanly.

## Context (full background)

See #75 for the full context, key decisions, and empirical-verification record. The conclusions hold for `release-1.0` because the underlying provider behavior is unchanged across the master and release-1.0 branches: `Spec.Resource` is dead code in both, `Spec.Location.Type=folder` works in both, and cross-host HA is implemented in neither.

## Verification

- `grep -rn "spec.template.spec.resource\|spec\\.resource\\b" docs/en --include="*.mdx"` returns empty after cherry-pick.
- `## Concepts and Terminology` anchor exists in `overview/providers/huawei-dcs.mdx`.
- 5 cross-page links to `overview/providers/huawei-dcs.mdx#concepts-and-terminology` resolve.

## Test Plan

- [ ] Run `yarn dev` against `release-1.0` locally and confirm the rendered output:
  - [ ] `overview/providers/huawei-dcs.mdx` shows the new `Concepts and Terminology` section with all sub-anchors reachable
  - [ ] `infrastructure/huawei-dcs.mdx` no longer mentions `spec.resource`; the new `Cross-Host High Availability` and `Advanced: Multi-Cluster Deployment` subsections render correctly; the `Running the diagnostic snippets` preamble appears before the first bash snippet
  - [ ] `manage-nodes/huawei-dcs.mdx` no longer mentions `spec.resource`; cross-links to the new infrastructure subsections work
- [ ] Verify left navigation under `Infrastructure` still shows two entries (Huawei DCS, Huawei Cloud Stack) with no insertion between them
- [ ] Verify left navigation under `Overview > Providers` is unchanged in structure
- [ ] Confirm `package.json` and `yarn.lock` are unchanged compared to current `release-1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)