### PR TITLE
[backport release-1.0] docs(huawei-cloud-stack): AIT-70656 hostname/FQDN docs

### DIFF
--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -136,21 +136,21 @@ spec:
     - hostname: master-1
       networks:
         - subnetName: <subnet-name>
-          ipAddress: 192.168.1.11
+          ipAddress: 192.0.2.11
     - hostname: master-2
       networks:
         - subnetName: <subnet-name>
-          ipAddress: 192.168.1.12
+          ipAddress: 192.0.2.12
     - hostname: master-3
       networks:
         - subnetName: <subnet-name>
-          ipAddress: 192.168.1.13
+          ipAddress: 192.0.2.13
 ```
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `.spec.configs[]` | array | Yes | Non-empty list of machine configurations |
-| `.spec.configs[].hostname` | string | Yes | VM hostname. Use lowercase letters, numbers, hyphens (`-`), or dots (`.`); the value must start and end with a lowercase letter or number and must not exceed 253 characters |
+| `.spec.configs[].hostname` | string | Yes | VM hostname. Use lowercase letters, numbers, hyphens (`-`), or dots (`.`); the value must start and end with a lowercase letter or number and must not exceed 253 characters (per the DNS name length limit in [RFC 1035](https://datatracker.ietf.org/doc/html/rfc1035#section-2.3.4)). Leading or trailing dots, all-dot strings, and uppercase letters are rejected and the controller surfaces the error on the owning `Machine` and `Cluster` status. See the **Hostname behavior on the node** subsection below for what `hostname` and `hostname -f` return when the value contains a dot. |
 | `.spec.configs[].networks[]` | array | Yes | Non-empty list of network configurations for the VM |
 | `.spec.configs[].networks[].subnetName` | string | No* | Recommended subnet name field for new manifests |
 | `.spec.configs[].networks[].subnetId` | string | No* | Subnet ID. Use this field instead of `subnetName` when the subnet name is ambiguous |
@@ -161,6 +161,19 @@ spec:
 **Note:** The CRD schema lists `subnetName`, `subenetName`, and `subnetId` as optional fields and does not express their allowed combinations. Follow the provider-level rules above when writing manifests.
 
 **Note:** To attach multiple NICs to one node, add multiple `networks[]` entries. The provider only uses these entries to attach NICs and assign subnet selectors plus static IPs. It does not support declaring per-NIC roles, default gateways, static routes, or per-NIC DNS settings.
+
+#### Hostname behavior on the node \{#hostname-behavior-on-the-node}
+
+The provider derives the node's POSIX hostname and FQDN from `hostname` as follows:
+
+| Pool `hostname` value | Node `hostname` | Node `hostname -f` | `/etc/hosts` entry written |
+|---|---|---|---|
+| `master-1` (no dot) | `master-1` | `master-1` (resolver returns the short name) | none added by the provider |
+| `master-1.example.org` (dotted) | `master-1` (short label, dot and everything after it stripped) | `master-1.example.org` | `<node-ip> master-1.example.org master-1` |
+
+The dotted form is the path to set up applications that depend on FQDN resolution (`hostname -f`, certificates with SAN entries, log labels). The provider sets `prefer_fqdn_over_hostname: false` and enables cloud-init `manage_etc_hosts` only when a dotted hostname is supplied, so POSIX tools continue to see the short name and `hostname -f` returns the full FQDN.
+
+Invalid hostnames (leading dot, trailing dot, all-dot strings, uppercase letters, or anything that violates the field constraint) are rejected before the VM boots. The error is set on the owning `Machine.status` and surfaced on the `Cluster.status.conditions` so it shows up under `kubectl describe cluster <name>` and `kubectl get machines -n cpaas-system -o wide`.
 
 ### Configure Machine Template
 
@@ -214,7 +227,7 @@ spec:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `.spec.template.spec.imageName` | string | Yes | HCS image name such as `microos-4.2.1-new` |
+| `.spec.template.spec.imageName` | string | Yes | HCS image name. Use the image identifier published in the current release's OS support matrix; placeholder shown as `<microos-version>` in the manifest above. The exact name moves with each MicroOS release, so do not hardcode the example value across versions. |
 | `.spec.template.spec.flavorName` | string | Yes | Provider-recognized HCS API value matched against `Flavor.Name`. Do not use the tenant UI display name |
 | `.spec.template.spec.availabilityZone` | string | No | Provider-recognized HCS API value matched against `ZoneName`. Do not use the tenant UI display name |
 | `.spec.template.spec.rootVolume.type` | string | Yes | Volume type (`SSD` or `SATA`) |
@@ -536,3 +549,9 @@ For instructions on adding worker nodes to the cluster, refer to [Managing Nodes
 ## Upgrading Clusters
 
 For instructions on upgrading cluster components, refer to [Upgrading Clusters](../upgrade-cluster/huawei-cloud-stack.mdx).
+
+## Troubleshooting
+
+If the cluster reaches `Provisioned` but never becomes Ready — for example, workload nodes stay `NotReady` because the CNI is not deployed — start with the provider-agnostic [Troubleshoot a Workload Cluster Stuck in Provisioned](../how-to/troubleshoot-cluster-not-ready.mdx).
+
+For HCS-specific failure patterns (for example, `kubeadm init` never completes because a dotted `HCSMachineConfigPool` hostname produced a POSIX hostname containing dots), see [Troubleshoot Huawei Cloud Stack Workload Clusters](../how-to/troubleshoot-workload-cluster-huawei-cloud-stack.mdx).

--- a/docs/en/how-to/migrate-hcs-node-fqdn-hostname.mdx
+++ b/docs/en/how-to/migrate-hcs-node-fqdn-hostname.mdx
@@ -1,0 +1,176 @@
+---
+weight: 40
+title: Configure FQDN Hostname on Existing HCS Clusters
+queries:
+  - migrate existing hcs cluster to fqdn hostname
+  - hcs node hostname returns full fqdn
+  - hcs hostname -f fails
+  - configure fqdn for hcs cluster nodes
+  - hcs node short hostname full fqdn
+---
+
+# Configure FQDN Hostname on Existing HCS Clusters
+
+Use this guide when an existing Huawei Cloud Stack (HCS) cluster needs nodes whose POSIX `hostname` returns the short label and whose `hostname -f` returns the full FQDN, and the cluster was originally created before `cluster-api-provider-hcs` v1.0.1.
+
+Applications that depend on a working `hostname` / `hostname -f` split — TLS server certificate SAN matching, Kerberos SPN composition, monitoring labels keyed on the short name, and any code that calls `getfqdn()` — require the node to be initialized by `cluster-api-provider-hcs` v1.0.1 or later. Cloud-init only runs on first boot, so existing nodes do not pick up the new behavior automatically; the node has to be replaced through the standard Cluster API rolling-replacement flow with the new controller in place.
+
+:::info
+**Version**
+
+Use this procedure when the management cluster runs `cluster-api-provider-hcs` v1.0.1 or later. Earlier controller versions render dotted `HCSMachineConfigPool.spec.configs[].hostname` values as the full FQDN string in the POSIX hostname, which breaks `hostname -f` and can also block kubeadm init.
+:::
+
+## Overview
+
+Two conditions must both be true for a node to expose the supported hostname / FQDN behavior:
+
+1. The node's `HCSMachineConfigPool.spec.configs[].hostname` entry contains a dot (FQDN form, for example `master-1.example.org`).
+2. The node was first booted by `cluster-api-provider-hcs` v1.0.1 or later.
+
+Existing nodes booted under the older controller continue to use the cloud-init user-data they received on first boot, so editing manifests or re-applying user-data does not retroactively change their hostname behavior. The supported migration path is to replace those nodes through Cluster API rolling replacement, with the upgraded controller already installed and Ready on the management cluster.
+
+Manual on-node edits to `/etc/hostname` and `/etc/hosts` do not persist on MicroOS / SLE Micro. Cloud-init re-renders these files on every boot, including reboots triggered by `transactional-update`, OS patching, or `systemctl reboot`.
+
+## Prerequisites
+
+- The `cluster-api-provider-hcs` plugin on the management cluster is at v1.0.1 or later, and the controller Deployment in `cpaas-system` is Ready.
+- The existing workload cluster is healthy: all current `Machine` objects report `phase=Running`, all `Node` objects report `Ready`, and no rolling replacement is in flight.
+- Storage caveats reviewed (see [Storage and data caveats](#storage-and-data-caveats)).
+- The target VM image used by the existing `HCSMachineTemplate` is still present in the HCS environment. (No image change is needed; the migration only renames the template to trigger replacement.)
+- The control plane `HCSMachineConfigPool` has at least one unused `(hostname, IP)` slot available so Cluster API can surge a new control plane machine before draining the old one. If the existing pool is sized exactly to the current replica count, extend it with one more entry before starting.
+
+## Step-by-step procedure
+
+### 1. Confirm the controller is upgraded
+
+```bash
+kubectl get deployment -n cpaas-system -l app=cluster-api-provider-hcs-manager -o wide
+kubectl rollout status deployment -n cpaas-system cluster-api-provider-hcs-manager
+```
+
+The Deployment must show a v1.0.1-or-later image tag and report all replicas Ready. Replacing nodes before the controller is upgraded re-renders the old user-data on the new VMs, leaving the cluster in the same state.
+
+### 2. Decide which pools and templates are in scope
+
+The migration is only required for pools whose entries contain a dot. List the existing `HCSMachineConfigPool` resources and check each `spec.configs[].hostname`:
+
+```bash
+kubectl get hcsmachineconfigpool -n cpaas-system
+kubectl get hcsmachineconfigpool <pool-name> -n cpaas-system \
+  -o jsonpath='{range .spec.configs[*]}{.hostname}{"\n"}{end}'
+```
+
+Pools whose entries are all short labels (no dot) are not affected by the migration and do not need to be touched. Continue only for pools that contain dotted entries.
+
+### 3. Extend the control plane pool with a surge slot
+
+Cluster API replaces control plane machines one at a time. The default rollout strategy needs a free `(hostname, IP)` slot in the pool to bring up the replacement machine before terminating the old one. If the existing control plane pool has exactly as many entries as `KubeadmControlPlane.spec.replicas`, add one more entry now:
+
+```bash
+kubectl edit hcsmachineconfigpool <cp-pool-name> -n cpaas-system
+```
+
+Add an extra entry under `spec.configs` with a new hostname and a free IP from the same subnet, then save. The new entry is held in reserve and consumed only when the first machine is replaced.
+
+### 4. Create a new `HCSMachineTemplate` for the control plane
+
+The new template can be a byte-for-byte copy of the existing one with a new `metadata.name`. The rename alone is what triggers Cluster API to roll machines and pick up the new user-data; you do not need to change `imageName`, `flavorName`, or any other field.
+
+```bash
+kubectl get hcsmachinetemplate <current-cp-template> -n cpaas-system -o yaml > new-cp-template.yaml
+```
+
+Edit `new-cp-template.yaml`:
+
+- Set `metadata.name` to a new value (for example, append `-fqdn` or a date suffix).
+- Strip server-generated metadata (`resourceVersion`, `uid`, `generation`, `creationTimestamp`, `managedFields`, the `kubectl.kubernetes.io/last-applied-configuration` annotation) and the entire `status` field.
+- Leave runtime identity fields unset, including `spec.template.spec.providerID` and `spec.template.spec.serverId`. The HCS provider assigns these values when it creates the new VMs.
+
+Apply the new template:
+
+```bash
+kubectl apply -f new-cp-template.yaml -n cpaas-system
+```
+
+Keep the previous template until the rollout is healthy; rollback uses it.
+
+### 5. Patch `KubeadmControlPlane` to reference the new template
+
+```bash
+kubectl patch kubeadmcontrolplane <kcp-name> -n cpaas-system --type='merge' \
+  -p='{"spec":{"machineTemplate":{"infrastructureRef":{"name":"<new-cp-template>"}}}}'
+```
+
+Cluster API now starts a rolling replacement of the control plane. Monitor progress:
+
+```bash
+kubectl get kubeadmcontrolplane <kcp-name> -n cpaas-system -w
+kubectl get machines -n cpaas-system -l cluster.x-k8s.io/control-plane
+```
+
+Wait until every control plane `Machine` is the new one (the old `Machine` names disappear) and `KubeadmControlPlane.status.readyReplicas` equals `spec.replicas`.
+
+### 6. Repeat for each `MachineDeployment` (workers)
+
+For each `MachineDeployment` whose nodes need the new hostname behavior, repeat steps 4 and 5 with the worker template:
+
+```bash
+kubectl get hcsmachinetemplate <current-worker-template> -n cpaas-system -o yaml > new-worker-template.yaml
+# Edit metadata.name, strip status/server fields, apply
+kubectl apply -f new-worker-template.yaml -n cpaas-system
+
+kubectl patch machinedeployment <md-name> -n cpaas-system --type='merge' \
+  -p='{"spec":{"template":{"spec":{"infrastructureRef":{"name":"<new-worker-template>"}}}}}'
+```
+
+Wait for each `MachineDeployment` to report `status.updatedReplicas` equal to `spec.replicas` and all worker `Machine` objects on the new template before moving on.
+
+### 7. Verify hostname behavior on each new node
+
+On each new node:
+
+```bash
+hostname
+hostname -f
+cat /etc/hosts
+```
+
+For a node whose pool config was `hostname: master-1.example.org`, expect:
+
+- `hostname` returns `master-1` (short label, dot and everything after it stripped).
+- `hostname -f` returns `master-1.example.org`.
+- `/etc/hosts` contains an entry of the form `<loopback-or-node-ip> master-1.example.org master-1`.
+
+If a new node reports the FQDN-style string from `hostname`, or `hostname -f` returns `Name or service not known`, the cloud-init log on the node (`/var/log/cloud-init.log` and `/var/lib/cloud/instance/user-data.txt`) is the first thing to inspect, then confirm the controller is actually at v1.0.1 or later.
+
+## Storage and data caveats \{#storage-and-data-caveats}
+
+Rolling replacement destroys each old VM and builds a fresh replacement from the new template. On HCS:
+
+- The system disk (root volume) is rebuilt from the VM image on every replacement.
+- Data volumes declared in `HCSMachineTemplate.spec.template.spec.dataVolumes` are not detached and reattached; volumes on the old VM may be removed with it.
+- Workload data must live on external persistent storage (HCS EVS CSI or equivalent) to survive the migration.
+
+Complete backup and migration of any node-local state before starting.
+
+## Rollback
+
+If the new rollout is unhealthy — new VMs fail to boot, nodes do not become `Ready`, or applications break in unexpected ways — patch each affected resource back to the previous template name. Cluster API treats the reversion as a new spec drift and rolls the new machines back to the previous template:
+
+```bash
+kubectl patch kubeadmcontrolplane <kcp-name> -n cpaas-system --type='merge' \
+  -p='{"spec":{"machineTemplate":{"infrastructureRef":{"name":"<previous-cp-template>"}}}}'
+
+kubectl patch machinedeployment <md-name> -n cpaas-system --type='merge' \
+  -p='{"spec":{"template":{"spec":{"infrastructureRef":{"name":"<previous-worker-template>"}}}}}'
+```
+
+Do not delete the previous `HCSMachineTemplate` until the new rollout is healthy. If it has already been deleted, recreate it from version control or backup before rolling back.
+
+## Related
+
+- [Upgrading Clusters on Huawei Cloud Stack](../upgrade-cluster/huawei-cloud-stack.mdx) — Kubernetes-version upgrades use the same rolling-replacement mechanism.
+- [Troubleshoot Huawei Cloud Stack Workload Clusters](./troubleshoot-workload-cluster-huawei-cloud-stack.mdx) — diagnose the kubeadm-init-stalled symptom that appears when an unfixed controller boots a dotted-hostname node.
+- [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx) — provider-agnostic import-controller diagnostic flow.
+- [Hostname behavior on the node](../create-cluster/huawei-cloud-stack.mdx#hostname-behavior-on-the-node) — what `hostname` / `hostname -f` / `/etc/hosts` look like for short versus dotted pool entries on a freshly created cluster.

--- a/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
+++ b/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
@@ -16,9 +16,11 @@ The diagnostic flow assumes the workload cluster was created by applying provide
 
 ## Scope
 
-The diagnostic flow in this guide targets the **`global` cluster's import controller**, which is shared across all Immutable Infrastructure providers (Huawei DCS, VMware vSphere, Huawei Cloud Stack). The four invariants in [Invariants of a Healthy Imported Cluster](#invariants-of-a-healthy-imported-cluster) — `clusters.platform.tkestack.io` presence, the `capi.cpaas.io/imported` label, the `ClusterCredential` count, and the workload-cluster `sentry` ServiceAccount — apply to every provider.
+The diagnostic flow in this guide targets the **`global` cluster's import controller**, which is shared across all Immutable Infrastructure providers. The four invariants in [Invariants of a Healthy Imported Cluster](#invariants-of-a-healthy-imported-cluster) — `clusters.platform.tkestack.io` presence, the `capi.cpaas.io/imported` label, the `ClusterCredential` count, and the workload-cluster `sentry` ServiceAccount — apply to every provider.
 
-The example log strings in this guide come from the **DCS provider** (`KubeOvn`, `DCSCluster`). Other providers produce equivalent failures but use provider-specific reconciler object names (for example, `HCSCluster` on Huawei Cloud Stack). The diagnostic pattern is the same; only the reconciler object names differ.
+The log strings in this guide use placeholders for reconciler object names because each infrastructure provider uses its own object types (for example, the provider's own `Cluster` and `Machine` infrastructure CRDs). When you read your provider's logs, substitute the placeholders for the real object names that appear in your provider's reconciler output. The diagnostic pattern itself does not depend on the provider — only the object names in the log strings do.
+
+If your environment is Huawei Cloud Stack and the symptoms below also include a stalled `kubeadm init` on a node whose pool config carries a dotted hostname, see [Troubleshoot HCS Workload Clusters](./troubleshoot-workload-cluster-huawei-cloud-stack.mdx) for the provider-specific pattern after you finish the generic diagnostic flow on this page.
 
 ## Symptoms
 
@@ -36,9 +38,11 @@ The cluster reaches a partial-success state and stays there. The following indic
 A typical secondary signature appears in the infrastructure provider reconciler logs on the `global` cluster:
 
 ```text
