### PR TITLE
docs(how-to): troubleshoot DCSMachine stuck in Deleting (AIT-67331) [release-1.0]

### DIFF
--- a/docs/en/how-to/troubleshoot-machine-stuck-deleting.mdx
+++ b/docs/en/how-to/troubleshoot-machine-stuck-deleting.mdx
@@ -1,0 +1,189 @@
+---
+weight: 40
+title: Troubleshoot a DCSMachine Stuck in Deleting
+queries:
+  - dcsmachine stuck deleting
+  - VMStopPending condition huawei dcs
+  - machine deletion stuck FC site policy
+  - errorCode 102212808 ait
+  - retain-vm annotation dcs cluster api provider
+---
+
+# Troubleshoot a DCSMachine Stuck in Deleting
+
+Use this guide when a `DCSMachine` on a Huawei DCS workload cluster stays in `Phase: Deleting` for longer than the expected ~60 seconds, blocking node turnover during scale-down, rolling upgrade, or full-cluster teardown.
+
+## Scope
+
+This guide covers the DCS-side failure modes that prevent `cluster-api-provider-dcs` from completing the `reconcileDelete` flow on a node. The provider's normal delete sequence is:
+
+```
+running VM  →  safe StopVm  →  stopped  →  (detach persistent disks if any)  →  DeleteVm  →  VM gone in DCS
+```
+
+Each step depends on the DCS platform responding. When DCS is unresponsive or refuses a step, the controller surfaces the wait reason on `DCSMachine.Status.Conditions.VMStopPending`. Reading that condition first usually identifies the problem without needing controller log access.
+
+This guide does **not** cover normal pre-deletion gating (CAPI `Machine` drain timeouts, finalizers held by other controllers) — those belong to upstream Cluster API troubleshooting.
+
+## Symptoms
+
+| Where to look | What you see |
+|---|---|
+| `Machine.status.phase` (on the `global` cluster) | `Deleting` for > 5 minutes |
+| `DCSMachine.status.conditions[?(@.type=="VMStopPending")]` | `Status: False` with a `Reason` and `Message` describing the wait |
+| DCS portal VM view | The VM is still listed (running, stopping, or some other non-stopped state) |
+| Controller log on the `global` cluster | A `cluster-api-provider-dcs-manager` line such as `issued safe StopVm` or `DeleteVm rejected by FC site policy` |
+
+If `VMStopPending` is absent and `Machine.status.phase` is still `Deleting`, the issue is more likely upstream of `reconcileDelete` (e.g., CAPI drain, kubeadm pre-delete hooks). Consult the [CAPI troubleshooting docs](https://cluster-api.sigs.k8s.io/user/troubleshooting.html) for that case.
+
+## Reading the VMStopPending Condition
+
+The `VMStopPending` condition is the primary signal for this guide.
+
+```shell
+kubectl -n <ns> describe dcsmachine <name>
+```
+
+Look for:
+
+```text
+Conditions:
+  Type:               VMStopPending
+  Status:             False
+  Severity:           Warning
+  Reason:             VMMidTransition
+  Message:            VM stuck in stopping; awaiting transition to stopped
+```
+
+The `Reason` field is the diagnostic:
+
+| Reason | Severity | What it means | Next step |
+|---|---|---|---|
+| `WaitingForStop` | Info | Safe `StopVm` was issued; controller polls every 10s for `stopped` | Wait up to ~60s. If the VM stays in `stopping` past that, jump to [VM Stuck in `stopping`](#vm-stuck-in-stopping). |
+| `VMMidTransition` | Warning | VM is in a transient state other than `running` / `stopped` (e.g., `stopping`, `starting`, `migrating`, `paused`, `hibernated`) | Inspect the `Message` field for the specific status. See [VM Stuck in Mid-Transition](#vm-stuck-in-mid-transition). |
+| *(condition absent)* | — | VM is either already `stopped` or already gone — controller is past the stop phase. | Check the DCS portal for VM existence and the `Machine` finalizers. |
+
+## Diagnostic Flows
+
+### VM Stuck in `stopping` \{#vm-stuck-in-stopping}
+
+The controller issued a graceful `StopVm` (calling DCS API `/action/stop?mode=safe`) and the VM acknowledged but never converged.
+
+Common causes:
+
+1. **VM `pvDriverStatus` is not `running`** — guest tools (vmtools / pvdriver) needed for graceful shutdown isn't responding. Verify on the DCS portal: open the VM detail page, check the `pvDriverStatus` field. If it shows anything other than `running`, the VM cannot accept a safe stop.
+2. **VM template predates `4.2.1`** — older DCS VM templates lack the guest tools required for safe stop. Confirm the `vmTemplateName` in the DCSMachine matches a `4.2.1+` template (label `cpaas.io/dcs-vm-template` on the `cpaas-system/<release>-dcs-vm-template` ConfigMap, see [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders)).
+3. **Guest OS hung** — the VM kernel is stuck and is not processing the ACPI shutdown.
+
+**Resolution path**:
+
+- For (1) and (3): Manually issue a `force` stop from the DCS portal (VM detail → Operations → Stop → Force). Once the VM reaches `stopped`, the controller's next reconcile picks up the new state and continues with `DeleteVm`.
+- For (2): The VM cannot be safely deleted by this provider on that template; back the workload off the node, manually power-off the VM, then [use `cpaas.io/retain-vm` to skip controller-side delete](#use-retain-vm-as-an-escape-hatch).
+
+### VM Stuck in Mid-Transition \{#vm-stuck-in-mid-transition}
+
+`Message` shows a status like `migrating`, `starting`, `paused`, or `hibernated`. The controller will not issue any operation on a VM in these states (DCS would reject) and is waiting indefinitely for the VM to converge to `running` or `stopped`.
+
+| Status in message | Likely cause | Resolution |
+|---|---|---|
+| `migrating` | Platform-initiated vMotion / live migration | Wait. Migration completes on its own; controller resumes when status reaches `running` or `stopped`. |
+| `starting` | Platform initiated VM start after a power event | Wait until `running`, then deletion proceeds. |
+| `paused` / `hibernated` | Platform-paused VM (does **not** self-recover) | Resume the VM manually from the DCS portal (Operations → Resume), or use [`cpaas.io/retain-vm`](#use-retain-vm-as-an-escape-hatch) to bypass and clean up the VM later. |
+
+### Controller Cannot Reach DCS API \{#controller-cannot-reach-dcs-api}
+
+If the `VMStopPending` condition is **absent** but `Machine.status.phase` is still `Deleting` for an extended period, the controller may be unable to talk to DCS at all. Check the controller log:
+
+```shell
+kubectl -n cpaas-system logs deployment/cluster-api-provider-dcs-manager --tail=50
+```
+
+Look for one of:
+
+| Log keyword | Cause |
+|---|---|
+| `connection refused` / `timeout` | DCS API endpoint unreachable from the `global` cluster |
+| `errorCode: 10100116` "帐户锁定中" | DCS admin account locked. See [DCS Account Lockout](#dcs-account-lockout). |
+| `401 Unauthorized` | Credential Secret is stale; rotate per [Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials). |
+
+### DCS Account Lockout \{#dcs-account-lockout}
+
+`errorCode: 10100116` indicates the DCS portal account in the cluster's credential Secret is in a brute-force lockout window. The DCS portal lockout policy resets per failed login, so a controller stuck in a retry loop will **indefinitely extend** the lockout.
+
+To break the cycle:
+
+```shell
+# 1. Scale the manager to 0 so it stops retrying
+kubectl -n cpaas-system scale deployment cluster-api-provider-dcs-manager --replicas=0
+
+# 2. Wait 5 minutes for the DCS lockout window to expire naturally
+sleep 300
+
+# 3. Restore the manager
+kubectl -n cpaas-system scale deployment cluster-api-provider-dcs-manager --replicas=1
+
+# 4. Verify the controller is happy
+kubectl -n cpaas-system logs deployment/cluster-api-provider-dcs-manager --tail=20
+```
+
+**Avoid reusing the DCS portal `admin` account for the provider's Secret in production.** Configure a dedicated DCS account (interconnect or domain user, see [Credential User Types](../infrastructure/huawei-dcs.mdx#user-types)) with the lockout policy relaxed, so a transient controller failure cannot lock the platform out for everyone.
+
+### FC Site Policy "仅能删除已停止虚拟机" (errorCode `102212808`) \{#fc-site-policy-stopped-only}
+
+If the workload cluster runs on a DCS site whose underlying FusionCompute platform has the "delete-only-when-stopped" safety policy enabled, **DeleteVm will be rejected when the VM is still `running`**. As of `cluster-api-provider-dcs v1.0.18`, the provider's normal delete flow handles this automatically by issuing safe `StopVm` before `DeleteVm`, but in rare race conditions an external actor (a human operator on the DCS portal, or another automation) can restart the VM between the controller's stop check and the `DeleteVm` call. The controller surfaces the race as:
+
+```text
+Controller log:
+  INFO  DeleteVm rejected by FC site policy, requeuing
+        vmUrn=urn:sites:<site>:vms:<vm-id>
+        errorCode=102212808
+```
+
+This is **not** an error — the controller treats `errorCode 102212808` as recoverable and requeues. The next reconcile re-checks VM status; if running again, the controller re-issues `StopVm(safe)` and proceeds. Normal recovery time is ~30 seconds.
+
+If you see this errorCode repeatedly (more than 3 cycles), an external actor is racing the controller. Suspend the external automation, or apply [`cpaas.io/retain-vm`](#use-retain-vm-as-an-escape-hatch) to fully take control of VM lifecycle outside the controller.
+
+## Use `cpaas.io/retain-vm` as an Escape Hatch \{#use-retain-vm-as-an-escape-hatch}
+
+When the controller cannot finish `reconcileDelete` for any reason and you need to release the `Machine` finalizer so the workload cluster can proceed (scale-down, upgrade, removal), annotate either the `Machine` or the `DCSMachine`:
+
+```shell
+kubectl -n <ns> annotate machine <machine-name> cpaas.io/retain-vm=true
+```
+
+Effect:
+
+- The controller's `reconcileDelete` recognizes the annotation, skips both `ensureVmStopped` and `DeleteVm`, and releases the `DCSMachine` finalizer.
+- The `Machine` then transitions out of `Deleting` and Cluster API can complete the parent operation.
+
+**Side effect — important**:
+
+- **The VM is not deleted from DCS** — it remains on the DCS platform, still consuming compute and storage resources, **outside Cluster API's lifecycle management**.
+- The IP / hostname slot in `DCSIpHostnamePool` is **also not released** — the pool entry will show as still in-use until you manually free it.
+
+After applying `retain-vm`, plan to manually:
+
+1. Stop and delete the VM on the DCS portal (or via DCS API).
+2. Free the IP / hostname entry from the corresponding `DCSIpHostnamePool`.
+3. (Optional) Clean up any persistent disks that were attached.
+
+## Verify Recovery
+
+After applying any of the resolutions above, watch the `DCSMachine` until the condition clears:
+
+```shell
+kubectl -n <ns> describe dcsmachine <name>
+# Look for: Conditions: VMStopPending  Status: True
+#           (or the condition disappears as the resource is deleted)
+
+kubectl -n <ns> get machines | grep <machine-name>
+# Phase should transition: Deleting → (Machine gone within ~30s)
+```
+
+If the `Machine` is fully gone and the VM is no longer listed on the DCS portal, recovery is complete.
+
+## See Also
+
+- [Creating Clusters on Huawei DCS](../create-cluster/huawei-dcs.mdx) — full cluster manifest reference
+- [Cloud Credentials for Huawei DCS](../infrastructure/huawei-dcs.mdx#cloud-credentials) — Secret format and User Types
+- [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx) — symptom-adjacent guide for cluster bring-up issues


### PR DESCRIPTION
## Summary

Backport of [PR #80](https://github.com/alauda/immutable-infra-docs/pull/80) (master) to `release-1.0`.

Adds a how-to guide that walks operators through the DCS-side failure modes preventing `cluster-api-provider-dcs` from completing `reconcileDelete` on a node — using the new `VMStopPending` condition surfaced by the provider as the primary diagnostic signal.

Use this guide when a `DCSMachine` stays in `Phase: Deleting` for longer than ~60 seconds (typical run is 60-90s including safe stop wait).

## Why on release-1.0

The matching `cluster-api-provider-dcs` change ([MR !38](https://gitlab-ce.alauda.cn/ait/cluster-api-provider-dcs/-/merge_requests/38)) targets `release-1.0` — that branch is the line shipping the new `ensureVmStopped` precondition + `VMStopPending` condition. Customer-facing troubleshooting doc must land on the same release line so it ships alongside the code change in the matching ACP release.

DBS customer specifically hit FC site policy errorCode `102212808` ("仅能删除已停止虚拟机") and the corresponding diagnostic decision tree is captured.

## Covered failure modes

1. VM stuck in mid-transition (stopping / starting / migrating)
2. safe StopVm rejected by DCS (4.2.1- template, guest tools failure)
3. FC site policy `102212808` race (external actor restarted VM)
4. DCS API connectivity loss (5xx, timeout, account lockout)
5. `cpaas.io/retain-vm` annotation as the operator escape hatch

## Empirical evidence

End-to-end validated against DCS test platform (site `EC1C108C`) on 2026-05-19 with the new `cluster-api-provider-dcs` v1.0.17-hotfix.38.1.g99dc8feb-it-67331-stop-vm-before-delete image:

- **Scenario A** (non-persistent CP delete): 78s end-to-end — observed `VMStopPending: False / VMMidTransition / Warning / "VM stuck in stopping; awaiting transition to stopped"` via `kubectl describe dcsmachine` exactly as documented.
- **Scenario C** (retain-vm annotation): 2s short-circuit — `reconcileDelete` skipped both StopVm and DeleteVm, finalizer released cleanly, VM stayed in DCS.

Full timeline + cross-validation evidence in [test-report.md](https://gitlab-ce.alauda.cn/ait/cluster-api-provider-dcs/-/blob/feat/AIT-67331-stop-vm-before-delete/docs/AIT-67331/test-report.md).

## Test plan

- [x] Wording stays in `docs/en/` only
- [x] Diagnostic command examples are operator-runnable
- [x] Cross-references to other how-to pages are non-broken
- [x] `frontmatter.queries` includes the customer's pain phrases

## Related

- master PR: https://github.com/alauda/immutable-infra-docs/pull/80
- cluster-api-provider-dcs MR !38: https://gitlab-ce.alauda.cn/ait/cluster-api-provider-dcs/-/merge_requests/38
- plugins-artifacts MR !308: https://gitlab-ce.alauda.cn/ait/plugins-artifacts/-/merge_requests/308
- AIT-67331 / DBS-142

🤖 Generated with [Claude Code](https://claude.com/claude-code)