### PR TITLE
docs: add HCS keep-disk guidance

### DIFF
--- a/docs/en/apis/providers/huawei-cloud-stack/index.mdx
+++ b/docs/en/apis/providers/huawei-cloud-stack/index.mdx
@@ -22,7 +22,7 @@ The Huawei Cloud Stack Infrastructure Provider defines custom resources for mana
 | `HCSCluster` | Represents a Kubernetes cluster infrastructure on HCS | [HCSCluster](./hcscluster.mdx) |
 | `HCSMachine` | Represents a virtual machine in HCS | [HCSMachine](./hcsmachine.mdx) |
 | `HCSMachineTemplate` | Template for creating HCS machines | [HCSMachineTemplate](./hcsmachinetemplate.mdx) |
-| `HCSMachineConfigPool` | Pool of IP addresses and hostnames | [HCSMachineConfigPool](./hcsmachineconfigpool.mdx) |
+| `HCSMachineConfigPool` | Pool of hostnames, static IP addresses, and persistent disk slots | [HCSMachineConfigPool](./hcsmachineconfigpool.mdx) |
 
 ## API Group
 

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -97,6 +97,7 @@ data:
   projectID: <base64-encoded-project-id>
   region: <base64-encoded-region>
   externalGlobalDomain: <base64-encoded-domain>
+  schema: <base64-encoded-schema>
 ```
 
 | Parameter | Description |
@@ -106,6 +107,7 @@ data:
 | `.data.projectID` | Resource Space ID from **My Settings** > **Resource Spaces** (base64-encoded) |
 | `.data.region` | HCS region API value used by the provider (base64-encoded). Tenant administrators cannot retrieve this value from the HCS UI; get it from the HCS administrator |
 | `.data.externalGlobalDomain` | HCS platform access domain used by the provider (base64-encoded) |
+| `.data.schema` | Optional API scheme for the HCS IAM endpoint, usually `https` (base64-encoded). If omitted, the provider uses `https` |
 
 You can reuse an existing HCS credential Secret. Its name does not need to match the cluster name, but `HCSCluster.spec.identityRef.name` must reference this Secret.
 

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -131,6 +131,8 @@ kind: HCSMachineConfigPool
 metadata:
   name: <cluster-name>-cp-pool
   namespace: cpaas-system
+  labels:
+    cluster.x-k8s.io/cluster-name: <cluster-name>
 spec:
   configs:
     - hostname: master-1
@@ -139,7 +141,7 @@ spec:
           ipAddress: 192.168.1.11
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -149,7 +151,7 @@ spec:
           ipAddress: 192.168.1.12
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -159,7 +161,7 @@ spec:
           ipAddress: 192.168.1.13
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -175,7 +177,7 @@ spec:
 | `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the VM |
 | `.spec.configs[].persistentDisks[]` | array | No | EVS disks that survive HCSMachine delete-recreate replacement |
 | `.spec.configs[].persistentDisks[].slot` | int | Yes* | Disk slot within one machine configuration. Slots must be unique and contiguous from `0` for the same hostname |
-| `.spec.configs[].persistentDisks[].size` | int | Yes* | EVS disk size in GB |
+| `.spec.configs[].persistentDisks[].size` | int | Yes* | EVS disk size in GB. For newly created EVS data disks, use `10` to `32768` GB. Existing claimed disks must match their current size |
 | `.spec.configs[].persistentDisks[].type` | string | Yes* | EVS disk type name available in the target availability zone |
 | `.spec.configs[].persistentDisks[].mountPath` | string | No | Guest mount path. Use `/var/cpaas` for platform state that must survive VM replacement |
 | `.spec.configs[].persistentDisks[].format` | string | No | File system format. If omitted, the provider uses `xfs` |

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -111,7 +111,7 @@ You can reuse an existing HCS credential Secret. Its name does not need to match
 
 ### Configure Machine Configuration Pool
 
-The `HCSMachineConfigPool` defines pre-configured hostnames and static IP addresses for VMs.
+The `HCSMachineConfigPool` defines pre-configured hostnames, static IP addresses, and any pool-managed persistent disks for VMs.
 
 :::warning
 **Pool Size Requirement**
@@ -137,14 +137,32 @@ spec:
       networks:
         - subnetName: <subnet-name>
           ipAddress: 192.168.1.11
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
     - hostname: master-2
       networks:
         - subnetName: <subnet-name>
           ipAddress: 192.168.1.12
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
     - hostname: master-3
       networks:
         - subnetName: <subnet-name>
           ipAddress: 192.168.1.13
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
 ```
 
 | Parameter | Type | Required | Description |
@@ -155,8 +173,19 @@ spec:
 | `.spec.configs[].networks[].subnetName` | string | No* | Recommended subnet name field for new manifests |
 | `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
 | `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the VM |
+| `.spec.configs[].persistentDisks[]` | array | No | EVS disks that survive HCSMachine delete-recreate replacement |
+| `.spec.configs[].persistentDisks[].slot` | int | Yes* | Disk slot within one machine configuration. Slots must be unique and contiguous from `0` for the same hostname |
+| `.spec.configs[].persistentDisks[].size` | int | Yes* | EVS disk size in GB |
+| `.spec.configs[].persistentDisks[].type` | string | Yes* | EVS disk type name available in the target availability zone |
+| `.spec.configs[].persistentDisks[].mountPath` | string | No | Guest mount path. Use `/var/cpaas` for platform state that must survive VM replacement |
+| `.spec.configs[].persistentDisks[].format` | string | No | File system format. If omitted, the provider uses `xfs` |
+| `.spec.configs[].persistentDisks[].mountOptions` | array | No | Mount options. If omitted, the provider uses `defaults,noatime` |
 
 *For new manifests, set either `subnetName` or `subnetId`. Existing manifests may continue to use `subenetName`, and may add `subnetName` only if both fields use the same value. Do not provide conflicting subnet selector values.
+
+**Persistent disk fields are required when `persistentDisks` is specified.**
+
+Use `persistentDisks[]` for node-local state that must survive VM replacement. Do not declare the same mount path in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 
 **Note:** The CRD schema lists `subnetName`, `subenetName`, and `subnetId` as optional fields and does not express their allowed combinations. Follow the provider-level rules above when writing manifests.
 
@@ -173,7 +202,8 @@ The following data disk mount points are recommended for control plane nodes:
 - `/var/lib/etcd` - etcd data (10GB+)
 - `/var/lib/kubelet` - kubelet data (100GB+)
 - `/var/lib/containerd` - container runtime data (100GB+)
-- `/var/cpaas` - platform data and logs (40GB+)
+
+The `/var/cpaas` path stores platform state and logs. Declare it in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` when it must survive VM replacement.
 :::
 
 ```yaml
@@ -206,10 +236,6 @@ spec:
           type: SSD
           mountPath: /var/lib/containerd
           format: xfs
-        - size: 40
-          type: SSD
-          mountPath: /var/cpaas
-          format: xfs
 ```
 
 | Parameter | Type | Required | Description |
@@ -227,6 +253,8 @@ spec:
 | `.spec.template.spec.dataVolumes[].format` | string | Yes* | File system format (`xfs` or `ext4`) |
 
 *Required when dataVolumes is specified.
+
+`dataVolumes[]` are recreated with the ECS. Do not use them for `/var/cpaas` or any other path that must survive rolling replacement. Put those paths in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`.
 
 **Note:** Do not set runtime identity fields such as `providerID` or `serverId` in `HCSMachineTemplate` manifests. The provider assigns these values when it creates HCS instances.
 

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -109,6 +109,8 @@ data:
 | `.data.externalGlobalDomain` | HCS platform access domain used by the provider (base64-encoded) |
 | `.data.schema` | Optional API scheme for the HCS IAM endpoint, usually `https` (base64-encoded). If omitted, the provider uses `https` |
 
+Existing credential Secrets created without `schema` continue to work unchanged. Only set `schema` if your HCS IAM endpoint uses `http` instead of the default `https`.
+
 You can reuse an existing HCS credential Secret. Its name does not need to match the cluster name, but `HCSCluster.spec.identityRef.name` must reference this Secret.
 
 ### Configure Machine Configuration Pool

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -511,7 +511,7 @@ The HCS `global` manifest must contain the following resources in the `cpaas-sys
 
 | Resource | Purpose |
 |----------|---------|
-| `Secret` | Stores `accessKey`, `secretKey`, `projectID`, `region`, and `externalGlobalDomain`. |
+| `Secret` | Stores `accessKey`, `secretKey`, `projectID`, `region`, `externalGlobalDomain`, and optional `schema`. |
 | `HCSMachineConfigPool` for control plane nodes | Assigns static hostnames, IP addresses, and any pool-managed persistent disks. |
 | `Cluster` | Connects the Cluster API `Cluster` to `HCSCluster` and `KubeadmControlPlane`. |
 | `HCSCluster` | Defines VPC, subnet, security group, ELB, and identity references. |

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -512,11 +512,11 @@ The HCS `global` manifest must contain the following resources in the `cpaas-sys
 | Resource | Purpose |
 |----------|---------|
 | `Secret` | Stores `accessKey`, `secretKey`, `projectID`, `region`, and `externalGlobalDomain`. |
-| `HCSMachineConfigPool` for control plane nodes | Assigns static hostnames and IP addresses. |
+| `HCSMachineConfigPool` for control plane nodes | Assigns static hostnames, IP addresses, and any pool-managed persistent disks. |
 | `Cluster` | Connects the Cluster API `Cluster` to `HCSCluster` and `KubeadmControlPlane`. |
 | `HCSCluster` | Defines VPC, subnet, security group, ELB, and identity references. |
 | `KubeadmControlPlane` | Bootstraps the Kubernetes control plane. Set `spec.version` to `${K8S_VERSION}`. |
-| `HCSMachineTemplate` for control plane nodes | Defines image, flavor, availability zone, root volume, and data volumes. |
+| `HCSMachineTemplate` for control plane nodes | Defines image, flavor, availability zone, root volume, and temporary data volumes. |
 | `HCSMachineConfigPool`, `HCSMachineTemplate`, `KubeadmConfigTemplate`, and `MachineDeployment` for workers | Creates worker nodes. |
 
 Use the HCS resource fields from [Creating Clusters on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx) and [Infrastructure Resources for Huawei Cloud Stack](../infrastructure/huawei-cloud-stack.mdx). For the `global` cluster, keep these additional requirements:
@@ -527,7 +527,7 @@ Use the HCS resource fields from [Creating Clusters on Huawei Cloud Stack](../cr
 - Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for MicroOS.
 - Keep the release manifest's non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries.
 - For a normal non-DR deployment, do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
-- Keep `/var/cpaas` as platform state. HCS `dataVolumes` are used during creation, but they are not a guaranteed state-preservation mechanism during node replacement.
+- Keep `/var/cpaas` as platform state. Declare it in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` when it must survive node replacement; do not rely on `HCSMachineTemplate.spec.template.spec.dataVolumes[]` as preserved state.
 - Use a highly available control plane for the `global` cluster. Single-control-plane HCS clusters are creation-only topologies and are not the recommended `global` upgrade path.
 
 The following fragment shows the `global`-specific Cluster API wiring. Fill the provider resource fields by using the HCS create-cluster references above.

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -127,6 +127,8 @@ kind: HCSMachineConfigPool
 metadata:
   name: <global-pool-name>
   namespace: cpaas-system