-ERROR  failed to reconcile KubeOvn object: ServiceAccount "sentry" not found
-ERROR  failed to reconcile DCSCluster: ServiceAccount "sentry" not found
+ERROR  failed to reconcile <CNI-AppRelease-object>: ServiceAccount "sentry" not found
+ERROR  failed to reconcile <Infra-Cluster-object>: ServiceAccount "sentry" not found
 ```
+
+`<CNI-AppRelease-object>` and `<Infra-Cluster-object>` are placeholders for the actual object types your provider uses. For example, the CNI AppRelease object is typically named after the CNI being deployed, and the infrastructure cluster object name matches your provider's CRD (your provider's own `*Cluster` CRD).
 
 The reconciler tries to apply the CNI through an `AppRelease` resource that is executed by the workload cluster's own `sentry` ServiceAccount. If that ServiceAccount is not present, the CNI is never deployed and the workload nodes stay `NotReady`.
 
@@ -113,7 +117,7 @@ kubectl logs -n cpaas-system <infra-provider-manager-pod> --tail=200 | \
   grep -E 'ServiceAccount|sentry|<cluster-name>'
 ```
 
-If you see repeated `ServiceAccount "sentry" not found` errors paired with a failure to reconcile the CNI object (for example, `KubeOvn`), the workload cluster's CNI is not being deployed because the import flow has not completed. Continue to Step 4.
+If you see repeated `ServiceAccount "sentry" not found` errors paired with a failure to reconcile the CNI AppRelease object, the workload cluster's CNI is not being deployed because the import flow has not completed. Continue to Step 4.
 
 ### Step 4 — Verify the global cluster has imported the workload cluster
 
