### PR TITLE
docs(how-to): add Troubleshoot a Cluster Stuck in Deleting (release-1.0)

### DIFF
--- a/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
+++ b/docs/en/how-to/troubleshoot-cluster-not-ready.mdx
@@ -166,3 +166,8 @@ Engage platform support with the following information:
 - The names and creation timestamps of every `clustercredentials.platform.tkestack.io` object that shares the same `cluster.x-k8s.io/cluster-name` label as the affected cluster.
 
 Recovery currently requires deleting and recreating the workload cluster after cleaning up the orphan `ClusterCredential` entries. Do not perform this on a production cluster without platform-support guidance: the recreate path triggers deletion of the underlying virtual machines on the IaaS platform, and provider-specific details (for example, DCS IP-pool and hostname planning, or HCS `HCSMachineConfigPool` re-allocation) must be reviewed before the recreate is applied.
+
+## See Also
+
+- [Troubleshoot a Cluster Stuck in Deleting](./troubleshoot-cluster-stuck-deleting.mdx) — covers ACP-built clusters that stall in `Deleting` rather than failing to import.
+- [Troubleshoot a DCSMachine Stuck in Deleting](./troubleshoot-machine-stuck-deleting.mdx) — node-level deletion stalls; different scope.

--- a/docs/en/how-to/troubleshoot-cluster-stuck-deleting.mdx
+++ b/docs/en/how-to/troubleshoot-cluster-stuck-deleting.mdx
@@ -1,0 +1,119 @@
+---
+weight: 35
+title: Troubleshoot a Cluster Stuck in Deleting
+queries:
+  - cluster stuck deleting
+  - cluster phase deleting forever
+  - capi.cpaas.io/imported finalizer
+  - cluster CR not removed after delete
+  - kubectl patch cluster finalizers null
+---
+
+# Troubleshoot a Cluster Stuck in Deleting
+
+## Scope
+
+This page covers the case where a workload cluster that was **built by ACP** is being deleted, every child resource (provider-specific `Machine` CRs and the IaaS VMs they represent) is already gone, but the top-level `Cluster` CR remains in `Phase: Deleting` indefinitely.
+
+This page applies to any ACP-built workload cluster, regardless of the underlying IaaS:
+
+- Huawei DCS (DCS Provider)
+- Huawei Cloud Stack (HCS Provider)
+- VMware vSphere (vSphere Provider)
+- Bare-metal on Immutable Infrastructure (baremetal Provider)
+- Clusters created through the SSH UPI path managed by `cluster-manager`
+
+Direct observation evidence comes from DCS; the other providers share the same `global`-cluster control-plane path.
+
+**Not in scope:**
+
+- A provider-specific `Machine` CR (such as `DCSMachine`) stuck in `Deleting` while the IaaS VM still exists — see [Troubleshoot a DCSMachine Stuck in Deleting](./troubleshoot-machine-stuck-deleting.mdx).
+- A workload cluster that was **imported** (onboarded as a Third-party Cluster) and never reached the ready state — see [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx).
+
+## Symptoms
+
+The Cluster CR shows the pattern below.
+
+| Where to look | What you see |
+| --- | --- |
+| `Cluster.status.phase` on the `global` cluster | `Deleting`, persisting far longer than expected — typically from one hour to many hours. |
+| `Cluster.metadata.deletionTimestamp` | Set. |
+| `Cluster.metadata.finalizers` | Still contains `capi.cpaas.io/imported`. |
+| `Cluster.spec.infrastructureRef` and `Cluster.spec.controlPlaneRef` | Both are set (for example `infrastructureRef.kind: DCSCluster`, `controlPlaneRef.kind: KubeadmControlPlane`). This marks an ACP-built cluster — a Third-party Cluster has neither reference. |
+| Provider-specific `Machine` CRs in the same namespace (`DCSMachine` / `HCSMachine` / `VSphereMachine` / etc.), plus the matching infrastructure `Cluster`, `KubeadmControlPlane`, `MachineDeployment`, and `Machine` resources | None remain — cascade deletion has already completed. |
+| The IaaS platform itself (DCS portal, vCenter, HCS portal, bare-metal inventory) | None of the cluster's VMs remain. |
+| Provider controller logs (for example `cluster-api-provider-dcs-manager`) | Show successful machine deletion entries such as `removed DCSMachine finalizer`. |
+
+The `capi.cpaas.io/imported` finalizer (and a `capi.cpaas.io/alauda-cluster: imported` label, if present) does **not** by itself mean the cluster was imported — ACP-built clusters carry these too. Use the `infrastructureRef` / `controlPlaneRef` row above to tell the two apart.
+
+## Diagnosis
+
+Run the two checks below on the `global` cluster to confirm the pattern.
+
+Confirm the `capi.cpaas.io/imported` finalizer is still present:
+
+```shell
+kubectl get cluster <name> -n <ns> -o yaml | grep -A 2 finalizers
+```
+
+Confirm the cluster is ACP-built. An ACP-built cluster has both `spec.infrastructureRef` and `spec.controlPlaneRef` set; a Third-party Cluster (onboarded by import) has neither:
+
+```shell
+kubectl get cluster <name> -n <ns> \
+  -o jsonpath='infrastructureRef={.spec.infrastructureRef.kind} controlPlaneRef={.spec.controlPlaneRef.kind}{"\n"}'
+```
+
+If both values are non-empty (for example `infrastructureRef=DCSCluster controlPlaneRef=KubeadmControlPlane`), the cluster is ACP-built and the workaround on this page applies. If both are empty, the cluster was onboarded as a Third-party Cluster; this page does not apply and the workaround below must not be used.
+
+## Why This Happens
+
+The `capi.cpaas.io/imported` finalizer on a `Cluster` CR is managed by a platform controller on the `global` cluster. For a cluster onboarded as a Third-party Cluster, that finalizer is released as part of the platform-side cleanup when the cluster is removed.
+
+An ACP-built cluster carries the same finalizer. When an ACP-built cluster is deleted, its child resources and IaaS VMs are removed correctly, but the `capi.cpaas.io/imported` finalizer on the top-level `Cluster` CR is not released — so the CR stays in `Deleting`.
+
+This is a platform-level behavior, not a fault in any IaaS provider, and it does not affect imported (Third-party) clusters. The exact handling is under investigation by the platform team.
+
+## Workaround
+
+Before clearing the finalizer, verify that nothing depends on the `Cluster` CR's continued presence — every child resource and every IaaS VM must already be gone.
+
+**Step 1 — Confirm all provider-specific `Machine` CRs in the namespace are gone:**
+
+```shell
+# Replace dcsmachines with the resource for your provider (hcsmachines, vspheremachines, ...).
+kubectl get dcsmachines,hcsmachines,vspheremachines -n <ns>
+
+# Also confirm the higher-level CAPI resources are gone:
+kubectl get machines,machinedeployments,kubeadmcontrolplanes,dcsclusters,hcsclusters,vsphereclusters -n <ns>
+```
+
+Each command must return no resources for this cluster.
+
+**Step 2 — Confirm the cluster's VMs are gone on the IaaS platform.** Use the provider-specific verification method:
+
+- DCS: list VMs through the DCS portal or the DCS API and verify that none of the cluster's VMs remain. See [Creating Clusters on Huawei DCS](../create-cluster/huawei-dcs.mdx) for the relevant cluster fields.
+- HCS: list VMs in the HCS portal and verify that none remain.
+- vSphere: list VMs in vCenter under the cluster's folder and verify that none remain.
+- Bare-metal: confirm machine deprovisioning has completed in the bare-metal inventory.
+
+**Step 3 — Only after Step 1 and Step 2 both confirm zero remaining resources**, clear the Cluster CR's finalizers:
+
+```shell
+kubectl patch cluster <name> -n <ns> --type=merge \
+  -p '{"metadata":{"finalizers":null}}'
+```
+
+The Cluster CR disappears immediately. Because every child resource and every IaaS VM was already gone before this step, removing the top-level finalizer cannot leave behind an orphan — it only clears a marker that no longer has any reconciler willing to release it.
+
+## Why Not Just Wait?
+
+The finalizer is not released on a timer, and for an ACP-built cluster it is not released by the normal platform cleanup path. Waiting does not change the state — observations of nine hours or more without progress have been recorded. Apply the workaround once Step 1 and Step 2 are confirmed.
+
+## Permanent Fix
+
+The fix belongs in the `global`-cluster control plane: the `capi.cpaas.io/imported` finalizer must be released for an ACP-built cluster once its child resources are gone. This is tracked outside this documentation set; no release date is committed here. Until the fix lands, the workaround above is the supported recovery path.
+
+## See Also
+
+- [Troubleshoot a DCSMachine Stuck in Deleting](./troubleshoot-machine-stuck-deleting.mdx) — node-level deletion stalls; different scope.
+- [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx) — covers true Third-party Cluster bring-up issues; different scope.