+  labels:
+    cluster.x-k8s.io/cluster-name: global
 spec:
   configs:
     - hostname: <node-hostname>
@@ -135,7 +137,7 @@ spec:
           ipAddress: <node-ip>
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -106,18 +106,45 @@ For HCS, create new immutable infrastructure templates instead of editing templa
 Update the control plane resources:
 
 - Create a new `HCSMachineTemplate` for the target image and set `spec.template.spec.imageName` to the MicroOS image that matches the target Kubernetes version.
+- Keep preserved node-local data, including `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. Do not move preserved disks back into `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 - Leave runtime identity fields unset in the new template, including `spec.template.spec.providerID` and `spec.template.spec.serverId`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `HCSMachineTemplate`.
-- Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` for the fixed-size `HCSMachineConfigPool` path unless you have prepared extra hostname and static IP entries.
+- Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the control plane pool uses pool-managed persistent disks.
 
 Update worker node resources:
 
 - Create a new worker `HCSMachineTemplate` with the target `imageName`.
 - Set each `MachineDeployment.spec.template.spec.version` to the target Kubernetes version.
 - Point each `MachineDeployment.spec.template.spec.infrastructureRef.name` to the new worker `HCSMachineTemplate`.
+- Keep each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` when the worker pool uses pool-managed persistent disks.
 
-Do not treat HCS `dataVolumes` as preserved state during node replacement. Move stateful data to external persistent storage, or complete backup and migration before starting the upgrade. This rolling upgrade workflow supports highly available control planes that can replace `HCSMachineTemplate` and `KubeadmControlPlane` references while `HCSMachineConfigPool` retains enough fixed identities for the rollout. Single-control-plane HCS clusters, including a `global` cluster with one control plane node, are not supported by this rolling upgrade workflow. Use an alternative documented procedure, recreate the control plane with immutable templates, or consult the out-of-band migration guide or support before proceeding.
+Pool-managed persistent disks are declared on the machine configuration pool, not on the machine template:
+
+```yaml
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCSMachineConfigPool
+metadata:
+  name: <global-pool-name>
+  namespace: cpaas-system
+spec:
+  configs:
+    - hostname: <node-hostname>
+      networks:
+        - subnetName: <subnet-name>
+          ipAddress: <node-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
+          mountOptions:
+            - defaults
+            - noatime
+```
+
+Do not treat HCS `dataVolumes[]` as preserved state during node replacement. This rolling upgrade workflow supports highly available control planes that can replace `HCSMachineTemplate` and `KubeadmControlPlane` references while `HCSMachineConfigPool` retains enough fixed identities and persistent disk slots for the rollout. Single-control-plane HCS clusters, including a `global` cluster with one control plane node, are not supported by this rolling upgrade workflow. Use an alternative documented procedure, recreate the control plane with immutable templates, or consult the out-of-band migration guide or support before proceeding.
 
   </Tab>
   <Tab label="Bare Metal">
@@ -185,7 +212,7 @@ Keep `maxSurge: 0` while reverting to the previous machine templates so replacem
   </Tab>
   <Tab label="Huawei Cloud Stack">
 
-For HCS, rollback depends on platform and etcd backups. Node-local data on HCS `dataVolumes` is not a reliable rollback source because node replacement may delete the old VM and attached volumes. If the control plane was already replaced, restore from the verified etcd backup, then reapply the previous manifest with the previous `HCSMachineTemplate` references and Kubernetes versions.
+For HCS, rollback depends on platform and etcd backups. Node-local data on HCS `dataVolumes[]` is not a reliable rollback source because node replacement may delete the old VM and attached volumes. Data declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is reattached during replacement. If the control plane was already replaced, restore from the verified etcd backup, then reapply the previous manifest with the previous `HCSMachineTemplate` references and Kubernetes versions.
 
   </Tab>
   <Tab label="Bare Metal">

--- a/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
+++ b/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
@@ -263,15 +263,17 @@ Inspect the pool status:
 kubectl get hcsmachineconfigpool <pool-name> -n cpaas-system -o yaml
 ```
 
-Each migrated disk appears under `status.persistentDiskStatus`. The stable states are:
+Each migrated disk appears under `status.persistentDiskStatus`:
 
 | Phase | Meaning |
 |-------|---------|
+| `Creating` | The provider is creating the EVS volume for this hostname and slot. |
+| `Available` | The EVS volume is ready and is not attached to any ECS. |
+| `Attaching` | The replacement ECS exists; the provider is confirming the attachment. |
 | `Attached` | The EVS disk is attached to the current ECS. |
-| `Available` | The EVS disk has been detached from the old ECS and is ready for the replacement ECS. |
+| `Detaching` | The disk is being detached before the old ECS is removed. |
+| `Deleting` | Pool deletion is in progress; the EVS volume is being removed. |
 | `Error` | The provider cannot safely continue. Inspect `lastError`. |
-
-During replacement, transient phases such as `Detaching` and `Attaching` may appear.
 
 Confirm the replacement node can read data from the preserved path:
 

--- a/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
+++ b/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
@@ -90,52 +90,7 @@ Use the following split:
 | `/var/lib/containerd` | `HCSMachineTemplate.spec.template.spec.dataVolumes[]` unless your operational design requires retaining it |
 | `/var/lib/etcd` | Use etcd backup and restore procedures for disaster recovery. Do not rely only on node-local disk retention. |
 
-For automatic migration, the provider claims an existing data volume by matching `mountPath`. If a preserved disk has no `mountPath`, perform a manual disk migration or prefill the pool status with the existing EVS `volumeID` before you trigger replacement.
-
-## Update the Machine Configuration Pool
-
-Edit the `HCSMachineConfigPool` that is referenced by the old `HCSMachineTemplate.spec.template.spec.configPoolRef.name`.
-
-Add one `persistentDisks[]` entry under each hostname that must preserve the disk:
-
-```yaml title="hcs-pool-persistent-disk.yaml"
-apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-kind: HCSMachineConfigPool
-metadata:
-  name: <pool-name>
-  namespace: cpaas-system
-  labels:
-    cluster.x-k8s.io/cluster-name: <cluster-name>
-spec:
-  configs:
-    - hostname: <node-hostname>
-      networks:
-        - subnetName: <subnet-name>
-          ipAddress: <node-ip>
-      persistentDisks:
-        - slot: 0
-          size: 40
-          type: SSD
-          mountPath: /var/cpaas
-          format: xfs
-          mountOptions:
-            - defaults
-            - noatime
-```
-
-Apply the updated pool:
-
-```bash
-kubectl apply -f hcs-pool-persistent-disk.yaml -n cpaas-system
-```
-
-Use these rules when you edit the pool:
-
-- Start `slot` at `0` for each hostname.
-- Keep slots contiguous for each hostname.
-- Set `size`, `type`, `mountPath`, and `format` to match the old data volume that you want to claim.
-- Add `cluster.x-k8s.io/cluster-name: <cluster-name>` if the pool does not already have it.
-- Keep the same persistent-disk declaration across all nodes that must preserve the same path.
+For automatic migration, the provider claims an existing data volume by matching `mountPath`. If a preserved disk has no `mountPath`, automatic claim is not available. Use a supported operational procedure to record the existing EVS `volumeID` in `status.persistentDiskStatus[]`, or migrate the data to a disk with a declared mount path before you trigger replacement.
 
 ## Create New Machine Templates
 
@@ -188,9 +143,9 @@ Apply the new template:
 kubectl apply -f new-template.yaml -n cpaas-system
 ```
 
-## Trigger Rolling Replacement
+## Prepare the Rollout Strategy
 
-Before you trigger replacement, confirm the rollout strategy:
+Before you update the pool, confirm the rollout strategy for each controller that will use the updated pool. Skip the `MachineDeployment` command if the cluster has no worker pool in this migration.
 
 ```bash
 kubectl get kubeadmcontrolplane <kcp-name> -n cpaas-system \
@@ -200,7 +155,68 @@ kubectl get machinedeployment <md-name> -n cpaas-system \
   -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}{"\n"}'
 ```
 
-Both values must be `0` for pools that use persistent disks.
+Each returned value must be `0` for pools that use persistent disks.
+
+If any returned value is not `0`, patch the affected rollout strategy before you update the pool:
+
+```bash
+kubectl patch kubeadmcontrolplane <kcp-name> -n cpaas-system \
+  --type='merge' \
+  -p='{"spec":{"rolloutStrategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":0}}}}'
+
+kubectl patch machinedeployment <md-name> -n cpaas-system \
+  --type='merge' \
+  -p='{"spec":{"strategy":{"type":"RollingUpdate","rollingUpdate":{"maxSurge":0}}}}'
+```
+
+## Update the Machine Configuration Pool
+
+Edit the `HCSMachineConfigPool` that is referenced by the old and new `HCSMachineTemplate.spec.template.spec.configPoolRef.name`.
+
+Add one `persistentDisks[]` entry under each hostname that must preserve the disk:
+
+```yaml title="hcs-pool-persistent-disk.yaml"
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCSMachineConfigPool
+metadata:
+  name: <pool-name>
+  namespace: cpaas-system
+  labels:
+    cluster.x-k8s.io/cluster-name: <cluster-name>
+spec:
+  configs:
+    - hostname: <node-hostname>
+      networks:
+        - subnetName: <subnet-name>
+          ipAddress: <node-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
+          mountOptions:
+            - defaults
+            - noatime
+```
+
+Use these rules when you edit the pool:
+
+- Start `slot` at `0` for each hostname.
+- Keep slots contiguous for each hostname.
+- Set `size`, `type`, `mountPath`, and `format` to match the old data volume that you want to claim.
+- Add `cluster.x-k8s.io/cluster-name: <cluster-name>` if the pool does not already have it.
+- Keep the same persistent-disk declaration across all nodes that must preserve the same path.
+
+Apply the updated pool only after the replacement template exists, has removed the preserved paths from `dataVolumes[]`, and the rollout strategy uses `maxSurge: 0`:
+
+```bash
+kubectl apply -f hcs-pool-persistent-disk.yaml -n cpaas-system
+```
+
+## Trigger Rolling Replacement
+
+After you apply the updated pool, immediately point the control plane or worker controller to the new template in the same maintenance window. Do not leave a pool that declares `/var/cpaas` persistent disks while the active rollout still points to an old template that also declares `/var/cpaas` in `dataVolumes[]`.
 
 For a control plane migration, point the `KubeadmControlPlane` to the new template:
 