@@ -148,7 +152,7 @@ When this pattern holds, the workload cluster's initial import on the `global` c
 ## What Does Not Resolve This Pattern
 
 :::warning
-Restarting the cluster-transformer pod on the `global` cluster does **not** re-import a workload cluster whose initial import already failed in this pattern. This was validated on 2026-05-12 against a live test environment: after a manual pod restart no log entries referenced the affected cluster and the missing `clusters.platform.tkestack.io` entry was not created.
+Restarting the cluster-transformer pod on the `global` cluster does **not** re-import a workload cluster whose initial import already failed in this pattern. After a manual pod restart no log entries reference the affected cluster and the missing `clusters.platform.tkestack.io` entry is not created.
 :::
 
 Do not assume the controller will eventually recover on its own when more than one orphan `ClusterCredential` is present for the same cluster.

--- a/docs/en/how-to/troubleshoot-workload-cluster-huawei-cloud-stack.mdx
+++ b/docs/en/how-to/troubleshoot-workload-cluster-huawei-cloud-stack.mdx
@@ -1,0 +1,66 @@
+---
+weight: 32
+title: Troubleshoot Huawei Cloud Stack Workload Clusters
+queries:
+  - troubleshoot hcs workload cluster
+  - hcs kubeadm init never completes
+  - hcs cluster stuck in provisioned hostname
+  - hcs hostname posix dots kubeadm
+  - hcs cluster api hostname fqdn issue
+---
+
+# Troubleshoot Huawei Cloud Stack Workload Clusters
+
+This guide covers troubleshooting patterns that are specific to Huawei Cloud Stack (HCS) workload clusters managed through Cluster API.
+
+If your cluster reaches `Cluster.status.phase = Provisioned` but the import flow does not complete and workload nodes stay `NotReady` because the CNI is missing, start with the provider-agnostic guide [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx). That guide covers the shared diagnostic flow (`global` cluster import controller, `sentry` ServiceAccount, `clusters.platform.tkestack.io` invariants) for every Immutable Infrastructure provider.
+
+If you have already completed the generic flow and the symptoms below also appear, see the HCS-specific pattern on this page.
+
+## Pattern: kubeadm init Never Completes Because the Hostname Is Wrong \{#kubeadm-init-hostname}
+
+Symptoms — all true at the same time:
+
+- `Cluster.status.phase=Provisioned`, `HCSCluster.status.ready=true`, the ELB is up.
+- `HCSMachine.status.instanceState=ACTIVE` with an `InternalIP` populated, but `Machine.status.nodeRef` never becomes set.
+- `KubeadmControlPlane.status.initialized` stays empty and `status.readyReplicas=0` past the usual init window of about 5 to 10 minutes.
+- The `cluster-api-provider-hcs` controller logs (in `cpaas-system`) repeatedly print `connect: connection refused` against the control plane ELB VIP on port 6443.
+- The `HCSMachineConfigPool.spec.configs[].hostname` value chosen for the node contains a dot (FQDN style, for example `master-1.example.org`).
+
+In `cluster-api-provider-hcs` releases earlier than v1.0.1, a dotted `HCSMachineConfigPool.spec.configs[].hostname` is rendered into cloud-init as the full FQDN string in the `hostname` field, with `prefer_fqdn_over_hostname: true`. The resulting node has a POSIX hostname that contains dots, which kubeadm init does not handle, so kube-apiserver never starts.
+
+### Diagnose
+
+If you can reach the node (HCS console, jump host, or an in-cluster debug pod):
+
+```bash
+# On the affected node
+hostname
+hostname -f
+cat /etc/hosts
+sudo cat /var/lib/cloud/instance/user-data.txt | head -40
+sudo journalctl -u cloud-init -b 0 | grep -E "hostname|fqdn|update_etc_hosts"
+```
+
+Indicators that you are hitting this pattern:
+
+- `hostname` returns the full dotted string instead of just the short label.
+- `hostname -f` returns `Name or service not known` or `Temporary failure in name resolution`.
+- `/etc/hosts` does **not** contain a line of the form `<node-ip> <fqdn> <short>`.
+- The cloud-init user-data on the node shows `prefer_fqdn_over_hostname: true` and does not set `manage_etc_hosts`.
+
+### Mitigate
+
+Upgrade the `cluster-api-provider-hcs` plugin to v1.0.1 or later, then trigger a rolling replacement of the affected control plane and worker machines so the new cloud-init runs on freshly booted VMs. The step-by-step procedure is documented in [Configure FQDN Hostname on Existing HCS Clusters](./migrate-hcs-node-fqdn-hostname.mdx).
+
+Manual edits to `/etc/hostname` and `/etc/hosts` on an existing MicroOS / SLE Micro node do not persist: cloud-init re-renders these files on every boot, including reboots triggered by `transactional-update`, OS patching, or `systemctl reboot`. Rolling replacement is the supported migration path.
+
+### Prevent
+
+Re-running the cluster create with `cluster-api-provider-hcs` v1.0.1 or later already installed avoids the pattern entirely. New manifests for HCS should follow [Hostname behavior on the node](../create-cluster/huawei-cloud-stack.mdx#hostname-behavior-on-the-node) on the cluster create page when picking dotted versus short hostnames in `HCSMachineConfigPool`.
+
+## Related
+
+- [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx) — provider-agnostic import-controller diagnostic flow that applies before any HCS-specific pattern on this page.
+- [Configure FQDN Hostname on Existing HCS Clusters](./migrate-hcs-node-fqdn-hostname.mdx) — rolling-replacement migration procedure for clusters created before `cluster-api-provider-hcs` v1.0.1.
+- [Create Cluster on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx) — manifest reference for new clusters, including [Hostname behavior on the node](../create-cluster/huawei-cloud-stack.mdx#hostname-behavior-on-the-node).


### PR DESCRIPTION
## Summary

Backport of master PR #82 (final, post-review state) to the **release-1.0** branch.

This PR ships the four customer-facing documentation changes onto the same release line that carries `cluster-api-provider-hcs` v1.0.1+, so customers tracking release-1.0 see the same hostname/FQDN guidance, troubleshooting pattern, and migration how-to as customers on master.

| Page | Change |
|---|---|
| `create-cluster/huawei-cloud-stack.mdx` | New **Hostname behavior on the node** subsection; RFC 1035 citation; `<microos-version>` placeholder; RFC 5737 example IPs; Troubleshooting section linking generic + HCS-specific troubleshoot pages |
| `how-to/troubleshoot-cluster-not-ready.mdx` | Genuinely provider-agnostic: placeholder reconciler names, HCS-specific pattern removed, stale internal test-date traces removed |
| `how-to/troubleshoot-workload-cluster-huawei-cloud-stack.mdx` (new) | HCS-only kubeadm-init-never-completes pattern with diagnose / mitigate / prevent + cross-links |
| `how-to/migrate-hcs-node-fqdn-hostname.mdx` (new) | Single supported rolling-replacement procedure for existing clusters; requires plugin >= v1.0.1 |

## Why a backport PR

Following the same pattern as PR #80 (master) / PR #81 (release-1.0 backport) for AIT-67331/AIT-69516: the corresponding code MR (cluster-api-provider-hcs MR !14) targets release-1.0's release line, so the doc updates must land on release-1.0 to stay in sync with the customer-visible plugin version.

## Method

Single squashed commit carrying the final post-review state from feat/AIT-70656-hcs-fqdn-doc-updates. Intermediate commits on the master PR branch (e.g., a Path A/B/C table that was later removed during review) are intentionally collapsed — release-1.0 sees only the final shipping content.

## Test plan

- [x] `yarn lint` — 0 errors, 0 warnings
- [x] release-1.0 baseline for these 4 paths was identical to master before this PR, so the file diff equals the net master PR #82 diff (no manual conflict resolution required)
- [ ] doom CI passes

## Out of scope

ZH / RU translations — handled by the existing translation pipeline; this PR is EN only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)