### PR TITLE
docs: align upgrade-cluster callouts with renamed acp-docs sync step

### DIFF
--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -17,7 +17,7 @@ This guide explains how to upgrade Kubernetes clusters on Huawei Cloud Stack wit
 :::info
 **Where this page fits in the full ACP upgrade flow**
 
-This page covers only the Kubernetes step of the upgrade. The full ACP upgrade flow — including pre-upgrade artifact preparation, ACP Core upgrade through CVO, Aligned plugin upgrades, and Agnostic plugin upgrades from Marketplace — is documented in the ACP product documentation. Complete those steps before you start the Kubernetes step on this page:
+This page covers only the Kubernetes step of the upgrade. The full ACP upgrade flow — including upgrade artifact synchronization, ACP Core upgrade through CVO, Aligned plugin upgrades, and Agnostic plugin upgrades from Marketplace — is documented in the ACP product documentation. Complete those steps before you start the Kubernetes step on this page:
 
 - <ExternalSiteLink name="acp" href="/upgrade/overview.html" children="Upgrade Overview (scope and sequencing)" />
 - <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -16,7 +16,7 @@ This guide explains how to complete Phase 2 of the upgrade workflow for clusters
 :::info
 **Where this page fits in the full ACP upgrade flow**
 
-This page covers only the Kubernetes step of the upgrade. The full ACP upgrade flow — including pre-upgrade artifact preparation, ACP Core upgrade through CVO, Aligned plugin upgrades, and Agnostic plugin upgrades from Marketplace — is documented in the ACP product documentation. Complete those steps before you start the Kubernetes step on this page:
+This page covers only the Kubernetes step of the upgrade. The full ACP upgrade flow — including upgrade artifact synchronization, ACP Core upgrade through CVO, Aligned plugin upgrades, and Agnostic plugin upgrades from Marketplace — is documented in the ACP product documentation. Complete those steps before you start the Kubernetes step on this page:
 
 - <ExternalSiteLink name="acp" href="/upgrade/overview.html" children="Upgrade Overview (scope and sequencing)" />
 - <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -16,7 +16,7 @@ This document explains how to upgrade Kubernetes clusters on VMware vSphere afte
 :::info
 **Where this page fits in the full ACP upgrade flow**
 
-This page covers only the Kubernetes step of the upgrade. The full ACP upgrade flow — including pre-upgrade artifact preparation, ACP Core upgrade through CVO, Aligned plugin upgrades, and Agnostic plugin upgrades from Marketplace — is documented in the ACP product documentation. Complete those steps before you start the Kubernetes step on this page:
+This page covers only the Kubernetes step of the upgrade. The full ACP upgrade flow — including upgrade artifact synchronization, ACP Core upgrade through CVO, Aligned plugin upgrades, and Agnostic plugin upgrades from Marketplace — is documented in the ACP product documentation. Complete those steps before you start the Kubernetes step on this page:
 
 - <ExternalSiteLink name="acp" href="/upgrade/overview.html" children="Upgrade Overview (scope and sequencing)" />
 - <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />


### PR DESCRIPTION
## Summary

The acp-docs "Standard Workflow" step previously called "Prepare upgrade artifacts" was renamed to "Sync upgrade artifacts" (see alauda/acp-docs#815). This updates the three immutable-infra upgrade-cluster pages so their "Where this page fits in the full ACP upgrade flow" callout uses matching terminology: "pre-upgrade artifact preparation" -> "upgrade artifact synchronization".

- `upgrade-cluster/huawei-dcs.mdx`, `huawei-cloud-stack.mdx`, `vmware-vsphere.mdx`.

No outbound anchor links into acp-docs are affected.

## Test plan

- [x] Docs-only wording change; `yarn lint` passes with 0 errors.
- [x] Merge alongside / after alauda/acp-docs#815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)