@@ -278,7 +294,7 @@ Use the pool status to decide the next action when a disk enters `phase: Error`.
 | Symptom | Likely cause | Action |
 |---------|--------------|--------|
 | `lastError` reports a mount-path conflict | The same path exists in both `dataVolumes[]` and `persistentDisks[]` | Remove the preserved path from the new `HCSMachineTemplate`, then retry the rollout. |
-| `lastError` reports no mount path match | The old data volume has no matching `mountPath` | Manually migrate the disk or prefill `status.persistentDiskStatus[].volumeID` before replacement. |
+| `lastError` reports no mount path match | The old data volume has no matching `mountPath` | Use a supported operational procedure to record the existing EVS `volumeID`, or migrate the data to a disk with a declared mount path before retrying replacement. |
 | `lastError` reports size or type mismatch | The pool declaration does not match the existing EVS disk | Correct the pool entry so `size` and `type` match the existing disk. |
 | `lastError` reports an availability zone conflict | The existing EVS disk and the target ECS are in different availability zones | Use an ECS availability zone that matches the EVS disk, or migrate the disk to the target zone before retrying. |
 | `lastError` reports that the EVS disk is attached to another ECS | The disk is attached outside the current replacement flow | Detach the disk manually only after you confirm ownership, then let the provider reconcile again. |

--- a/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
+++ b/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
@@ -1,0 +1,303 @@
+---
+weight: 25
+title: Migrate Existing Huawei Cloud Stack Clusters to Pool-Managed Persistent Disks
+queries:
+  - migrate existing huawei cloud stack cluster to persistent disks
+  - upgrade hcs cluster to pool managed persistent disks
+  - hcs keep disk migration guide
+---
+
+# Migrate Existing Huawei Cloud Stack Clusters to Pool-Managed Persistent Disks
+
+Use this guide when you upgrade an existing Huawei Cloud Stack (HCS) cluster from the older `HCSMachineTemplate` data-volume layout to the pool-managed persistent-disk model.
+
+In HCS provider `TODO: <Provider Version>` or later, disks that must survive node replacement are declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. This includes the platform-required `/var/cpaas` disk.
+
+:::info
+**Version**
+
+Use this procedure when the cluster runs ACP `TODO: <ACP Version>` or later and the target HCS provider version is `TODO: <Provider Version>` or later.
+:::
+
+## Overview
+
+Older HCS clusters commonly placed `/var/cpaas` in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`. That layout creates data volumes with the ECS. During rolling replacement, the old ECS and its template-owned data volumes may be deleted together.
+
+The pool-managed model moves upgrade-preserved disks into `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. Each persistent disk is bound to a fixed `(hostname, slot)` identity. During rolling replacement, the provider:
+
+1. Claims the existing EVS disk from the old ECS when it matches the pool declaration.
+2. Stops the old ECS.
+3. Detaches the EVS disk and waits until it is available.
+4. Deletes the old ECS.
+5. Creates the replacement ECS with the same EVS disk attached before first boot.
+6. Boots the replacement ECS, which mounts the existing file system without reformatting it.
+
+## Before You Start
+
+Verify all of the following before you begin:
+
+- The management cluster has HCS provider `TODO: <Provider Version>` or later.
+- The workload cluster is healthy and all nodes are `Ready`.
+- The cluster uses `HCSMachineConfigPool` to assign fixed hostnames and IP addresses.
+- The preserved disks have non-empty mount paths in the old `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
+- The relevant rollout strategies use `maxSurge: 0`.
+- You have a maintenance window for one-by-one node replacement.
+- You have a verified backup of etcd and platform configuration.
+
+:::warning
+Do not declare the same mount path in both `HCSMachineTemplate.spec.template.spec.dataVolumes[]` and `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. The provider rejects this configuration to prevent data loss.
+:::
+
+## Inspect the Current Disk Layout
+
+Identify the management-cluster objects that control the cluster:
+
+```bash
+kubectl get cluster -n cpaas-system
+kubectl get kubeadmcontrolplane -n cpaas-system
+kubectl get machinedeployment -n cpaas-system
+kubectl get hcsmachinetemplate -n cpaas-system
+kubectl get hcsmachineconfigpool -n cpaas-system
+kubectl get hcsmachine -n cpaas-system
+```
+
+Inspect the current machine templates:
+
+```bash
+kubectl get hcsmachinetemplate <template-name> -n cpaas-system -o yaml
+```
+
+Record every `dataVolumes[]` entry that must be preserved. For each disk, record:
+
+| Field | Source |
+|-------|--------|
+| `mountPath` | `HCSMachineTemplate.spec.template.spec.dataVolumes[].mountPath` |
+| `size` | `HCSMachineTemplate.spec.template.spec.dataVolumes[].size` |
+| `type` | `HCSMachineTemplate.spec.template.spec.dataVolumes[].type` |
+| `format` | `HCSMachineTemplate.spec.template.spec.dataVolumes[].format` |
+
+## Decide Which Disks to Preserve
+
+Move only the disks that must survive node replacement to the pool-managed model.
+
+Use the following split:
+
+| Path | Recommended declaration |
+|------|-------------------------|
+| `/var/cpaas` | `HCSMachineConfigPool.spec.configs[].persistentDisks[]` |
+| Monitoring or log data stored under `/var/cpaas` | `HCSMachineConfigPool.spec.configs[].persistentDisks[]` |
+| `/var/lib/kubelet` | `HCSMachineTemplate.spec.template.spec.dataVolumes[]` unless your operational design requires retaining it |
+| `/var/lib/containerd` | `HCSMachineTemplate.spec.template.spec.dataVolumes[]` unless your operational design requires retaining it |
+| `/var/lib/etcd` | Use etcd backup and restore procedures for disaster recovery. Do not rely only on node-local disk retention. |
+
+For automatic migration, the provider claims an existing data volume by matching `mountPath`. If a preserved disk has no `mountPath`, perform a manual disk migration or prefill the pool status with the existing EVS `volumeID` before you trigger replacement.
+
+## Update the Machine Configuration Pool
+
+Edit the `HCSMachineConfigPool` that is referenced by the old `HCSMachineTemplate.spec.template.spec.configPoolRef.name`.
+
+Add one `persistentDisks[]` entry under each hostname that must preserve the disk:
+
+```yaml title="hcs-pool-persistent-disk.yaml"
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCSMachineConfigPool
+metadata:
+  name: <pool-name>
+  namespace: cpaas-system
+  labels:
+    cluster.x-k8s.io/cluster-name: <cluster-name>
+spec:
+  configs:
+    - hostname: <node-hostname>
+      networks:
+        - subnetName: <subnet-name>
+          ipAddress: <node-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
+          mountOptions:
+            - defaults
+            - noatime
+```
+
+Apply the updated pool:
+
+```bash
+kubectl apply -f hcs-pool-persistent-disk.yaml -n cpaas-system
+```
+
+Use these rules when you edit the pool:
+
+- Start `slot` at `0` for each hostname.
+- Keep slots contiguous for each hostname.
+- Set `size`, `type`, `mountPath`, and `format` to match the old data volume that you want to claim.
+- Add `cluster.x-k8s.io/cluster-name: <cluster-name>` if the pool does not already have it.
+- Keep the same persistent-disk declaration across all nodes that must preserve the same path.
+
+## Create New Machine Templates
+
+Create new `HCSMachineTemplate` resources for the replacement nodes. Do not edit the existing templates in place.
+
+Copy the current template:
+
+```bash
+kubectl get hcsmachinetemplate <current-template-name> -n cpaas-system -o yaml > new-template.yaml
+```
+
+Edit `new-template.yaml`:
+
+1. Set `metadata.name` to a new template name.
+2. Remove server-generated metadata, such as `resourceVersion`, `uid`, `creationTimestamp`, `managedFields`, and `status`.
+3. Leave runtime identity fields unset, including `spec.template.spec.providerID` and `spec.template.spec.serverId`.
+4. Remove the preserved paths from `spec.template.spec.dataVolumes[]`.
+5. Keep only temporary data volumes that may be recreated with each ECS.
+6. Update `spec.template.spec.imageName` and other upgrade fields when this migration is part of a Kubernetes or image upgrade.
+
+For example, after `/var/cpaas` moves to the pool, the template keeps temporary disks only:
+
+```yaml title="hcs-machine-template-temporary-data-volumes.yaml"
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCSMachineTemplate
+metadata:
+  name: <new-template-name>
+  namespace: cpaas-system
+spec:
+  template:
+    spec:
+      imageName: <vm-image-name>
+      flavorName: <instance-flavor>
+      availabilityZone: <availability-zone>
+      rootVolume:
+        type: SSD
+        size: 100
+      configPoolRef:
+        name: <pool-name>
+      dataVolumes:
+        - size: 100
+          type: SSD
+          mountPath: /var/lib/containerd
+          format: xfs
+```
+
+Apply the new template:
+
+```bash
+kubectl apply -f new-template.yaml -n cpaas-system
+```
+
+## Trigger Rolling Replacement
+
+Before you trigger replacement, confirm the rollout strategy:
+
+```bash
+kubectl get kubeadmcontrolplane <kcp-name> -n cpaas-system \
+  -o jsonpath='{.spec.rolloutStrategy.rollingUpdate.maxSurge}{"\n"}'
+
+kubectl get machinedeployment <md-name> -n cpaas-system \
+  -o jsonpath='{.spec.strategy.rollingUpdate.maxSurge}{"\n"}'
+```
+
+Both values must be `0` for pools that use persistent disks.
+
+For a control plane migration, point the `KubeadmControlPlane` to the new template:
+
+```bash
+kubectl patch kubeadmcontrolplane <kcp-name> -n cpaas-system \
+  --type='merge' \
+  -p='{"spec":{"machineTemplate":{"infrastructureRef":{"name":"<new-template-name>"}}}}'
+```
+
+For a worker migration, point the `MachineDeployment` to the new template:
+
+```bash
+kubectl patch machinedeployment <md-name> -n cpaas-system \
+  --type='merge' \
+  -p='{"spec":{"template":{"spec":{"infrastructureRef":{"name":"<new-template-name>"}}}}}'
+```
+
+If the template reference already points to the target template and you need to force a one-by-one replacement, set `rolloutAfter`:
+
+```bash
+kubectl patch kubeadmcontrolplane <kcp-name> -n cpaas-system \
+  --type='merge' \
+  -p='{"spec": {"rolloutAfter": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}}'
+
+kubectl patch machinedeployment <md-name> -n cpaas-system \
+  --type='merge' \
+  -p='{"spec": {"rolloutAfter": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"}}'
+```
+
+## Verify the Migration
+
+Watch the rolling replacement:
+
+```bash
+kubectl get kubeadmcontrolplane <kcp-name> -n cpaas-system -w
+kubectl get machinedeployment <md-name> -n cpaas-system -w
+kubectl get machine -n cpaas-system -w
+kubectl get hcsmachine -n cpaas-system -w
+```
+
+Inspect the pool status:
+
+```bash
+kubectl get hcsmachineconfigpool <pool-name> -n cpaas-system -o yaml
+```
+
+Each migrated disk appears under `status.persistentDiskStatus`. The stable states are:
+
+| Phase | Meaning |
+|-------|---------|
+| `Attached` | The EVS disk is attached to the current ECS. |
+| `Available` | The EVS disk has been detached from the old ECS and is ready for the replacement ECS. |
+| `Error` | The provider cannot safely continue. Inspect `lastError`. |
+
+During replacement, transient phases such as `Detaching` and `Attaching` may appear.
+
+Confirm the replacement node can read data from the preserved path:
+
+```bash
+kubectl --kubeconfig <workload-kubeconfig> debug node/<node-name> --image=busybox -- \
+  chroot /host sh -c 'mount | grep /var/cpaas && ls -la /var/cpaas'
+```
+
+For a stronger data-retention check, write a marker before the rollout and read it after the replacement node becomes `Ready`:
+
+```bash
+kubectl --kubeconfig <workload-kubeconfig> debug node/<node-name> --image=busybox -- \
+  chroot /host sh -c 'cat /var/cpaas/<marker-file>'
+```
+
+## Failure Handling
+
+Use the pool status to decide the next action when a disk enters `phase: Error`.
+
+| Symptom | Likely cause | Action |
+|---------|--------------|--------|
+| `lastError` reports a mount-path conflict | The same path exists in both `dataVolumes[]` and `persistentDisks[]` | Remove the preserved path from the new `HCSMachineTemplate`, then retry the rollout. |
+| `lastError` reports no mount path match | The old data volume has no matching `mountPath` | Manually migrate the disk or prefill `status.persistentDiskStatus[].volumeID` before replacement. |
+| `lastError` reports size or type mismatch | The pool declaration does not match the existing EVS disk | Correct the pool entry so `size` and `type` match the existing disk. |
+| `lastError` reports an availability zone conflict | The existing EVS disk and the target ECS are in different availability zones | Use an ECS availability zone that matches the EVS disk, or migrate the disk to the target zone before retrying. |
+| `lastError` reports that the EVS disk is attached to another ECS | The disk is attached outside the current replacement flow | Detach the disk manually only after you confirm ownership, then let the provider reconcile again. |
+| `lastError` reports that `volumeID` was not found | The tracked EVS disk was deleted | Restore or recreate the expected EVS disk with the correct ownership tags before retrying. |
+
+Do not delete the old `HCSMachine` or force-remove finalizers while a persistent disk is in an unresolved error state. The provider blocks deletion to avoid deleting the old ECS before it can safely claim and detach the disk.
+
+## Limitations and Recovery Notes
+
+- This procedure applies to clusters that use `HCSMachineConfigPool` with fixed hostnames and IP addresses.
+- Pool-managed persistent disks require one-by-one replacement. Keep `maxSurge: 0` for each control plane or worker rollout that uses persistent disks.
+- The provider automatically claims existing data volumes by matching a non-empty `mountPath`.
+- `dataVolumes[]` that are not declared in `persistentDisks[]` remain template-owned and may be deleted with the old ECS.
+- After the provider accepts a persistent disk entry, treat `slot`, `size`, `type`, `format`, and `mountPath` as immutable.
+- `mountOptions` can change, but the change takes effect only on a replacement VM.
+- Single-control-plane HCS clusters are creation-only topologies in the documented upgrade workflow. Do not use this rolling migration procedure for a single-control-plane cluster.
+
+## Related Topics
+
+- [Infrastructure Resources for Huawei Cloud Stack](../infrastructure/huawei-cloud-stack.mdx)
+- [Creating Clusters on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx)
+- [Upgrading Clusters on Huawei Cloud Stack](../upgrade-cluster/huawei-cloud-stack.mdx)