--- a/docs/en/how-to/troubleshoot-machine-stuck-deleting.mdx
+++ b/docs/en/how-to/troubleshoot-machine-stuck-deleting.mdx
@@ -187,3 +187,4 @@ If the `Machine` is fully gone and the VM is no longer listed on the DCS portal,
 - [Creating Clusters on Huawei DCS](../create-cluster/huawei-dcs.mdx) — full cluster manifest reference
 - [Cloud Credentials for Huawei DCS](../infrastructure/huawei-dcs.mdx#cloud-credentials) — Secret format and User Types
 - [Troubleshoot a Workload Cluster Stuck in Provisioned](./troubleshoot-cluster-not-ready.mdx) — symptom-adjacent guide for cluster bring-up issues
+- [Troubleshoot a Cluster Stuck in Deleting](./troubleshoot-cluster-stuck-deleting.mdx) — top-level `Cluster` CR stuck in `Deleting` after every child machine is gone


### PR DESCRIPTION
## Summary

Backport of #89 to `release-1.0`.

Adds a new troubleshooting page for an ACP-built workload cluster whose top-level `Cluster` CR stays in `Phase: Deleting` after all child resources and IaaS VMs are gone, because the `capi.cpaas.io/imported` finalizer is not released. Includes Symptoms, Diagnosis, Workaround (with mandatory pre-checks), and cross-links to the adjacent troubleshooting pages.

Cherry-picked cleanly from `chao/troubleshoot-cluster-stuck-deleting` (commit `8e04381`).

## Test plan

- [x] Docs-only change; `yarn lint` passes with 0 errors.
- [x] Same review as #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)