### PR TITLE
docs(vmware): add global install and providerID guidance

### DIFF
--- a/.cspell/abbreviations.txt
+++ b/.cspell/abbreviations.txt
@@ -1,3 +1,4 @@
 CAPI
 CAPV
+Kubeadm
 kubelet

--- a/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
@@ -1211,6 +1211,11 @@ Prioritize the following checks:
 - If the `cpaas.io/registry-address` annotation is missing, verify the public registry credential and the platform controller that injects the annotation.
 - If a machine is stuck in `Provisioning`, check `VSphereMachine` conditions for `MachineConfigPoolReady` — it shows whether slot allocation failed due to pool binding or datacenter mismatch.
 - If a VM is waiting for IP allocation, verify VMware Tools, the static IP settings, and `VSphereVM.status.addresses`.
+- If workload `Node` objects remain without `spec.providerID`, first verify the CPI delivery resources and then check for duplicate vCenter guest hostnames. When an old VM in the same datacenter still reports the same guest hostname as a new node, `cloud-provider-vsphere` can fall back to node-name lookup, cache the old VM, and reject the new node because the VM IP does not match the kubelet node IP. Check the leader `vsphere-cloud-controller-manager` logs, the node `SystemUUID`, the real VM UUID, and vCenter guest hostname/IP values. After you fix or remove the duplicate hostname or old VM conflict, restart the workload cluster's `vsphere-cloud-controller-manager` Pods to clear the bad in-memory cache:
+  ```bash
+  kubectl --kubeconfig=/tmp/<cluster_name>.kubeconfig -n kube-system delete pod \
+    -l k8s-app=vsphere-cloud-controller-manager
+  ```
 - If datastore space is exhausted, verify whether old VM directories or `.vmdk` files remain in the target datastore.
 - If the template system disk size does not match the manifest values, first check the actual clone mode. When the VM was created as `linkedClone`, the system disk stays at the template's size and `diskGiB` is ignored. Only `fullClone` uses `diskGiB`, and in that case `diskGiB` must not be smaller than the template disk size.
 - If the control plane endpoint does not come up, verify the load balancer, the VIP, and port `6443`.

--- a/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
@@ -675,6 +675,7 @@ spec:
       server: "<vsphere_server>"
       template: "<template_name>"
       cloneMode: <clone_mode>
+      folder: "<vm_folder>"
       datastore: "<cp_system_datastore>"
       diskGiB: <cp_system_disk_gib>
       memoryMiB: <cp_memory_mib>
@@ -1006,6 +1007,7 @@ spec:
       server: "<vsphere_server>"
       template: "<template_name>"
       cloneMode: <clone_mode>
+      folder: "<vm_folder>"
       datastore: "<worker_system_datastore>"
       diskGiB: <worker_system_disk_gib>
       memoryMiB: <worker_memory_mib>

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -187,6 +187,7 @@ The template should also meet the following requirements:
 | Parameter | Placeholder | Required | Validation or Notes | Example | Actual Value |
 |-----------|-------------|----------|---------------------|---------|--------------|
 | Default datacenter | `<default_datacenter>` | Yes | Used by the baseline topology. | `dc-a` | - |
+| VM folder | `<vm_folder>` | Yes | Folder path for VMs created from `VSphereMachineTemplate`. Use `/<datacenter>/vm/<cluster_name>` so operators can identify which cluster the VMs belong to in vCenter. For `global` DR deployments, add one child folder under `<cluster_name>` to distinguish the primary and standby clusters. | `/dc-a/vm/demo-cluster` | - |
 
 ### Primary NIC parameters
 

--- a/docs/en/global/disaster_recovery.mdx
+++ b/docs/en/global/disaster_recovery.mdx
@@ -21,6 +21,7 @@ That deployment procedure is the authoritative source for the installation-time 
 - Primary and standby clusters use the same Kubernetes API server encryption provider configuration.
 - The etcd server certificate SAN list includes the local control plane VIP, Platform Access Address, and DR VIP.
 - Huawei DCS deployments reference the shared encryption provider Secret from `DCSCluster.spec.encryptionProviderConfigRef`.
+- VMware vSphere deployments write the same `/etc/kubernetes/encryption-provider.conf` file through `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
 - Huawei Cloud Stack deployments write the same `/etc/kubernetes/encryption-provider.conf` file through `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
 - The primary cluster installs `global-etcd-sync` with the standby cluster connection values after both installations succeed.
 