--- a/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
+++ b/docs/en/how-to/hcs_persistent_disk_upgrade.mdx
@@ -11,12 +11,12 @@ queries:
 
 Use this guide when you upgrade an existing Huawei Cloud Stack (HCS) cluster from the older `HCSMachineTemplate` data-volume layout to the pool-managed persistent-disk model.
 
-In HCS provider `TODO: <Provider Version>` or later, disks that must survive node replacement are declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. This includes the platform-required `/var/cpaas` disk.
+In HCS provider `v1.0.1` or later, disks that must survive node replacement are declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. This includes the platform-required `/var/cpaas` disk.
 
 :::info
 **Version**
 
-Use this procedure when the cluster runs ACP `TODO: <ACP Version>` or later and the target HCS provider version is `TODO: <Provider Version>` or later.
+Use this procedure when the cluster runs ACP `v4.3.1` or later and the target HCS provider version is `v1.0.1` or later.
 :::
 
 ## Overview
@@ -36,7 +36,7 @@ The pool-managed model moves upgrade-preserved disks into `HCSMachineConfigPool.
 
 Verify all of the following before you begin:
 
-- The management cluster has HCS provider `TODO: <Provider Version>` or later.
+- The management cluster has HCS provider `v1.0.1` or later.
 - The workload cluster is healthy and all nodes are `Ready`.
 - The cluster uses `HCSMachineConfigPool` to assign fixed hostnames and IP addresses.
 - The preserved disks have non-empty mount paths in the old `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -146,7 +146,7 @@ Prepare the following before you create `HCSMachineConfigPool` resources:
 - Enough entries to cover the initial replica count
 - Any pool-managed persistent disks that must be bound to each fixed hostname
 
-For static IP control planes with at least three replicas, the recommended upgrade path uses `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0`. This scale-down-then-scale-up approach usually does not require extra control plane IPs. If you plan a single-control-plane create-only topology (`replicas: 1`), do not copy that rollout setting into the create manifest. Prepare additional hostname and IP slots only when you plan to increase control plane replicas or set `maxSurge` greater than `0`.
+For static IP control planes with at least three replicas, the recommended upgrade path uses `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0`. This scale-down-then-scale-up approach usually does not require extra control plane IPs. If you plan a single-control-plane create-only topology (`replicas: 1`), do not copy that rollout setting into the create manifest. For pools that use persistent disks, keep `maxSurge: 0` because each disk is bound to one fixed hostname and slot.
 
 ### Pool-Managed Persistent Disks
 
@@ -170,7 +170,7 @@ spec:
           ipAddress: <node-ip>
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -184,15 +184,16 @@ spec:
 | Field | Description |
 |-------|-------------|
 | `slot` | Disk position within one machine configuration. Slots must be unique and contiguous from `0` for the same hostname. |
-| `size` | EVS disk size in GB. For newly created EVS data disks, use a size supported by the target HCS EVS service. |
+| `size` | EVS disk size in GB. For newly created EVS data disks, use `10` to `32768` GB. Existing claimed disks must match their current size. |
 | `type` | EVS disk type name that is available in the target availability zone. |
-| `mountPath` | Mount path inside the guest OS. Use `/var/cpaas` for platform state that must survive VM replacement. |
+| `mountPath` | Mount path inside the guest OS. Use `/var/cpaas` for platform state that must survive VM replacement. Size this disk for platform monitoring, log, and plug-in data. |
 | `format` | File system used when a new disk is initialized. If omitted, the provider uses `xfs`. Existing file systems are not reformatted during reattachment. |
 | `mountOptions` | Mount options applied when the replacement VM mounts the disk. If omitted, the provider uses `defaults,noatime`. |
 
 **Update rules:**
 
 - Do not declare the same `mountPath` in both `HCSMachineConfigPool.spec.configs[].persistentDisks[]` and `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
+- You can append new `persistentDisks[]` entries to an existing machine configuration. The provider creates or claims the EVS disk, but it does not hot-mount the disk into the running ECS. Trigger a rolling replacement with `maxSurge: 0` before you expect the new disk to be formatted and mounted inside the guest OS.
 - Do not remove or change `slot`, `size`, `type`, `format`, or `mountPath` after the provider has accepted a persistent disk entry. These fields define the disk identity and claim contract.
 - You can update `mountOptions`. The change takes effect when the node is replaced and the replacement VM renders its disk mounts.
 - Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` and `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` for pools that use persistent disks.

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -35,6 +35,7 @@ Prepare the following inputs before you create or edit any cluster manifests:
 | `accessKey` and `secretKey` | HCS credential `Secret` | HCS **My Settings** > **Access Keys** | Yes | Base64-encode these values before applying the Secret |
 | `projectID` | HCS credential `Secret` | HCS **My Settings** > **Resource Spaces** | Yes | Use the Resource Space ID, not the display name |
 | `externalGlobalDomain` | HCS credential `Secret` | HCS platform access domain | Yes | Use the HCS platform domain that the provider should call |
+| `schema` | HCS credential `Secret` | HCS administrator | No | Optional API scheme for the HCS IAM endpoint. If omitted, the provider uses `https` |
 | `region` | HCS credential `Secret` | HCS administrator | Yes | Tenant administrators cannot retrieve this value from the HCS UI |
 | `imageName` | `HCSMachineTemplate` | HCS image inventory | Yes | Use the validated HCS image name for the selected MicroOS image |
 | `flavorName` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `Flavor.Name`, not the tenant UI display name |
@@ -59,6 +60,7 @@ Create the HCS credential `Secret` only after you collect all required values.
 | `projectID` | Resource Space ID | HCS **My Settings** > **Resource Spaces** |
 | `externalGlobalDomain` | HCS platform access domain | HCS platform domain provided for API access |
 | `region` | HCS region API value used by the provider | HCS administrator |
+| `schema` | Optional API scheme for the HCS IAM endpoint. If omitted, the provider uses `https` | HCS administrator |
 
 **Note:** Tenant administrators cannot retrieve `region` from the HCS UI. Get the exact provider-recognized value from the HCS administrator before you encode the Secret.
 
@@ -204,7 +206,7 @@ Use the following mapping after you complete the preparation checklist:
 
 | Prepared input | YAML fields |
 |----------------|-------------|
-| `accessKey`, `secretKey`, `projectID`, `externalGlobalDomain`, `region` | `Secret.data.*` |
+| `accessKey`, `secretKey`, `projectID`, `externalGlobalDomain`, `region`, optional `schema` | `Secret.data.*` |
 | `imageName`, `flavorName`, `availabilityZone`, root volume, and temporary data volume layout | `HCSMachineTemplate.spec.template.spec.*` |
 | Control plane and worker hostnames, static IPs, and pool-managed persistent disks | `HCSMachineConfigPool.spec.configs[]` |
 | VPC name, subnet inventory, security group name | `HCSCluster.spec.network.*` |

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -7,6 +7,7 @@ queries:
   - hcs infrastructure preparation
   - hcs secret subnet and elb planning
   - huawei cloud stack yaml prerequisites
+  - hcs pool managed persistent disks
 ---
 
 # Infrastructure Resources for Huawei Cloud Stack
@@ -38,7 +39,7 @@ Prepare the following inputs before you create or edit any cluster manifests:
 | `imageName` | `HCSMachineTemplate` | HCS image inventory | Yes | Use the validated HCS image name for the selected MicroOS image |
 | `flavorName` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `Flavor.Name`, not the tenant UI display name |
 | `availabilityZone` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `ZoneName`, not the tenant UI display name |
-| Root and data volume layout | `HCSMachineTemplate` | Cluster storage plan | Yes | Plan disk sizes and mount points before you write the template. Include `/var/lib/etcd`, `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas` where required |
+| Root, temporary data volume, and persistent disk layout | `HCSMachineTemplate`, `HCSMachineConfigPool` | Cluster storage plan | Yes | Plan disk sizes and mount points before you write the template and pool. Put disks that can be recreated with the VM in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`. Put disks that must survive VM replacement, such as `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` |
 | VPC name and security group name | `HCSCluster` | HCS network inventory | Yes | Confirm that the referenced VPC and security group already exist and are usable |
 | Cluster subnet inventory | `HCSCluster`, `HCSMachineConfigPool`, control plane ELB | HCS network inventory | Yes | Prepare the subnet name, subnet ID, ELB-related subnet metadata, CIDR, gateway, DNS values, and planned free IP range for every subnet that the cluster will use |
 | Control plane and worker hostnames and static IPs | `HCSMachineConfigPool` | HCS subnet planning | Yes for static IP workflows | Prepare at least one entry per planned replica |
@@ -63,14 +64,15 @@ Create the HCS credential `Secret` only after you collect all required values.
 
 ## Compute Values
 
-Prepare the VM image, flavor, availability zone, and disk layout before you write the `HCSMachineTemplate`.
+Prepare the VM image, flavor, availability zone, temporary data volume layout, and persistent disk layout before you write the `HCSMachineTemplate` and `HCSMachineConfigPool`.
 
 | Input | Guidance |
 |-------|----------|
 | `imageName` | Use the validated HCS image name for the MicroOS image you want to deploy |
 | `flavorName` | Use the provider-recognized HCS API value matched against `Flavor.Name`. Do not use the tenant UI display name |
 | `availabilityZone` | Use the provider-recognized HCS API value matched against `ZoneName`. Do not use the tenant UI display name |
-| Root and data volumes | Plan system and data disks in advance. Control plane templates typically require `/var/lib/etcd`, `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas`. Worker templates typically require `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas` |
+| Root and temporary data volumes | Plan system and temporary data disks in advance. Control plane templates typically use temporary data volumes for `/var/lib/etcd`, `/var/lib/kubelet`, and `/var/lib/containerd`. Worker templates typically use temporary data volumes for `/var/lib/kubelet` and `/var/lib/containerd`. |
+| Pool-managed persistent disks | Plan disks that must survive VM replacement in advance. Use this model for `/var/cpaas` and other node-local state that must be retained during rolling replacement. |
 
 **Note:** Tenant administrators cannot retrieve the provider-recognized `flavorName` and `availabilityZone` values from the HCS UI. Get the exact API values from the HCS administrator before you write the manifest.
 
@@ -142,8 +144,58 @@ Prepare the following before you create `HCSMachineConfigPool` resources:
 - Control plane hostnames and static IPs
 - Worker hostnames and static IPs, if workers are created
 - Enough entries to cover the initial replica count
+- Any pool-managed persistent disks that must be bound to each fixed hostname
 
 For static IP control planes with at least three replicas, the recommended upgrade path uses `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0`. This scale-down-then-scale-up approach usually does not require extra control plane IPs. If you plan a single-control-plane create-only topology (`replicas: 1`), do not copy that rollout setting into the create manifest. Prepare additional hostname and IP slots only when you plan to increase control plane replicas or set `maxSurge` greater than `0`.
+
+### Pool-Managed Persistent Disks
+
+Declare HCS disks that must survive VM delete-recreate replacement in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`.
+
+Use this model for `/var/cpaas`, monitoring data, log data, or other node-local state that must be retained during rolling replacement. Keep `HCSMachineTemplate.spec.template.spec.dataVolumes[]` for temporary disks that may be recreated with each new ECS.
+
+```yaml title="hcs-machine-config-pool-with-persistent-disk.yaml"
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: HCSMachineConfigPool
+metadata:
+  name: <cluster-name>-cp-pool
+  namespace: cpaas-system
+  labels:
+    cluster.x-k8s.io/cluster-name: <cluster-name>
+spec:
+  configs:
+    - hostname: <node-hostname>
+      networks:
+        - subnetName: <subnet-name>
+          ipAddress: <node-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
+          mountOptions:
+            - defaults
+            - noatime
+```
+
+**Persistent disk field descriptions:**
+
+| Field | Description |
+|-------|-------------|
+| `slot` | Disk position within one machine configuration. Slots must be unique and contiguous from `0` for the same hostname. |
+| `size` | EVS disk size in GB. For newly created EVS data disks, use a size supported by the target HCS EVS service. |
+| `type` | EVS disk type name that is available in the target availability zone. |
+| `mountPath` | Mount path inside the guest OS. Use `/var/cpaas` for platform state that must survive VM replacement. |
+| `format` | File system used when a new disk is initialized. If omitted, the provider uses `xfs`. Existing file systems are not reformatted during reattachment. |
+| `mountOptions` | Mount options applied when the replacement VM mounts the disk. If omitted, the provider uses `defaults,noatime`. |
+
+**Update rules:**
+
+- Do not declare the same `mountPath` in both `HCSMachineConfigPool.spec.configs[].persistentDisks[]` and `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
+- Do not remove or change `slot`, `size`, `type`, `format`, or `mountPath` after the provider has accepted a persistent disk entry. These fields define the disk identity and claim contract.
+- You can update `mountOptions`. The change takes effect when the node is replaced and the replacement VM renders its disk mounts.
+- Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` and `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` for pools that use persistent disks.
 
 ## Value-to-YAML Mapping
 
@@ -152,8 +204,8 @@ Use the following mapping after you complete the preparation checklist:
 | Prepared input | YAML fields |
 |----------------|-------------|
 | `accessKey`, `secretKey`, `projectID`, `externalGlobalDomain`, `region` | `Secret.data.*` |
-| `imageName`, `flavorName`, `availabilityZone`, disk layout | `HCSMachineTemplate.spec.template.spec.*` |
-| Control plane and worker hostnames and static IPs | `HCSMachineConfigPool.spec.configs[]` |
+| `imageName`, `flavorName`, `availabilityZone`, root volume, and temporary data volume layout | `HCSMachineTemplate.spec.template.spec.*` |
+| Control plane and worker hostnames, static IPs, and pool-managed persistent disks | `HCSMachineConfigPool.spec.configs[]` |
 | VPC name, subnet inventory, security group name | `HCSCluster.spec.network.*` |
 | `vipAddress`, `vipSubnetName`, `vipDomainName`, `elbVirsubnetL4Ips`, `elbVirsubnetL7Ips` | `HCSCluster.spec.controlPlaneLoadBalancer.*` |
 | Kubernetes version and component baseline | `KubeadmControlPlane.spec.version`, `Cluster.spec.clusterNetwork.*`, cluster annotations, and related bootstrap settings |

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -62,6 +62,8 @@ Create the HCS credential `Secret` only after you collect all required values.
 | `region` | HCS region API value used by the provider | HCS administrator |
 | `schema` | Optional API scheme for the HCS IAM endpoint. If omitted, the provider uses `https` | HCS administrator |
 
+Existing credential Secrets created without `schema` continue to work unchanged. Only set `schema` if your HCS IAM endpoint uses `http` instead of the default `https`.
+
 **Note:** Tenant administrators cannot retrieve `region` from the HCS UI. Get the exact provider-recognized value from the HCS administrator before you encode the Secret.
 
 ## Compute Values

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -7,6 +7,7 @@ queries:
   - hcs worker nodes
   - hcs node management
   - hcs machine deployment
+  - hcs worker persistent disks
 ---
 
 # Managing Nodes on Huawei Cloud Stack