@@ -44,9 +45,7 @@ Follow the DCS steps in [Optional Disaster Recovery Deployment](./install.mdx#op
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere disaster recovery support for the `global` cluster on Immutable Infrastructure is planned.
-</Directive>
+Follow the VMware vSphere steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The VMware vSphere installation uses the same `KubeadmControlPlane` encryption file entry and etcd SAN configuration as the primary installation. No `VSphereCluster` encryption Secret reference is required.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">

--- a/docs/en/global/disaster_recovery.mdx
+++ b/docs/en/global/disaster_recovery.mdx
@@ -5,6 +5,7 @@ queries:
   - global cluster disaster recovery on immutable infrastructure
   - immutable infra etcd sync
   - microos global dr
+  - vmware vsphere global cluster disaster recovery
   - immutable os disaster recovery
 ---
 
@@ -19,10 +20,11 @@ Use [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-reco
 That deployment procedure is the authoritative source for the installation-time DR configuration, including:
 
 - Primary and standby clusters use the same Kubernetes API server encryption provider configuration.
-- The etcd server certificate SAN list includes the local control plane VIP, Platform Access Address, and DR VIP.
+- The etcd server certificate SAN list includes both the primary and standby control plane VIPs and the Platform Access Address.
 - Huawei DCS deployments reference the shared encryption provider Secret from `DCSCluster.spec.encryptionProviderConfigRef`.
 - VMware vSphere deployments write the same `/etc/kubernetes/encryption-provider.conf` file through `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
 - Huawei Cloud Stack deployments write the same `/etc/kubernetes/encryption-provider.conf` file through `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
+- VMware vSphere and Huawei Cloud Stack create the `dcs-import-extra-resources` ConfigMap before installer import so the installation can preserve provider-specific resources. The name keeps the `dcs` prefix for historical installer compatibility. Huawei DCS uses the built-in provider resource migration unless extra resources must be imported.
 - The primary cluster installs `global-etcd-sync` with the standby cluster connection values after both installations succeed.
 
 ## Operational Scope
@@ -31,7 +33,7 @@ After the primary and standby clusters are installed, operate DR as a separate l
 
 - Verify `etcd-sync` health and replication lag.
 - Verify that the standby cluster can decrypt Kubernetes Secrets created on the primary cluster.
-- Validate the DR VIP and platform access path before a planned failover.
+- Validate the primary and standby control plane VIPs and the platform access path before a planned failover.
 - Execute failover and failback with an approved operations procedure.
 - Reconcile provider-specific resources after a failover.
 
@@ -40,17 +42,17 @@ After the primary and standby clusters are installed, operate DR as a separate l
 <Tabs>
   <Tab label="Huawei DCS">
 
-Follow the DCS steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The DCS installation must keep the same encryption provider Secret and `DCSCluster.spec.encryptionProviderConfigRef` on both sides. Do not add the encryption provider file to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` for DCS.
+Follow the DCS steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The DCS installation must keep the same encryption provider Secret and `DCSCluster.spec.encryptionProviderConfigRef` on both sides. Do not add the encryption provider file to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` for DCS. DCS provider resources are migrated by the built-in flow; create `dcs-import-extra-resources` only when extra resources must be imported.
 
   </Tab>
   <Tab label="VMware vSphere">
 
-Follow the VMware vSphere steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The VMware vSphere installation uses the same `KubeadmControlPlane` encryption file entry and etcd SAN configuration as the primary installation. No `VSphereCluster` encryption Secret reference is required.
+Follow the VMware vSphere steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The VMware vSphere installation uses the same `KubeadmControlPlane` encryption file entry and etcd SAN configuration as the primary installation. No `VSphereCluster` encryption Secret reference is required. Create the VMware vSphere `dcs-import-extra-resources` ConfigMap so the installer imports vSphere infrastructure resources and the `global-vsphere-credentials` Secret referenced by `VSphereCluster.spec.identityRef.name`.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
 
-Follow the HCS steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The HCS installation uses the same `KubeadmControlPlane` encryption file entry and etcd SAN configuration as the primary installation. No `HCSCluster` encryption Secret reference is required.
+Follow the HCS steps in [Optional Disaster Recovery Deployment](./install.mdx#optional-disaster-recovery-deployment). The HCS installation uses the same `KubeadmControlPlane` encryption file entry and etcd SAN configuration as the primary installation. No `HCSCluster` encryption Secret reference is required. Create the HCS `dcs-import-extra-resources` ConfigMap so the installer imports HCS infrastructure resources and the Secret referenced by `HCSCluster.spec.identityRef.name`.
 
   </Tab>
   <Tab label="Bare Metal">

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -5,6 +5,7 @@ queries:
   - install global cluster on immutable infrastructure
   - microos global cluster installation
   - install platform on huawei dcs huawei cloud stack
+  - install global cluster on vmware vsphere immutable infrastructure
   - immutable os global install
   - global cluster naming convention prefix dr failover
 ---
@@ -556,6 +557,10 @@ Use the DCS resource fields from [Creating Clusters on Huawei DCS](../create-clu
 - Keep `/var/cpaas` as platform state. If you need the disk to survive rolling replacement, declare it in `DCSIpHostnamePool.spec.pool[].persistentDisk`; do not rely on `DCSMachineTemplate` template disks as preserved state.
 - Use concrete `datastoreName` values for DCS local storage unless you have verified that the selected datastore cluster can place volumes on hosts that can run the target VM.
 
+<Directive type="warning" title="Fragment Scope">
+  The following YAML is a differential fragment, not a complete manifest that you can apply directly. Merge these `global`-specific changes into the manifest that you prepare from the DCS create-cluster references, then apply the complete manifest file.
+</Directive>
+
 The following fragment shows the `global`-specific Cluster API wiring. Fill the provider resource fields by using the DCS create-cluster references above.
 
 ```yaml
@@ -641,17 +646,20 @@ The VMware vSphere `global` manifest must contain the following resources in the
 | `ClusterResourceSet`, `ConfigMap`, and `Secret` for the vSphere CPI | Delivers the vSphere CPI resources to the `global` cluster after the API server becomes reachable. |
 | `VSphereMachineConfigPool`, `VSphereMachineTemplate`, `KubeadmConfigTemplate`, and `MachineDeployment` for workers | Creates worker nodes. |
 
-Use the VMware vSphere resource fields from [Creating a VMware vSphere Cluster in the global Cluster](../create-cluster/vmware-vsphere/create-cluster-in-global.mdx) and [VMware vSphere Provider](../overview/providers/vmware-vsphere.mdx). For the `global` cluster, keep these additional requirements:
+Prepare the vSphere input values by using [Preparing Parameters for a VMware vSphere Cluster](../create-cluster/vmware-vsphere/parameter-checklist.mdx). Prepare the `global` cluster manifest by using [Creating a VMware vSphere Cluster in the global Cluster](../create-cluster/vmware-vsphere/create-cluster-in-global.mdx) and [VMware vSphere Provider](../overview/providers/vmware-vsphere.mdx) as the base references. The create-cluster guide is written for workload clusters that are created from the `global` cluster, but most vSphere YAML in that guide can be reused for the `global` cluster after you apply the following additional requirements:
 
 - Set `Cluster.metadata.name` and `VSphereCluster.metadata.name` to `global` (the infra cluster shares the CAPI `Cluster` name). Prefix every other CAPI resource and provider resource with `global-`; the wiring fragment below uses `KubeadmControlPlane.metadata.name: global-kcp`.
 - Add `Cluster.metadata.labels.is-global: "true"` and `Cluster.metadata.labels.cluster-type: VSphere`.
 - Add `Cluster.metadata.annotations["cpaas.io/registry-address"]` with `${NODE_REGISTRY_ADDRESS}`.
 - Keep the VMware vSphere annotations required by the platform controllers, including the network and CPI annotations from the VMware vSphere create-cluster guide.
-- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for MicroOS.
-- Keep the release manifest's non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries.
-- For a normal non-DR deployment, do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
-- Keep `/var/cpaas` as platform state. If the data disk must survive node replacement, declare it in `VSphereMachineConfigPool` instead of treating `VSphereMachineTemplate` alone as the state-preservation mechanism.
-- Use the vCenter network or port group name for `networkName`, and use the guest NIC name for `deviceName` when you need deterministic guest-network metadata.
+- Set `VSphereMachineTemplate.spec.template.spec.folder` to `/<datacenter>/vm/global` so operators can identify the `global` cluster VMs in vCenter. In a DR deployment, use distinct child folders such as `/<datacenter>/vm/global/primary` and `/<datacenter>/vm/global/standby` for the primary and standby clusters.
+- Set `VSphereCluster.spec.identityRef.name` to `global-vsphere-credentials`. This fixed Secret name is required only for the VMware vSphere `global` installation path; non-`global` VMware vSphere clusters follow the generic create-cluster guide.
+- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: cloud-init`, or leave the field unset because `cloud-init` is the default for VMware vSphere.
+- Keep the release manifest's kubeadm files, including the VMware vSphere `/etc/kubernetes/encryption-provider.conf` file entry, kubelet patches, audit policy, and installer RBAC entries. VMware vSphere delivers this file through `KubeadmControlPlane.spec.kubeadmConfigSpec.files`; do not follow the DCS `DCSCluster.spec.encryptionProviderConfigRef` pattern.
+
+<Directive type="warning" title="Fragment Scope">
+  The following YAML is a differential fragment, not a complete manifest that you can apply directly. Merge these `global`-specific changes into the manifest that you prepare from the VMware vSphere create-cluster guide, then apply the complete manifest file.
+</Directive>
 
 The following fragment shows the `global`-specific Cluster API wiring. Fill the provider resource fields by using the VMware vSphere create-cluster reference above.
 
@@ -708,7 +716,7 @@ spec:
       kind: VSphereMachineTemplate
       name: global-master-machine-template
   kubeadmConfigSpec:
-    format: ignition
+    format: cloud-init
     clusterConfiguration:
       etcd:
         local:
@@ -743,11 +751,15 @@ Use the HCS resource fields from [Creating Clusters on Huawei Cloud Stack](../cr
 - Set `Cluster.metadata.name` and `HCSCluster.metadata.name` to `global` (the infra cluster shares the CAPI `Cluster` name). Prefix every other CAPI resource and provider resource with `global-`; the wiring fragment below uses `KubeadmControlPlane.metadata.name: global-kcp`.
 - Add `Cluster.metadata.labels.is-global: "true"` and `Cluster.metadata.labels.cluster-type: HCS`.
 - Add `Cluster.metadata.annotations["cpaas.io/registry-address"]` with `${NODE_REGISTRY_ADDRESS}`.
-- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for MicroOS.
+- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: cloud-init`, or leave the field unset because `cloud-init` is the default for HCS.
 - Keep the release manifest's non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries.
 - For a normal non-DR deployment, do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
 - Keep `/var/cpaas` as platform state. HCS `dataVolumes` are used during creation, but they are not a guaranteed state-preservation mechanism during node replacement.
 - Use a highly available control plane for the `global` cluster. Single-control-plane HCS clusters are creation-only topologies and are not the recommended `global` upgrade path.
+
+<Directive type="warning" title="Fragment Scope">
+  The following YAML is a differential fragment, not a complete manifest that you can apply directly. Merge these `global`-specific changes into the manifest that you prepare from the HCS create-cluster references, then apply the complete manifest file.
+</Directive>
 
 The following fragment shows the `global`-specific Cluster API wiring. Fill the provider resource fields by using the HCS create-cluster references above.
 
@@ -801,7 +813,7 @@ spec:
       kind: HCSMachineTemplate
       name: global-master-machine-template
   kubeadmConfigSpec:
-    format: ignition
+    format: cloud-init
     clusterConfiguration:
       etcd:
         local:
@@ -863,11 +875,101 @@ kubectl get machines -n cpaas-system
 
 The control plane is ready when the `KubeadmControlPlane` reports `Ready: True` and the `Cluster` reports `Phase: Provisioned`.
 
-### Step 7 — Import Additional Resources When Required
+### Step 7 — Import Provider Resources
 
-Before triggering the installer, create the `dcs-import-extra-resources` ConfigMap when required by your deployment scenario.
+Before triggering the installer, create the `dcs-import-extra-resources` ConfigMap in the `cpaas-system` namespace for providers that require extra resource import. The ConfigMap name keeps the `dcs` prefix for historical installer compatibility, even when the provider is not Huawei DCS.
 
-This ConfigMap is mandatory for HCS DR standby installations (to import HCS infrastructure resources) and optional for DCS when you need to preserve additional resources beyond the default installation flow.
+VMware vSphere and Huawei Cloud Stack require this ConfigMap for both normal and disaster recovery `global` installations. Huawei DCS does not require it for the default installation because DCS provider resources are migrated by the built-in flow; create it for DCS only when you need to import additional resources beyond the built-in provider resource migration.
+
+<Tabs>
+  <Tab label="Huawei DCS">
+
+Do not create the DCS `dcs-import-extra-resources` ConfigMap for the default DCS installation path. DCS provider resources are migrated by the built-in flow. Create this ConfigMap only when your DCS deployment needs to import additional resources beyond the built-in provider resource migration, and keep the ConfigMap name exactly `dcs-import-extra-resources`.
+
+  </Tab>
+  <Tab label="VMware vSphere">
+
+Create and apply the VMware vSphere import ConfigMap before you trigger the installer. This ConfigMap is required for both normal and disaster recovery `global` installations. The `global-vsphere-credentials` Secret stores the vCenter username and password and must be the same Secret name referenced by `VSphereCluster.spec.identityRef.name` in the VMware vSphere `global` manifest.
+
+```shell
+mkdir -p /root/yamls
+cat > /root/yamls/dcs-import-extra-resources.yaml <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcs-import-extra-resources
+  namespace: cpaas-system
+data:
+  resources.yaml: |
+    resources:
+    - resource: "vsphereclusters.infrastructure.cluster.x-k8s.io"
+      names: ["global"]
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/vsphereclusters/cpaas-system/"
+      method: etcdctl
+    - resource: "vspheremachinetemplates.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/vspheremachinetemplates/cpaas-system/"
+      method: etcdctl
+    - resource: "vspheremachines.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/vspheremachines/cpaas-system/"
+      method: etcdctl
+    - resource: "vspherevms.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/vspherevms/cpaas-system/"
+      method: etcdctl
+    - resource: "vspheremachineconfigpools.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/vspheremachineconfigpools/cpaas-system/"
+      method: etcdctl
+    - resource: "secrets"
+      names: ["global-vsphere-credentials"]
+      method: kubectl
+EOF
+
+kubectl apply -f /root/yamls/dcs-import-extra-resources.yaml
+```
+
+  </Tab>
+  <Tab label="Huawei Cloud Stack">
+
+Create and apply the HCS import ConfigMap before you trigger the installer. This ConfigMap is required for both normal and disaster recovery `global` installations. Set `HCS_SECRET_NAME` to the same Secret name used by `HCSCluster.spec.identityRef.name`.
+
+```shell
+mkdir -p /root/yamls
+cat > /root/yamls/dcs-import-extra-resources.yaml <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcs-import-extra-resources
+  namespace: cpaas-system
+data:
+  resources.yaml: |
+    resources:
+    - resource: "secrets"
+      names: ["${HCS_SECRET_NAME}"]
+      method: kubectl
+    - resource: "hcsclusters.infrastructure.cluster.x-k8s.io"
+      names: ["global"]
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsclusters/cpaas-system/"
+      method: etcdctl
+    - resource: "hcsmachinetemplates.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsmachinetemplates/cpaas-system/"
+      method: etcdctl
+    - resource: "hcsmachineconfigpools.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsmachineconfigpools/cpaas-system/"
+      method: etcdctl
+    - resource: "hcsmachines.infrastructure.cluster.x-k8s.io"
+      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsmachines/cpaas-system/"
+      method: etcdctl
+EOF
+
+kubectl apply -f /root/yamls/dcs-import-extra-resources.yaml
+```
+
+  </Tab>
+  <Tab label="Bare Metal">
+    <Directive type="info" title="Status: Planned">
+      Bare-metal provider resource import for the `global` cluster on Immutable Infrastructure is planned.
+    </Directive>
+  </Tab>
+</Tabs>
 
 ### Step 8 — Trigger the Platform Installation
 
@@ -882,16 +984,16 @@ export INSTALLER_IP=$(kubectl get pods -n cpaas-system -l service_name=cpaas-ins
   `INSTALLER_IP` is the Pod IP of the embedded installer in `minialauda`. The endpoint is used only during installation.
 </Directive>
 
-Create the provider-specific installer configuration JSON file on the current KIND host, then submit it to the installer endpoint. DCS and HCS use the same endpoint path, but their request bodies are different.
+Create the provider-specific installer configuration JSON file on the current KIND host, then submit it to the installer endpoint. DCS, VMware vSphere, and HCS use the same endpoint path, but their request bodies are different.
 
-| Field | Huawei DCS | Huawei Cloud Stack |
-|-------|------------|--------------------|
-| Endpoint path | `/cpaas-installer/api/config/dcs` | `/cpaas-installer/api/config/dcs` |
-| `console.host` | Local `global` HA VIP list | Empty list, `[]` |
-| `console.globalHost` | Platform access address | Platform access address |
-| `cluster.clusterCIDR` and `cluster.serviceCIDR` | Required | Not set |
-| `cluster.features.ha` | Required, points to the local HA VIP with `isThirdParty: true` | Not set; HCS ELB is declared in `HCSCluster` |
-| `hostIP` | Current KIND host IP | Current KIND host IP |
+| Field | Huawei DCS | VMware vSphere | Huawei Cloud Stack |
+|-------|------------|----------------|--------------------|
+| Endpoint path | `/cpaas-installer/api/config/dcs` | `/cpaas-installer/api/config/dcs` | `/cpaas-installer/api/config/dcs` |
+| `console.host` | Local `global` HA VIP list | Empty list, `[]` | Empty list, `[]` |
+| `console.globalHost` | Platform access address | Platform access address | Platform access address |
+| `cluster.clusterCIDR` and `cluster.serviceCIDR` | Required | Not set; cluster CIDRs are declared in the VMware vSphere `Cluster` manifest | Not set |
+| `cluster.features.ha` | Required, points to the local HA VIP with `isThirdParty: true` | Not set; the control plane endpoint is declared in `VSphereCluster.spec.controlPlaneEndpoint.host` | Not set; HCS ELB is declared in `HCSCluster` |
+| `hostIP` | Current KIND host IP | Current KIND host IP | Current KIND host IP |
 
 <Tabs>
   <Tab label="Huawei DCS">
@@ -954,9 +1056,47 @@ Set `console.host` and `cluster.features.ha.vip` to the local `global` HA VIP. D
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere installer request details for the `global` cluster on Immutable Infrastructure are planned.
-</Directive>
+VMware vSphere uses the same installer endpoint path as DCS, but its request body does not include `cluster.features.ha`. The control plane endpoint is declared in `VSphereCluster.spec.controlPlaneEndpoint.host`, and the cluster CIDRs are declared in the VMware vSphere `Cluster` manifest.
+
+```shell
+mkdir -p /root/yamls
+export INSTALLER_CONFIG_JSON="/root/yamls/installer-config-vsphere.json"
+
+cat > "${INSTALLER_CONFIG_JSON}" <<EOF
+{
+  "basic": {
+    "username": "admin@cpaas.io",
+    "password": "<base64-platform-admin-password>"
+  },
+  "registry": {
+    "domain": "${REGISTRY_DOMAIN}",
+    "username": "<registry-username>",
+    "password": "<base64-registry-password>"
+  },
+  "console": {
+    "host": [],
+    "globalHost": "${PLATFORM_HOST}",
+    "httpPort": 80,
+    "httpsPort": 443,
+    "cert": {
+      "selfSigned": {}
+    }
+  },
+  "product": [
+    "base",
+    "acp"
+  ],
+  "deployMode": "normal",
+  "hostIP": "${HOST_IP}"
+}
+EOF
+
+curl -k -X POST "http://${INSTALLER_IP}:8080/cpaas-installer/api/config/dcs" \
+  -H 'Content-Type: application/json' \
+  -d @"${INSTALLER_CONFIG_JSON}"
+```
+
+Keep `console.host` as an empty list because the VMware vSphere control plane endpoint is already set in the `global` manifest. Do not use the platform domain in `console.host`; use `console.globalHost` for the platform access address.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
@@ -1069,7 +1209,7 @@ Issues that are not listed here usually point to environment-specific causes. Ca
 
 Use this section when you deploy primary and standby `global` clusters for disaster recovery. Complete these additions before you apply the provider-specific manifest for each `global` cluster.
 
-Primary and standby clusters must use the same encryption provider configuration. Normal non-DR deployments do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`; for DCS, normal non-DR deployments also do not set `DCSCluster.spec.encryptionProviderConfigRef`.
+Primary and standby clusters must use the same encryption provider configuration. For DCS and HCS, normal non-DR deployments do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`; for DCS, normal non-DR deployments also do not set `DCSCluster.spec.encryptionProviderConfigRef`. VMware vSphere keeps the release manifest's `/etc/kubernetes/encryption-provider.conf` file entry.
 
 ### Prepare Shared DR Variables
 
@@ -1078,7 +1218,6 @@ Set the same encryption key value on both the primary and standby installation e
 ```shell
 export ENCRYPTION_PROVIDER_CONF="/root/yamls/encryption-provider.conf"
 export ENCRYPTION_PROVIDER_SECRET_B64="<base64-shared-etcd-encryption-key>"
-export DR_VIP="<disaster-recovery-vip>"
 export PRIMARY_CLUSTER_VIP="<primary-ha-vip>"
 export STANDBY_CLUSTER_VIP="<standby-ha-vip>"
 export ETCD_SYNC_VERSION="<global-etcd-sync-version>"
@@ -1105,13 +1244,13 @@ EOF_CONF
 
 ### Add DR Certificate SANs to KubeadmControlPlane
 
-In the manifest generated in Step 4, include the local control plane VIP, platform access address, and DR VIP in `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.serverCertSANs`.
+In the manifest generated in Step 4, include both the primary and standby control plane VIPs and the platform access address in `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.serverCertSANs`. Use the same SAN list on both the primary and standby installation environments.
 
 ```yaml
 serverCertSANs:
-  - "${CONTROL_PLANE_VIP}"
+  - "${PRIMARY_CLUSTER_VIP}"
+  - "${STANDBY_CLUSTER_VIP}"
   - "${PLATFORM_HOST}"
-  - "${DR_VIP}"
 ```
 
 ### Add Provider-Specific DR Fields
@@ -1142,7 +1281,7 @@ If you created `dcs-import-extra-resources`, keep the ConfigMap on both the prim
   </Tab>
   <Tab label="VMware vSphere">
 
-No `VSphereCluster` encryption Secret reference is required. For VMware vSphere, append this file entry to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` on both the primary and standby installation environments. Render the manifest so that `${ENCRYPTION_PROVIDER_SECRET_B64}` is replaced with the same base64 key value on both sides.
+No `VSphereCluster` encryption Secret reference is required. For VMware vSphere, keep this file entry in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` on both the primary and standby installation environments. The rendered `/etc/kubernetes/encryption-provider.conf` content must be identical on both sides, including the provider order, key name, and base64 key value. Also create the VMware vSphere `dcs-import-extra-resources` ConfigMap from Step 7 on both installation environments so the installer imports the vSphere infrastructure resources and the `global-vsphere-credentials` Secret.
 
 ```yaml
 - path: /etc/kubernetes/encryption-provider.conf
@@ -1162,12 +1301,12 @@ No `VSphereCluster` encryption Secret reference is required. For VMware vSphere,
             secret: ${ENCRYPTION_PROVIDER_SECRET_B64}
 ```
 
-Keep the same `serverCertSANs` on both the primary and standby installation environments.
+Keep the same DR `serverCertSANs` list on both the primary and standby installation environments.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
 
-No `HCSCluster` encryption Secret reference is required. For HCS, append this file entry to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` on both the primary and standby installation environments. Render the manifest so that `${ENCRYPTION_PROVIDER_SECRET_B64}` is replaced with the same base64 key value on both sides.
+No `HCSCluster` encryption Secret reference is required. For HCS, append this file entry to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` on both the primary and standby installation environments. The rendered `/etc/kubernetes/encryption-provider.conf` content must be identical on both sides, including the provider order, key name, and base64 key value.
 
 ```yaml
 - path: /etc/kubernetes/encryption-provider.conf
@@ -1187,43 +1326,9 @@ No `HCSCluster` encryption Secret reference is required. For HCS, append this fi
             secret: ${ENCRYPTION_PROVIDER_SECRET_B64}
 ```
 
-Keep the same `serverCertSANs` on both the primary and standby installation environments.
+Keep the same DR `serverCertSANs` list on both the primary and standby installation environments.
 
-Create and apply `dcs-import-extra-resources` on the HCS standby installation environment before the HCS DR installer import. The ConfigMap name is shared by the installer and remains `dcs-import-extra-resources` even for HCS.
-
-```shell
-mkdir -p /root/yamls
-cat > /root/yamls/dcs-import-extra-resources.yaml <<EOF
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: dcs-import-extra-resources
-  namespace: cpaas-system
-data:
-  resources.yaml: |
-    resources:
-    - resource: "secrets"
-      names: ["${HCS_SECRET_NAME}"]
-      method: kubectl
-    - resource: "hcsclusters.infrastructure.cluster.x-k8s.io"
-      names: ["global"]
-      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsclusters/cpaas-system/"
-      method: etcdctl
-    - resource: "hcsmachinetemplates.infrastructure.cluster.x-k8s.io"
-      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsmachinetemplates/cpaas-system/"
-      method: etcdctl
-    - resource: "hcsmachineconfigpools.infrastructure.cluster.x-k8s.io"
-      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsmachineconfigpools/cpaas-system/"
-      method: etcdctl
-    - resource: "hcsmachines.infrastructure.cluster.x-k8s.io"
-      etcdKeyBase: "/registry/infrastructure.cluster.x-k8s.io/hcsmachines/cpaas-system/"
-      method: etcdctl
-EOF
-
-kubectl apply -f /root/yamls/dcs-import-extra-resources.yaml
-```
-
-Set `HCS_SECRET_NAME` to the same Secret name used by `HCSCluster.spec.identityRef.name`.
+Create the HCS `dcs-import-extra-resources` ConfigMap from Step 7 on both installation environments. Set `HCS_SECRET_NAME` to the same Secret name used by `HCSCluster.spec.identityRef.name`.
 
   </Tab>
   <Tab label="Bare Metal">
@@ -1242,8 +1347,8 @@ Use the provider-specific installer configuration differences for both sides:
 | Provider | Primary installation | Standby installation |
 |----------|----------------------|----------------------|
 | Huawei DCS | Set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. | Set `console.host` and `cluster.features.ha.vip` to the standby HA VIP. |
-| VMware vSphere | Set `VSphereCluster.spec.controlPlaneEndpoint.host` to the primary HA VIP used by the primary manifest. | Set `VSphereCluster.spec.controlPlaneEndpoint.host` to the standby HA VIP used by the standby manifest. |
-| Huawei Cloud Stack | Keep `console.host: []`; the primary VIP is managed by the HCS ELB. | Keep `console.host: []`; the standby VIP is managed by the HCS ELB. |
+| VMware vSphere | Set `VSphereCluster.spec.controlPlaneEndpoint.host` to the primary HA VIP used by the primary manifest. Create the VMware vSphere `dcs-import-extra-resources` ConfigMap from Step 7 and keep `global-vsphere-credentials` aligned with `VSphereCluster.spec.identityRef.name`. | Set `VSphereCluster.spec.controlPlaneEndpoint.host` to the standby HA VIP used by the standby manifest. Create the VMware vSphere `dcs-import-extra-resources` ConfigMap from Step 7 and keep `global-vsphere-credentials` aligned with `VSphereCluster.spec.identityRef.name`. |
+| Huawei Cloud Stack | Keep `console.host: []`; the primary VIP is managed by the HCS ELB. Create the HCS `dcs-import-extra-resources` ConfigMap from Step 7 and keep `HCS_SECRET_NAME` aligned with `HCSCluster.spec.identityRef.name`. | Keep `console.host: []`; the standby VIP is managed by the HCS ELB. Create the HCS `dcs-import-extra-resources` ConfigMap from Step 7 and keep `HCS_SECRET_NAME` aligned with `HCSCluster.spec.identityRef.name`. |
 
 For the primary cluster, make sure the platform domain resolves to the primary HA VIP. In Step 8, set `hostIP` to the primary KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. For VMware vSphere, set the control plane endpoint in the primary manifest to the primary HA VIP. For HCS, keep `console.host: []` because the VIP is owned by the HCS ELB.
 

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -101,6 +101,10 @@ The bootstrap script provisions an embedded registry, the Cluster API control pl
 
 Upload the Kubeadm provider package and the infrastructure provider package to the local registry.
 
+<Directive type="info" title="Why cluster.type is Baremetal for every provider">
+  The AppRelease values in the tabs below all set `global.cluster.type: Baremetal`. This is a chart-internal classifier, not the IaaS provider name. Keep `Baremetal` for the Huawei DCS, VMware vSphere, and Huawei Cloud Stack `global` installations. The value drives how the platform configures node-level components; it does not select the infrastructure provider.
+</Directive>
+
 <Tabs>
   <Tab label="Huawei DCS">
 
@@ -161,7 +165,7 @@ spec:
         isGlobal: true
         name: global
         networkType: kube-ovn
-        type: Baremetal # Provider internal value; keep Baremetal for DCS global installation.
+        type: Baremetal
       host: ${PLATFORM_HOST}
       ingress:
         ingressClassName: ${INGRESS_CLASS_NAME}
@@ -207,7 +211,7 @@ spec:
         isGlobal: true
         name: global
         networkType: kube-ovn
-        type: Baremetal # Provider internal value; keep Baremetal for DCS global installation.
+        type: Baremetal
       host: ${PLATFORM_HOST}
       ingress:
         ingressClassName: ${INGRESS_CLASS_NAME}
@@ -295,7 +299,7 @@ spec:
         isGlobal: true
         name: global
         networkType: kube-ovn
-        type: Baremetal # Provider internal value; keep Baremetal for VMware vSphere global installation.
+        type: Baremetal
       host: ${PLATFORM_HOST}
       ingress:
         ingressClassName: ${INGRESS_CLASS_NAME}
@@ -341,7 +345,7 @@ spec:
         isGlobal: true
         name: global
         networkType: kube-ovn
-        type: Baremetal # Provider internal value; keep Baremetal for VMware vSphere global installation.
+        type: Baremetal
       host: ${PLATFORM_HOST}
       ingress:
         ingressClassName: ${INGRESS_CLASS_NAME}
@@ -430,7 +434,7 @@ spec:
         isGlobal: true
         name: global
         networkType: kube-ovn
-        type: Baremetal # Provider internal value; keep Baremetal for HCS global installation.
+        type: Baremetal
       host: ${PLATFORM_HOST}
       ingress:
         ingressClassName: ${INGRESS_CLASS_NAME}
@@ -476,7 +480,7 @@ spec:
         isGlobal: true
         name: global
         networkType: kube-ovn
-        type: Baremetal # Provider internal value; keep Baremetal for HCS global installation.
+        type: Baremetal
       host: ${PLATFORM_HOST}
       ingress:
         ingressClassName: ${INGRESS_CLASS_NAME}
@@ -524,6 +528,14 @@ Use the provider creation guides as the detailed resource reference:
 - Huawei Cloud Stack: [Creating Clusters on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx)
 
 Apply the [naming convention from Common Prerequisites](#common-prerequisites) to every resource in the manifest you author below.
+
+Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format` to the value that the target provider accepts. The provider controllers enforce this:
+
+| Provider | Bootstrap userdata format |
+|----------|---------------------------|
+| Huawei DCS | `ignition` (provider-enforced; the DCS provider rejects any other format with `invalid format, expected ignition, got <other>`). |
+| VMware vSphere | `cloud-init` (provider default; setting `ignition` is not supported). |
+| Huawei Cloud Stack | `cloud-init` (provider-enforced; the HCS provider rejects `ignition` with `ignition format is not supported`). |
 
 <Tabs>
   <Tab label="Huawei DCS">
@@ -637,7 +649,7 @@ The VMware vSphere `global` manifest must contain the following resources in the
 
 | Resource | Purpose |
 |----------|---------|
-| `Secret` | Stores the vCenter username and password referenced by `VSphereCluster.spec.identityRef`. |
+| `Secret` (must be named `global-vsphere-credentials`) | Stores the vCenter username and password. Must be referenced by `VSphereCluster.spec.identityRef.name`. The fixed name is required for the vSphere `global` install path: the import ConfigMap in Step 7 and the DR section hardcode this exact name. |
 | `VSphereMachineConfigPool` for control plane nodes | Assigns static hostnames, datacenter values, IP addresses, network settings, and optional data disks. |
 | `VSphereMachineTemplate` for control plane nodes | Defines the VM template, clone mode, CPU, memory, datastore, folder, network devices, and system disk settings. |
 | `KubeadmControlPlane` | Bootstraps the Kubernetes control plane. Set `spec.version` to `${K8S_VERSION}`. |
@@ -884,7 +896,7 @@ VMware vSphere and Huawei Cloud Stack require this ConfigMap for both normal and
 <Tabs>
   <Tab label="Huawei DCS">
 
-Do not create the DCS `dcs-import-extra-resources` ConfigMap for the default DCS installation path. DCS provider resources are migrated by the built-in flow. Create this ConfigMap only when your DCS deployment needs to import additional resources beyond the built-in provider resource migration, and keep the ConfigMap name exactly `dcs-import-extra-resources`.
+Do not create the DCS `dcs-import-extra-resources` ConfigMap for the default DCS installation path. DCS provider resources are migrated by the built-in flow.
 
   </Tab>
   <Tab label="VMware vSphere">

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -18,7 +18,7 @@ This document describes how to install the `global` cluster onto Immutable Infra
 Choose this installation path when all of the following conditions apply:
 
 - You want the `global` cluster to run on an immutable operating system. MicroOS is the supported image today.
-- Your infrastructure is one of the documented providers: Huawei DCS or Huawei Cloud Stack. VMware vSphere and bare-metal support for the `global` cluster are planned.
+- Your infrastructure is one of the documented providers: Huawei DCS, VMware vSphere, or Huawei Cloud Stack. Bare-metal support for the `global` cluster is planned.
 - You can run a temporary KIND host that has network access to the target IaaS platform.
 
 For traditional operating systems such as Ubuntu or RHEL, use <ExternalSiteLink name="acp" href="/install/index.html" children="the standard installation path" /> instead.
@@ -53,7 +53,7 @@ Before installation, record the supported version set for the delivery package:
 |-------|---------|
 | Core Package version | Provides the installer, local registry, and base platform payload. |
 | Kubeadm provider chart version | Must match the Cluster API control plane resources used by the global manifest. |
-| Infrastructure provider chart version | Use the DCS or HCS provider chart version delivered with the target release. |
+| Infrastructure provider chart version | Use the VMware vSphere, DCS, or HCS provider chart version delivered with the target release. |
 | MicroOS image or VM template | Must contain the Kubernetes version used by `K8S_VERSION`. |
 | `K8S_VERSION` | Use v-prefixed semver that matches the target MicroOS image, such as `v<major>.<minor>.<patch>`. |
 
@@ -238,9 +238,136 @@ done
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere support for the `global` cluster on Immutable Infrastructure is planned. This installation procedure will be added in a later release.
-</Directive>
+Set the provider package paths and chart versions.
+
+```shell
+export VSPHERE_PROVIDER_PACK="/root/cluster-api-provider-vsphere.amd64.<version>.tgz"
+export KUBEADM_PROVIDER_PACK="/root/cluster-api-provider-kubeadm.amd64.<version>.tgz"
+export VSPHERE_PROVIDER_VERSION="<vsphere-provider-chart-version>"
+export KUBEADM_PROVIDER_VERSION="<kubeadm-provider-chart-version>"
+```
+
+Upload the packages.
+
+```shell
+/root/cpaas-install/installer/res/amd64/packtool pack push \
+  -r "${LOCAL_REGISTRY_ADDRESS}" -c "${VSPHERE_PROVIDER_PACK}"
+
+/root/cpaas-install/installer/res/amd64/packtool pack push \
+  -r "${LOCAL_REGISTRY_ADDRESS}" -c "${KUBEADM_PROVIDER_PACK}"
+```
+
+Create and apply the AppRelease resources for the Kubeadm provider and the VMware vSphere provider.
+
+```shell
+mkdir -p /root/yamls
+export VSPHERE_PROVIDER_APPRELEASES="/root/yamls/vsphere-provider-appreleases.yaml"
+
+cat > "${VSPHERE_PROVIDER_APPRELEASES}" <<EOF
+---
+apiVersion: operator.alauda.io/v1alpha1
+kind: AppRelease
+metadata:
+  annotations:
+    auto-recycle: "true"
+    interval-sync: "true"
+  name: cluster-api-provider-kubeadm
+  namespace: cpaas-system
+spec:
+  destination:
+    cluster: ""
+    namespace: ""
+  source:
+    chartPullSecret: global-registry-auth
+    charts:
+      - name: ait/chart-cluster-api-provider-kubeadm
+        releaseName: cluster-api-provider-kubeadm
+        targetRevision: ${KUBEADM_PROVIDER_VERSION}
+    repoURL: ${BOOTSTRAP_REGISTRY_ADDRESS}
+  timeout: 120
+  values:
+    global:
+      albName: ${INGRESS_CLASS_NAME}
+      auth:
+        default_admin: admin@cpaas.io
+      cluster:
+        isGlobal: true
+        name: global
+        networkType: kube-ovn
+        type: Baremetal # Provider internal value; keep Baremetal for VMware vSphere global installation.
+      host: ${PLATFORM_HOST}
+      ingress:
+        ingressClassName: ${INGRESS_CLASS_NAME}
+      labelBaseDomain: cpaas.io
+      namespace: cpaas-system
+      platformUrl: https://${PLATFORM_HOST}
+      protectSecretFiles:
+        enabled: false
+      region: global
+      registry:
+        address: ${BOOTSTRAP_REGISTRY_ADDRESS}
+        imagePullSecrets:
+          - global-registry-auth
+      replicas: 1
+      scheme: https
+---
+apiVersion: operator.alauda.io/v1alpha1
+kind: AppRelease
+metadata:
+  annotations:
+    auto-recycle: "true"
+    interval-sync: "true"
+  name: cluster-api-provider-vsphere
+  namespace: cpaas-system
+spec:
+  destination:
+    cluster: ""
+    namespace: ""
+  source:
+    chartPullSecret: global-registry-auth
+    charts:
+      - name: ait/chart-cluster-api-provider-vsphere
+        releaseName: cluster-api-provider-vsphere
+        targetRevision: ${VSPHERE_PROVIDER_VERSION}
+    repoURL: ${BOOTSTRAP_REGISTRY_ADDRESS}
+  timeout: 120
+  values:
+    global:
+      albName: ${INGRESS_CLASS_NAME}
+      auth:
+        default_admin: admin@cpaas.io
+      cluster:
+        isGlobal: true
+        name: global
+        networkType: kube-ovn
+        type: Baremetal # Provider internal value; keep Baremetal for VMware vSphere global installation.
+      host: ${PLATFORM_HOST}
+      ingress:
+        ingressClassName: ${INGRESS_CLASS_NAME}
+      labelBaseDomain: cpaas.io
+      namespace: cpaas-system
+      platformUrl: https://${PLATFORM_HOST}
+      protectSecretFiles:
+        enabled: false
+      region: global
+      registry:
+        address: ${BOOTSTRAP_REGISTRY_ADDRESS}
+        imagePullSecrets:
+          - global-registry-auth
+      replicas: 1
+      scheme: https
+EOF
+
+kubectl apply -f "${VSPHERE_PROVIDER_APPRELEASES}"
+
+until kubectl get crd kubeadmcontrolplanes.controlplane.cluster.x-k8s.io --ignore-not-found 2>/dev/null | grep -q kubeadmcontrolplanes.controlplane.cluster.x-k8s.io; do
+  sleep 10
+done
+
+until kubectl get crd vsphereclusters.infrastructure.cluster.x-k8s.io --ignore-not-found 2>/dev/null | grep -q vsphereclusters.infrastructure.cluster.x-k8s.io; do
+  sleep 10
+done
+```
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
@@ -392,6 +519,7 @@ Create one provider-specific manifest for the `global` cluster. The manifest use
 Use the provider creation guides as the detailed resource reference:
 
 - Huawei DCS: [Creating Clusters on Huawei DCS](../create-cluster/huawei-dcs.mdx)
+- VMware vSphere: [Creating a VMware vSphere Cluster in the global Cluster](../create-cluster/vmware-vsphere/create-cluster-in-global.mdx)
 - Huawei Cloud Stack: [Creating Clusters on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx)
 
 Apply the [naming convention from Common Prerequisites](#common-prerequisites) to every resource in the manifest you author below.
@@ -494,9 +622,100 @@ spec:
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere manifest requirements for the `global` cluster on Immutable Infrastructure are planned.
-</Directive>
+Set the output path for the VMware vSphere `global` manifest before you render it.
+
+```shell
+export GLOBAL_VSPHERE_YAML="/root/yamls/new-global.yaml"
+```
+
+The VMware vSphere `global` manifest must contain the following resources in the `cpaas-system` namespace:
+
+| Resource | Purpose |
+|----------|---------|
+| `Secret` | Stores the vCenter username and password referenced by `VSphereCluster.spec.identityRef`. |
+| `VSphereMachineConfigPool` for control plane nodes | Assigns static hostnames, datacenter values, IP addresses, network settings, and optional data disks. |
+| `VSphereMachineTemplate` for control plane nodes | Defines the VM template, clone mode, CPU, memory, datastore, folder, network devices, and system disk settings. |
+| `KubeadmControlPlane` | Bootstraps the Kubernetes control plane. Set `spec.version` to `${K8S_VERSION}`. |
+| `VSphereCluster` | Defines the vCenter endpoint, thumbprint, credential reference, and control plane endpoint. |
+| `Cluster` | Connects the Cluster API `Cluster` to `VSphereCluster` and `KubeadmControlPlane`. |
+| `ClusterResourceSet`, `ConfigMap`, and `Secret` for the vSphere CPI | Delivers the vSphere CPI resources to the `global` cluster after the API server becomes reachable. |
+| `VSphereMachineConfigPool`, `VSphereMachineTemplate`, `KubeadmConfigTemplate`, and `MachineDeployment` for workers | Creates worker nodes. |
+
+Use the VMware vSphere resource fields from [Creating a VMware vSphere Cluster in the global Cluster](../create-cluster/vmware-vsphere/create-cluster-in-global.mdx) and [VMware vSphere Provider](../overview/providers/vmware-vsphere.mdx). For the `global` cluster, keep these additional requirements:
+
+- Set `Cluster.metadata.name` and `VSphereCluster.metadata.name` to `global` (the infra cluster shares the CAPI `Cluster` name). Prefix every other CAPI resource and provider resource with `global-`; the wiring fragment below uses `KubeadmControlPlane.metadata.name: global-kcp`.
+- Add `Cluster.metadata.labels.is-global: "true"` and `Cluster.metadata.labels.cluster-type: VSphere`.
+- Add `Cluster.metadata.annotations["cpaas.io/registry-address"]` with `${NODE_REGISTRY_ADDRESS}`.
+- Keep the VMware vSphere annotations required by the platform controllers, including the network and CPI annotations from the VMware vSphere create-cluster guide.
+- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for MicroOS.
+- Keep the release manifest's non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries.
+- For a normal non-DR deployment, do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
+- Keep `/var/cpaas` as platform state. If the data disk must survive node replacement, declare it in `VSphereMachineConfigPool` instead of treating `VSphereMachineTemplate` alone as the state-preservation mechanism.
+- Use the vCenter network or port group name for `networkName`, and use the guest NIC name for `deviceName` when you need deterministic guest-network metadata.
+
+The following fragment shows the `global`-specific Cluster API wiring. Fill the provider resource fields by using the VMware vSphere create-cluster reference above.
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: global
+  namespace: cpaas-system
+  labels:
+    cluster-type: VSphere
+    is-global: "true"
+    addons.cluster.x-k8s.io/vsphere-cpi: "enabled"
+  annotations:
+    capi.cpaas.io/resource-group-version: infrastructure.cluster.x-k8s.io/v1beta1
+    capi.cpaas.io/resource-kind: VSphereCluster
+    cpaas.io/alb-address-type: ClusterAddress
+    cpaas.io/network-type: kube-ovn
+    cpaas.io/registry-address: "${NODE_REGISTRY_ADDRESS}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - ${CLUSTER_CIDR}
+    services:
+      cidrBlocks:
+        - ${SERVICE_CIDR}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: global-kcp
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: VSphereCluster
+    name: global
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: global-kcp
+  namespace: cpaas-system
+spec:
+  replicas: 3
+  version: "${K8S_VERSION}"
+  rolloutStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+  machineTemplate:
+    nodeDrainTimeout: 1m
+    nodeDeletionTimeout: 5m
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: VSphereMachineTemplate
+      name: global-master-machine-template
+  kubeadmConfigSpec:
+    format: ignition
+    clusterConfiguration:
+      etcd:
+        local:
+          serverCertSANs:
+            - "${CONTROL_PLANE_VIP}"
+            - "${PLATFORM_HOST}"
+```
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
@@ -613,9 +832,9 @@ kubectl apply -f "${GLOBAL_DCS_YAML}"
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere apply steps for the `global` cluster on Immutable Infrastructure are planned.
-</Directive>
+```shell
+kubectl apply -f "${GLOBAL_VSPHERE_YAML}"
+```
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
@@ -923,9 +1142,27 @@ If you created `dcs-import-extra-resources`, keep the ConfigMap on both the prim
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere disaster recovery settings for the `global` cluster on Immutable Infrastructure are planned.
-</Directive>
+No `VSphereCluster` encryption Secret reference is required. For VMware vSphere, append this file entry to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` on both the primary and standby installation environments. Render the manifest so that `${ENCRYPTION_PROVIDER_SECRET_B64}` is replaced with the same base64 key value on both sides.
+
+```yaml
+- path: /etc/kubernetes/encryption-provider.conf
+  owner: "root:root"
+  append: false
+  permissions: "0644"
+  content: |
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: EncryptionConfiguration
+    resources:
+    - resources:
+      - secrets
+      providers:
+      - aescbc:
+          keys:
+          - name: key1
+            secret: ${ENCRYPTION_PROVIDER_SECRET_B64}
+```
+
+Keep the same `serverCertSANs` on both the primary and standby installation environments.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
@@ -1005,11 +1242,12 @@ Use the provider-specific installer configuration differences for both sides:
 | Provider | Primary installation | Standby installation |
 |----------|----------------------|----------------------|
 | Huawei DCS | Set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. | Set `console.host` and `cluster.features.ha.vip` to the standby HA VIP. |
+| VMware vSphere | Set `VSphereCluster.spec.controlPlaneEndpoint.host` to the primary HA VIP used by the primary manifest. | Set `VSphereCluster.spec.controlPlaneEndpoint.host` to the standby HA VIP used by the standby manifest. |
 | Huawei Cloud Stack | Keep `console.host: []`; the primary VIP is managed by the HCS ELB. | Keep `console.host: []`; the standby VIP is managed by the HCS ELB. |
 
-For the primary cluster, make sure the platform domain resolves to the primary HA VIP. In Step 8, set `hostIP` to the primary KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. For HCS, keep `console.host: []` because the VIP is owned by the HCS ELB.
+For the primary cluster, make sure the platform domain resolves to the primary HA VIP. In Step 8, set `hostIP` to the primary KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. For VMware vSphere, set the control plane endpoint in the primary manifest to the primary HA VIP. For HCS, keep `console.host: []` because the VIP is owned by the HCS ELB.
 
-After the primary cluster installation succeeds, switch the platform domain to the standby HA VIP as required by the DR procedure. Then install the standby cluster. In Step 8 on the standby KIND host, set `hostIP` to the standby KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the standby HA VIP. For HCS, keep `console.host: []`. Get `INSTALLER_IP` from the `cpaas-installer` Pod on the standby KIND host; do not reuse the primary KIND host value.
+After the primary cluster installation succeeds, switch the platform domain to the standby HA VIP as required by the DR procedure. Then install the standby cluster. In Step 8 on the standby KIND host, set `hostIP` to the standby KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the standby HA VIP. For VMware vSphere, set the control plane endpoint in the standby manifest to the standby HA VIP. For HCS, keep `console.host: []`. Get `INSTALLER_IP` from the `cpaas-installer` Pod on the standby KIND host; do not reuse the primary KIND host value.
 
 After both clusters are installed, get the primary `k8sadmin` token on a primary control plane node. `etcd-sync` is installed only on the standby cluster, and its `active_cluster_*` values point to the primary cluster. Keep this value in its original base64 Secret form for `active_cluster_token`.
 


### PR DESCRIPTION
Add VMware vSphere content to the immutable global cluster installation guide:
- document provider package upload and AppRelease installation for the vSphere provider
- add vSphere global manifest requirements, resource checklist, and CAPI wiring example
- add vSphere manifest apply command
- document vSphere DR encryption-provider configuration and primary/standby endpoint handling
- update global DR notes to mark VMware vSphere DR as supported
- add troubleshooting for missing Node providerID caused by duplicate vCenter guest hostnames and stale cloud-provider-vsphere cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added VM folder guidance for vSphere manifests and a checklist entry with required folder path format and global-DR naming advice.
  * Expanded troubleshooting for vSphere Nodes missing provider IDs, duplicate guest-hostname conflicts, and how to clear controller cache.
  * Clarified immutable-infrastructure DR requirements: encryption alignment, etcd certificate SANs, import ConfigMap/credentials, and updated failover validation.
  * Completed global install docs for vSphere: provider install/import steps, package upload, and HA/encryption alignment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/immutable-infra-docs/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->