@@ -38,7 +39,7 @@ Before you prepare worker YAML, complete the HCS input checklist in [Infrastruct
 
 ### Step 1: Configure Machine Configuration Pool
 
-The `HCSMachineConfigPool` defines the network configuration for worker node VMs. You must plan and configure the IP addresses, hostnames, and other network parameters before deployment.
+The `HCSMachineConfigPool` defines the network configuration and any pool-managed persistent disks for worker node VMs. You must plan and configure the IP addresses, hostnames, persistent disk slots, and other parameters before deployment.
 
 :::warning
 **Pool Size Requirement**
@@ -62,14 +63,32 @@ spec:
       networks:
         - subnetName: <subnet-name>
           ipAddress: <worker-1-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
     - hostname: <worker-2-hostname>
       networks:
         - subnetName: <subnet-name>
           ipAddress: <worker-2-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
     - hostname: <worker-3-hostname>
       networks:
         - subnetName: <subnet-name>
           ipAddress: <worker-3-ip>
+      persistentDisks:
+        - slot: 0
+          size: 40
+          type: SSD
+          mountPath: /var/cpaas
+          format: xfs
 ```
 
 | Parameter | Type | Required | Description |
@@ -80,8 +99,19 @@ spec:
 | `.spec.configs[].networks[].subnetName` | string | No* | Recommended subnet name field for new manifests |
 | `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
 | `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the worker VM |
+| `.spec.configs[].persistentDisks[]` | array | No | EVS disks that survive HCSMachine delete-recreate replacement |
+| `.spec.configs[].persistentDisks[].slot` | int | Yes* | Disk slot within one machine configuration. Slots must be unique and contiguous from `0` for the same hostname |
+| `.spec.configs[].persistentDisks[].size` | int | Yes* | EVS disk size in GB |
+| `.spec.configs[].persistentDisks[].type` | string | Yes* | EVS disk type name available in the target availability zone |
+| `.spec.configs[].persistentDisks[].mountPath` | string | No | Guest mount path. Use `/var/cpaas` for platform state that must survive VM replacement |
+| `.spec.configs[].persistentDisks[].format` | string | No | File system format. If omitted, the provider uses `xfs` |
+| `.spec.configs[].persistentDisks[].mountOptions` | array | No | Mount options. If omitted, the provider uses `defaults,noatime` |
 
 *For new manifests, set either `subnetName` or `subnetId`. Existing manifests may continue to use `subenetName`, and may add `subnetName` only if both fields use the same value. Do not provide conflicting subnet selector values.
+
+**Persistent disk fields are required when `persistentDisks` is specified.**
+
+Use `persistentDisks[]` for node-local state that must survive worker replacement. Do not declare the same mount path in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 
 **Note:** The CRD schema lists `subnetName`, `subenetName`, and `subnetId` as optional fields and does not express their allowed combinations. Follow the provider-level rules above when writing manifests.
 
@@ -91,7 +121,7 @@ spec:
 
 The `HCSMachineTemplate` defines the VM specifications for worker nodes.
 
-Configure worker nodes with a system volume and data volumes for `/var/lib/kubelet`, `/var/lib/containerd`, and `/var/cpaas`. You may add more data volumes, but preserve these paths so node bootstrap and platform components can use the expected runtime directories. These paths do not imply that data volumes will be preserved when nodes are replaced.
+Configure worker nodes with a system volume and temporary data volumes for paths that may be recreated with each ECS, such as `/var/lib/kubelet` and `/var/lib/containerd`. Put `/var/cpaas` in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` when platform state must survive worker replacement.
 
 Use the provider-recognized `flavorName` and `availabilityZone` API values when you prepare the worker template. These values are not the tenant UI display names.
 
@@ -121,10 +151,6 @@ spec:
           type: SSD
           mountPath: /var/lib/containerd
           format: xfs
-        - size: 10
-          type: SSD
-          mountPath: /var/cpaas
-          format: xfs
 ```
 
 | Parameter | Type | Required | Description |
@@ -142,6 +168,8 @@ spec:
 | `.spec.template.spec.dataVolumes[].format` | string | Yes* | File system format |
 
 *Required when dataVolumes is specified.
+
+`dataVolumes[]` are recreated with the ECS. Do not use them for `/var/cpaas` or any other path that must survive rolling replacement.
 
 **Note:** Do not set runtime identity fields such as `providerID` or `serverId` in `HCSMachineTemplate` manifests. The provider assigns these values when it creates HCS instances.
 
@@ -326,7 +354,7 @@ Scaling down removes nodes and their associated disks. Ensure:
 
 To upgrade worker machine specifications (CPU, memory, disk, VM image), follow these steps:
 
-**Note:** Worker infrastructure upgrades rely on Cluster API rolling replacement. The current HCS provider does not preserve or reattach data disks during node replacement. When a worker node is replaced, the old VM and its attached volumes may be deleted together. Move stateful data to external persistent storage, or complete backup and migration before starting the upgrade.
+**Note:** Worker infrastructure upgrades rely on Cluster API rolling replacement. HCS `dataVolumes[]` are not preserved during replacement. To preserve node-local state such as `/var/cpaas`, declare it in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` before the rollout and keep `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0`.
 
 1. **Create New Machine Template**
 

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -57,6 +57,8 @@ kind: HCSMachineConfigPool
 metadata:
   name: <cluster-name>-worker-pool
   namespace: cpaas-system
+  labels:
+    cluster.x-k8s.io/cluster-name: <cluster-name>
 spec:
   configs:
     - hostname: <worker-1-hostname>
@@ -65,7 +67,7 @@ spec:
           ipAddress: <worker-1-ip>
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -75,7 +77,7 @@ spec:
           ipAddress: <worker-2-ip>
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -85,7 +87,7 @@ spec:
           ipAddress: <worker-3-ip>
       persistentDisks:
         - slot: 0
-          size: 40
+          size: 100
           type: SSD
           mountPath: /var/cpaas
           format: xfs
@@ -101,7 +103,7 @@ spec:
 | `.spec.configs[].networks[].ipAddress` | string | Yes | Static IP address for the worker VM |
 | `.spec.configs[].persistentDisks[]` | array | No | EVS disks that survive HCSMachine delete-recreate replacement |
 | `.spec.configs[].persistentDisks[].slot` | int | Yes* | Disk slot within one machine configuration. Slots must be unique and contiguous from `0` for the same hostname |
-| `.spec.configs[].persistentDisks[].size` | int | Yes* | EVS disk size in GB |
+| `.spec.configs[].persistentDisks[].size` | int | Yes* | EVS disk size in GB. For newly created EVS data disks, use `10` to `32768` GB. Existing claimed disks must match their current size |
 | `.spec.configs[].persistentDisks[].type` | string | Yes* | EVS disk type name available in the target availability zone |
 | `.spec.configs[].persistentDisks[].mountPath` | string | No | Guest mount path. Use `/var/cpaas` for platform state that must survive VM replacement |
 | `.spec.configs[].persistentDisks[].format` | string | No | File system format. If omitted, the provider uses `xfs` |
@@ -116,6 +118,22 @@ Use `persistentDisks[]` for node-local state that must survive worker replacemen
 **Note:** The CRD schema lists `subnetName`, `subenetName`, and `subnetId` as optional fields and does not express their allowed combinations. Follow the provider-level rules above when writing manifests.
 
 **Note:** `networks[]` can contain more than one entry when a worker node needs multiple NICs. The current provider only uses each entry to attach a NIC with a subnet selector and static IP. It does not support per-NIC role declarations, default gateway selection, static routes, route metrics, or per-NIC DNS settings.
+
+### Pool-Managed Persistent Disks for Workers
+
+Declare worker-node disks that must survive replacement in the matching `HCSMachineConfigPool.spec.configs[].persistentDisks[]` entry. Use this model for `/var/cpaas` and for any other node-local state that must be retained during rolling replacement.
+
+- Keep `HCSMachineTemplate.spec.template.spec.dataVolumes[]` for temporary disks that may be recreated with each ECS.
+- Keep slots unique and contiguous from `0` for each hostname. The provider uses `(hostname, slot)` as the persistent-disk identity.
+- Treat `slot`, `size`, `type`, `format`, and `mountPath` as immutable after the provider accepts the entry.
+- You can update `mountOptions`. The change takes effect after the worker is replaced.
+- You can append new `persistentDisks[]` entries. The provider creates or claims the EVS disk, but it does not hot-mount the disk into the running ECS. Trigger a rolling replacement with `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` before you expect the new disk to be formatted and mounted inside the guest OS.
+
+To inspect persistent-disk runtime state during worker operations, check the pool status:
+
+```bash
+kubectl get hcsmachineconfigpool <cluster-name>-worker-pool -n cpaas-system -o yaml
+```
 
 ### Step 2: Configure Machine Template
 
@@ -286,7 +304,7 @@ Increase the number of worker nodes to handle increased workload.
 
 2. **Extend Configuration Pool**
 
-   Add new IP configurations to the pool for the additional nodes.
+   Add new machine configurations to the pool for the additional nodes. If the new workers need preserved node-local state such as `/var/cpaas`, include the matching `persistentDisks[]` entries in each new configuration.
 
    ```bash
    kubectl get hcsmachineconfigpool <cluster-name>-worker-pool -n cpaas-system -o yaml
@@ -297,6 +315,8 @@ Increase the number of worker nodes to handle increased workload.
    ```bash
    kubectl apply -f <updated-pool-config.yaml>
    ```
+
+   When you edit the pool, keep all existing `configs[]` entries and their accepted `persistentDisks[]` entries unchanged unless you are intentionally appending a new disk slot.
 
 3. **Scale Up the MachineDeployment**
 
@@ -324,7 +344,7 @@ Decrease the number of worker nodes to reduce cluster capacity.
 :::warning
 **Data Loss Warning**
 
-Scaling down removes nodes and their associated disks. Ensure:
+Scaling down removes worker nodes and their ECS instances. Template-owned `dataVolumes[]` are not preserved. Pool-managed persistent disks declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` remain tracked by the pool and can be reused while the corresponding hostname entry stays in the pool. Ensure:
 - Workloads can tolerate node loss through proper replication
 - No critical data is stored only on the nodes being removed
 - Applications are designed for horizontal scaling
@@ -362,7 +382,9 @@ To upgrade worker machine specifications (CPU, memory, disk, VM image), follow t
    - `imageName` - VM image
    - `flavorName` - Instance type
    - `rootVolume.size` - System disk size
-   - `dataVolumes` - Data disk configurations
+   - `dataVolumes` - Temporary data disk configurations
+
+   If you need to add a new pool-managed persistent disk, append it to the worker `HCSMachineConfigPool` first. The provider creates or claims the EVS disk, but the running ECS does not mount it until this rolling replacement creates a replacement worker.
 
      ```bash
      kubectl get hcsmachinetemplate <current-template> -n cpaas-system -o yaml > new-template.yaml

--- a/docs/en/overview/providers/huawei-cloud-stack.mdx
+++ b/docs/en/overview/providers/huawei-cloud-stack.mdx
@@ -19,12 +19,15 @@ The Huawei Cloud Stack Infrastructure Provider enables Immutable Infrastructure 
 
 Huawei Cloud Stack is a hybrid cloud solution that extends public cloud capabilities to private data centers. The HCS Provider leverages HCS APIs to manage infrastructure resources including virtual machines, networks, storage, and load balancers.
 
+HCS provider `v1.0.1` or later supports pool-managed persistent disks. Declare disks that must survive node replacement in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`, not in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
+
 ## Key Features
 
 - **Kube-OVN Integration**: Native support for Kube-OVN container network interface
 - **ELB Load Balancer**: Built-in elastic load balancer support for control plane high availability
 - **Static IP Configuration**: Static IP address allocation for enterprise network environments
-- **Machine Configuration Pools**: Pre-defined hostnames and IP address pools for predictable VM provisioning
+- **Machine Configuration Pools**: Pre-defined hostnames, static IP addresses, and persistent disk slots for predictable VM provisioning
+- **Pool-Managed Persistent Disks**: EVS disks can be detached from an old ECS and attached to the replacement ECS during rolling upgrades
 - **Control Plane Security Bootstrap**: Supports kube-apiserver audit, admission, encryption provider, and kubelet certificate configuration through kubeadm bootstrap data
 - **Availability Zone Selection**: Supports specifying the target availability zone for HCS machines
 
@@ -35,7 +38,7 @@ Huawei Cloud Stack is a hybrid cloud solution that extends public cloud capabili
 | `HCSCluster` | Represents HCS infrastructure including VPC, subnets, and load balancer configuration |
 | `HCSMachine` | Represents a virtual machine instance in HCS |
 | `HCSMachineTemplate` | Template for creating HCS machines with instance specifications |
-| `HCSMachineConfigPool` | Pool of pre-defined hostnames and static IP addresses |
+| `HCSMachineConfigPool` | Pool of pre-defined hostnames, static IP addresses, and persistent disk slots |
 
 ## Documentation
 
@@ -43,4 +46,5 @@ Huawei Cloud Stack is a hybrid cloud solution that extends public cloud capabili
 - [Creating Clusters](../../create-cluster/huawei-cloud-stack.mdx)
 - [Managing Nodes](../../manage-nodes/huawei-cloud-stack.mdx)
 - [Upgrading Clusters](../../upgrade-cluster/huawei-cloud-stack.mdx)
+- [Migrate Existing Clusters to Pool-Managed Persistent Disks](../../how-to/hcs_persistent_disk_upgrade.mdx)
 - [Provider APIs](../../apis/providers/huawei-cloud-stack/)

--- a/docs/en/overview/providers/index.mdx
+++ b/docs/en/overview/providers/index.mdx
@@ -39,7 +39,7 @@ Fleet Essentials works with Infrastructure Providers to deliver platform-specifi
 
 **Provider Extensions**:
 - **DCS Provider**: Alauda Container Platform DCS Infrastructure Provider `1.0.13` and later adds DCS-specific UI pages and workflows on Huawei DCS. Pool-managed persistent-disk scenarios require DCS provider `v1.0.16` or later, and in `v1.0.16` the `DCSIpHostnamePool.spec.pool[].persistentDisk` configuration remains YAML-only
-- **HCS Provider**: Enables UI-based cluster creation and management on Huawei Cloud Stack (coming soon)
+- **HCS Provider**: Provides YAML-based cluster lifecycle management on Huawei Cloud Stack. HCS provider `v1.0.1` and later supports pool-managed persistent disks through `HCSMachineConfigPool.spec.configs[].persistentDisks[]`
 - **vSphere Provider**: The VMware vSphere infrastructure provider is generally available; its Fleet Essentials UI extension for cluster creation and management is coming soon
 
 ## Provider Architecture

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -4,18 +4,6 @@ weight: 50
 
 # Release Notes
 
-## 2026-05-30
-
-### Component Version
-- Alauda Container Platform HCS Infrastructure Provider: `v1.0.1`
-
-### Changes
-- Added first support for pool-managed persistent disks on Huawei Cloud Stack in HCS provider `v1.0.1`.
-- `HCSMachineConfigPool` now declares EVS disks that survive node replacement through `spec.configs[].persistentDisks[]` and tracks runtime attachment state through `status.persistentDiskStatus[]`.
-- The platform-required `/var/cpaas` disk is now documented as a pool-managed persistent disk instead of a template-owned `HCSMachineTemplate.spec.template.spec.dataVolumes[]` entry.
-- HCS rolling replacement workflows that use pool-managed persistent disks must use `maxSurge: 0` so the replacement ECS can reuse the same fixed `(hostname, slot)` disk identity.
-- Existing clusters can migrate to the new model by following [Migrate Existing Huawei Cloud Stack Clusters to Pool-Managed Persistent Disks](../how-to/hcs_persistent_disk_upgrade.mdx).
-
 ## 2026-04-30
 
 ### Component Version

--- a/docs/en/overview/release_notes.mdx
+++ b/docs/en/overview/release_notes.mdx
@@ -4,6 +4,18 @@ weight: 50
 
 # Release Notes
 
+## 2026-05-30
+
+### Component Version
+- Alauda Container Platform HCS Infrastructure Provider: `v1.0.1`
+
+### Changes
+- Added first support for pool-managed persistent disks on Huawei Cloud Stack in HCS provider `v1.0.1`.
+- `HCSMachineConfigPool` now declares EVS disks that survive node replacement through `spec.configs[].persistentDisks[]` and tracks runtime attachment state through `status.persistentDiskStatus[]`.
+- The platform-required `/var/cpaas` disk is now documented as a pool-managed persistent disk instead of a template-owned `HCSMachineTemplate.spec.template.spec.dataVolumes[]` entry.
+- HCS rolling replacement workflows that use pool-managed persistent disks must use `maxSurge: 0` so the replacement ECS can reuse the same fixed `(hostname, slot)` disk identity.
+- Existing clusters can migrate to the new model by following [Migrate Existing Huawei Cloud Stack Clusters to Pool-Managed Persistent Disks](../how-to/hcs_persistent_disk_upgrade.mdx).
+
 ## 2026-04-30
 
 ### Component Version

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -7,6 +7,7 @@ queries:
   - upgrade hcs cluster
   - hcs kubernetes upgrade
   - hcs cluster version update
+  - hcs upgrade preserve persistent disks
 ---
 
 # Upgrading Clusters on Huawei Cloud Stack
@@ -55,6 +56,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The target VM image is present in the HCS environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the image is not present when the new `HCSMachineTemplate` is applied.
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - Review the Kubernetes upgrade path and version skew policy.
+- Any node-local state that must survive replacement is declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`, not in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 
 For initial deployment, see the [Create Cluster](../create-cluster/huawei-cloud-stack.mdx) guide.
 
@@ -67,16 +69,16 @@ The upgrade workflow in this document applies to HCS clusters with a highly avai
 :::warning
 **Disk Preservation Model**
 
-Upgrades rely on Cluster API's rolling replacement mechanism. The HCS provider currently has four disk classes, and **none of the HCS-side classes survives a delete-recreate**:
+Upgrades rely on Cluster API's rolling replacement mechanism. The HCS provider has four disk classes:
 
 | Disk class | Declared in | Survives upgrade? | Use for |
 |---|---|---|---|
 | System disk (root volume) | `HCSMachineTemplate.spec.template.spec.rootVolume` | ❌ Never | OS + kubelet/kubeadm/containerd. Rebuilt from the new VM image every replacement. |
-| Data volumes | `HCSMachineTemplate.spec.template.spec.dataVolumes` | ❌ Never | The HCS provider does not detach/reattach these. Volumes attached to the old VM may be deleted together with it. |
-| Pool-managed persistent disks | (not implemented for HCS) | — | Not available. DCS and vSphere have an equivalent; HCS does not. |
+| Data volumes | `HCSMachineTemplate.spec.template.spec.dataVolumes` | ❌ Never | Temporary node-local paths that can be recreated with each ECS. Volumes attached to the old VM may be deleted together with it. |
+| Pool-managed persistent disks | `HCSMachineConfigPool.spec.configs[].persistentDisks[]` | ✅ Yes | Node-local state that must survive delete-recreate replacement, such as `/var/cpaas`. |
 | External CSI volumes (HCS EVS CSI, etc.) | Workload PVCs / CSI driver | ✅ Unrelated to node lifecycle | Application data. Use this path for any state that must survive upgrades. |
 
-Do not treat node-local data on HCS data volumes as preserved state. Move stateful data to external persistent storage, or complete backup and migration before starting the upgrade.
+Do not treat node-local data on HCS `dataVolumes[]` as preserved state. Move `/var/cpaas` and any other retained node-local paths to pool-managed persistent disks before the rolling replacement.
 :::
 
 :::warning
@@ -119,11 +121,12 @@ Upgrading the underlying machine images for control plane nodes provides securit
    - Set `metadata.name` to `<new-template-name>`
    - Remove server-generated metadata and status fields from the copied manifest.
    - Leave runtime identity fields unset, including `spec.template.spec.providerID` and `spec.template.spec.serverId`. The HCS provider assigns these values when it creates instances.
+   - Keep preserved paths such as `/var/cpaas` out of `spec.template.spec.dataVolumes[]`. Declare those paths in the referenced `HCSMachineConfigPool.spec.configs[].persistentDisks[]`.
    - Update as needed:
      - `spec.template.spec.imageName`
      - `spec.template.spec.flavorName`
      - `spec.template.spec.rootVolume.size`
-     - `spec.template.spec.dataVolumes`
+     - `spec.template.spec.dataVolumes` for temporary disks only
 
 3. **Deploy Updated Template**
 
@@ -262,7 +265,7 @@ Three facts to internalize before rolling back:
 
 - **The old VMs are gone.** They were destroyed during the upgrade. Rollback uses the old template to build a fresh set of replacement machines; it does not restore the original VMs.
 - **The old `HCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before rolling back.
-- **HCS has no pool-managed persistent disks.** Anything written to a node's local data volumes during the upgrade window is lost when that VM is replaced. Application data must live on external persistent storage (HCS EVS CSI or equivalent) to survive the rollback.
+- **Only pool-managed persistent disks preserve node-local state.** Data written to `HCSMachineTemplate.spec.template.spec.dataVolumes[]` during the upgrade window is lost when that VM is replaced. Data written to disks declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is retained and reattached to the replacement VM. Application data should still use external persistent storage such as HCS EVS CSI unless your operational design explicitly depends on node-local state.
 
 Procedure:
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -27,6 +27,18 @@ This page covers only the Kubernetes step of the upgrade. The full ACP upgrade f
 Use this page when the same cluster runs on an immutable operating system, because the Kubernetes step on immutable OS replaces nodes from a new VM template rather than upgrading binaries in place.
 :::
 
+:::info
+**Version**
+
+HCS provider `v1.0.1` is the first release that supports pool-managed persistent disks.
+:::
+
+:::info
+**Existing Cluster Migration**
+
+If your cluster runs ACP `v4.3.1` or later and you are moving to HCS provider `v1.0.1` or later, complete the migration procedure in [Migrate Existing Huawei Cloud Stack Clusters to Pool-Managed Persistent Disks](../how-to/hcs_persistent_disk_upgrade.mdx) before you rely on upgrade-time disk preservation.
+:::
+
 ## Overview
 
 Cluster upgrades on HCS encompass multiple components and follow a structured approach to ensure system reliability:
@@ -45,6 +57,12 @@ Upgrade HCS clusters in the following order:
 2. Upgrade the Distribution Version on the workload cluster. See [Upgrading Clusters](index.mdx).
 3. Upgrade the control plane Kubernetes version.
 4. Upgrade worker nodes to the target Kubernetes version.
+
+Cluster API orchestrates rolling updates with built-in safety mechanisms to reduce service disruption.
+
+:::warning
+Skipping step 1 risks two failure modes: the old controller silently ignores new schema fields written to `HCSMachineConfigPool` / `HCSMachineTemplate`; or a controller image swap mid-rollout interrupts persistent-disk state-machine progression. Always settle the management-side upgrade before touching workload rollout.
+:::
 
 ## Prerequisites
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -47,8 +47,6 @@ Cluster upgrades on HCS encompass multiple components and follow a structured ap
 - **Worker Node Upgrades**: Upgrade worker nodes with new machine images and Kubernetes versions
 - **Infrastructure Updates**: Modify virtual machine specifications, storage, and network configurations
 
-Cluster API orchestrates declarative rolling updates with built-in safety mechanisms.
-
 ## Upgrade Sequence
 
 Upgrade HCS clusters in the following order:
@@ -117,7 +115,7 @@ The Fleet Essentials UI workflow has not been adapted to the Cluster Version Ope
 
 Control plane upgrades update the Kubernetes API server, etcd, scheduler, and controller manager, along with the underlying VM infrastructure.
 
-For HCS control planes backed by a fixed-size `HCSMachineConfigPool`, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` during upgrades. This default scale-down-then-scale-up path usually does not require additional control plane IPs. Only prepare extra hostname and static IP entries in the control plane pool if you plan to increase control plane replicas or intentionally set `maxSurge` greater than `0`.
+For HCS control planes backed by an `HCSMachineConfigPool` that uses pool-managed persistent disks, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` during upgrades. Persistent disks are bound to fixed `(hostname, slot)` identities, so the rollout must remove the old machine before the replacement machine can reuse the same disk.
 
 ### Infrastructure Image Updates
 
@@ -226,7 +224,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 
    Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same MicroOS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
 
-   Keep `spec.rolloutStrategy.rollingUpdate.maxSurge: 0` for the default static IP control plane path. Only adjust rollout settings beyond this after you extend the control plane `HCSMachineConfigPool` with extra hostname and IP slots.
+   Keep `spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the referenced control plane pool uses persistent disks. The replacement machine must reuse the same fixed hostname and disk slot after the old machine is removed.
 
 3. **Update the Kube-OVN version annotation on the `Cluster` resource**
 

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsclusters.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsclusters.yaml
@@ -5,8 +5,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: hcsclusters.infrastructure.cluster.x-k8s.io
-  labels:
-    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
@@ -111,6 +109,8 @@ spec:
                   pools:
                     items:
                       properties:
+                        healthMonitorID:
+                          type: string
                         id:
                           type: string
                         protocolPort:
@@ -160,6 +160,27 @@ spec:
                       name of the VPC, optionally included in JSON output.
                     type: string
                 type: object
+              encryptionProviderConfigRef:
+                description: |-
+                  EncryptionProviderConfigRef references a Secret containing a pre-existing
+                  encryption-provider.conf for the cluster. When set, the controller uses
+                  this config instead of generating a new random encryption key.
+                  Required for disaster recovery: the standby cluster must use the same
+                  encryption key as the primary cluster so that restored etcd data can be
+                  decrypted by the API server.
+                  The referenced Secret must contain a key "encryption-provider.conf".
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
               identityRef:
                 description: IdentityRef is a reference to the identity used to provision
                   the cluster.

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachineconfigpools.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachineconfigpools.yaml
@@ -5,8 +5,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: hcsmachineconfigpools.infrastructure.cluster.x-k8s.io
-  labels:
-    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:
@@ -60,9 +58,7 @@ spec:
             description: spec defines the desired state of HCSMachineConfigPool
             properties:
               configs:
-                description: |-
-                  Configs is the list of machine configurations available in this pool.
-                  Each config can be claimed by a HCSMachine.
+                description: Configs lists machine configurations claimable by HCSMachines.
                 items:
                   description: MachineConfig defines the configuration for a single
                     machine in the pool.
@@ -99,12 +95,74 @@ spec:
                         type: object
                       minItems: 1
                       type: array
+                    persistentDisks:
+                      description: |-
+                        PersistentDisks declares EVS disks that survive HCSMachine delete-recreate. Each disk
+                        is bound to the (Hostname, Slot) identity and re-attached to the new ECS on rolling
+                        upgrade. Slots must be unique and contiguous from 0.
+                      items:
+                        description: |-
+                          PersistentDisk defines a persistent EVS disk attached to a fixed machine slot in the pool.
+                          Persistent disks survive HCSMachine delete-recreate cycles (e.g. rolling upgrades),
+                          while temporary disks declared in HCSMachineTemplate.spec.dataVolumes[] are removed
+                          together with their ECS.
+                        properties:
+                          format:
+                            description: |-
+                              Format is the filesystem format; empty normalises to xfs. Already-formatted disks
+                              are not re-formatted. Immutable once accepted (validating webhook).
+                            type: string
+                          mountOptions:
+                            description: MountOptions overrides the default ("defaults,noatime");
+                              takes effect on next rebuild.
+                            items:
+                              type: string
+                            type: array
+                          mountPath:
+                            description: |-
+                              MountPath is the guest filesystem mount path; empty means block device only (no
+                              fs_setup/mount). Immutable once accepted (validating webhook).
+                            type: string
+                          size:
+                            description: |-
+                              Size is the EVS volume size in GB. CRD lower bound is 1 to accept legacy claimed
+                              volumes; the controller enforces the EVS [10, 32768] range only for new volumes.
+                              Immutable once accepted (validating webhook).
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          slot:
+                            description: |-
+                              Slot is the disk position within the MachineConfig. Unique and contiguous from 0;
+                              combined with hostname it keys the underlying EVS volume.
+                            format: int32
+                            minimum: 0
+                            type: integer
+                          type:
+                            description: |-
+                              Type is the EVS volume type name (e.g. SSD, SATA, hcs_global_ssd). Availability is
+                              checked at reconcile via CinderListVolumeTypes; no static whitelist.
+                              Immutable once accepted (validating webhook).
+                            minLength: 1
+                            type: string
+                        required:
+                        - size
+                        - slot
+                        - type
+                        type: object
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - slot
+                      x-kubernetes-list-type: map
                   required:
                   - hostname
                   - networks
                   type: object
                 minItems: 1
                 type: array
+                x-kubernetes-list-map-keys:
+                - hostname
+                x-kubernetes-list-type: map
             type: object
           status:
             description: status defines the observed state of HCSMachineConfigPool
@@ -113,6 +171,78 @@ spec:
                 description: AvailableCount is the number of available configurations
                   in the pool.
                 type: integer
+              persistentDiskStatus:
+                description: |-
+                  PersistentDiskStatus records the runtime state of every persistent disk owned by
+                  this pool, keyed by (Hostname, Slot).
+                items:
+                  description: |-
+                    PersistentDiskStatus records the runtime state of a single persistent disk, keyed by
+                    (Hostname, Slot). Spec fields (size/type/format/mountPath) are not duplicated here.
+                  properties:
+                    attachedServerID:
+                      description: |-
+                        AttachedServerID is the ECS server id where the disk is currently attached.
+                        Cleared during reconcileDelete after the EVS has returned to available.
+                      type: string
+                    availabilityZone:
+                      description: AvailabilityZone of the EVS volume; the controller
+                        locks the ECS AZ to this value.
+                      type: string
+                    device:
+                      description: |-
+                        Device is the guest-visible device path (e.g. /dev/vdc) computed from the current
+                        (len(spec.dataVolumes), slot). Cleared during reconcileDelete.
+                      type: string
+                    hostname:
+                      description: Hostname identifies which MachineConfig the disk
+                        belongs to.
+                      type: string
+                    lastError:
+                      description: LastError records the last error message, set when
+                        Phase=Error.
+                      type: string
+                    lastTransitionTime:
+                      description: LastTransitionTime marks the most recent phase
+                        change.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the stable EVS volume name produced by
+                        PersistentVolumeName().
+                      type: string
+                    ownerMachineName:
+                      description: OwnerMachineName is the name of the HCSMachine
+                        currently bound to this disk.
+                      type: string
+                    ownerMachineUID:
+                      description: OwnerMachineUID is the UID of the HCSMachine currently
+                        bound to this disk.
+                      type: string
+                    phase:
+                      description: Phase is the current lifecycle phase.
+                      enum:
+                      - Creating
+                      - Available
+                      - Attaching
+                      - Attached
+                      - Detaching
+                      - Deleting
+                      - Error
+                      type: string
+                    slot:
+                      description: Slot is the disk slot within the MachineConfig
+                        (matches spec).
+                      format: int32
+                      type: integer
+                    volumeID:
+                      description: VolumeID is the HCS EVS volume id.
+                      type: string
+                  required:
+                  - hostname
+                  - slot
+                  type: object
+                type: array
               totalCount:
                 description: TotalCount is the total number of configurations in the
                   pool.

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachines.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachines.yaml
@@ -5,8 +5,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: hcsmachines.infrastructure.cluster.x-k8s.io
-  labels:
-    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachinetemplates.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsmachinetemplates.yaml
@@ -5,8 +5,6 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.18.0
   name: hcsmachinetemplates.infrastructure.cluster.x-k8s.io
-  labels:
-    cluster.x-k8s.io/v1beta1: v1beta1
 spec:
   group: infrastructure.cluster.x-k8s.io
   names:


### PR DESCRIPTION
## Summary
- Document HCS provider `v1.0.1` support for pool-managed persistent disks, including the `/var/cpaas` placement rule and `maxSurge: 0` rollout requirement.
- Add the HCS migration how-to: `Migrate Existing Huawei Cloud Stack Clusters to Pool-Managed Persistent Disks`.
- Update HCS create, upgrade, global install/upgrade, node management, provider overview, API index, release notes, and shared CRD reference content for keep-disk behavior.
- Add HCS credential `schema` guidance and keep CRD reference files aligned with the provider CRDs.

## Related Implementation
- HCS provider implementation MR: https://gitlab-ce.alauda.cn/ait/cluster-api-provider-hcs/-/merge_requests/13

## Validation
- `git diff --check`
- `yarn lint`

`yarn build` and `yarn translate` were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive updates for Huawei Cloud Stack cluster creation, management, and upgrade procedures emphasizing pool-managed persistent disk configuration
  * Added new migration guide for transitioning existing clusters to pool-managed persistent disks
  * Updated CRD schemas to support persistent disk tracking and management

* **Release Notes**
  * Added v1.0.1 release notes documenting support for pool-managed persistent disks on Huawei Cloud Stack

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/immutable-infra-docs/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->