### PR TITLE
docs(upgrade-cluster): correct Kube-OVN AppRelease guidance and OS Support Matrix chart version (release-1.0)

### DIFF
--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -70,6 +70,8 @@ If global cluster nodes use a multi-NIC layout (for example, one NIC on the ACP 
 
 Configure a LoadBalancer for the Kubernetes API Server before creating the cluster. The LoadBalancer distributes API server traffic across control plane nodes to ensure high availability.
 
+The DCS provider does not create this load balancer. Provision it yourself before cluster creation and reference its address in `DCSCluster.spec.controlPlaneLoadBalancer`. For a single-control-plane deployment that has no load balancer in front of the API server, see [Single-Control-Plane (No External LB) Layout](#single-control-plane-layout).
+
 ### 6. Public Registry Configuration
 
 Configure the public registry credentials. This includes:

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -156,6 +156,8 @@ The template should also meet the following requirements:
 
 ## Load Balancer Prerequisites
 
+The control plane VIP is served by an external load balancer that you provision before cluster creation. The documented vSphere flow does not deploy an in-cluster VIP component, so the load balancer, its VIP allocation, and its backend (real-server) maintenance are all prepared and owned outside the cluster.
+
 | Parameter | Placeholder | Required | Validation or Notes | Example | Actual Value |
 |-----------|-------------|----------|---------------------|---------|--------------|
 | Control plane VIP | `<vip>` | Yes | The VIP is already allocated. | `10.10.10.10` | - |

--- a/docs/en/overview/os-support-matrix.mdx
+++ b/docs/en/overview/os-support-matrix.mdx
@@ -15,16 +15,22 @@ This requirement applies when you create or upgrade cluster nodes with ACP-provi
 
 ## Version Mapping
 
-| ACP Version | MicroOS Image Version | Kubernetes Version | containerd | coredns | etcd | pause | kube-ovn |
+| ACP Version | MicroOS Image Version | Kubernetes Version | containerd | coredns | etcd | pause | kube-ovn (chart) |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| v4.0.9 | **MicroOS-5.5-v4.0.9** | v1.31.14-2 | 1.7.23-4 | 1.12.4-v4.0.20 | v3.5.25-251215 | 3.10 | v1.14.28 |
-| v4.1.0 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v1.14.4 |
-| v4.1.1 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v1.14.5 |
-| v4.1.2 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v1.14.9 |
-| v4.1.3 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.12.4-v4.1.2 | v3.5.21 | 3.10 | v1.14.11 |
-| v4.1.5 | **MicroOS-5.5-v4.1.5** | v1.32.11-2 | 1.7.27-4 | 1.12.4-v4.1.5 | v3.5.25-251215 | 3.10 | v1.14.30 |
-| v4.2.0 | **MicroOS-5.5-v4.2.0** | v1.33.6 | 1.7.27-4 | 1.12.4-v4.2.3 | v3.5.21-251117 | 3.10 | v1.14.18 |
-| v4.2.1 | **MicroOS-5.5-v4.2.1** | v1.33.7-1 | 1.7.29-4 | 1.12.4-v4.2.4 | v3.5.25-251215 | 3.10 | v1.14.25 |
-| v4.2.2 | **MicroOS-5.5-v4.2.2** | v1.33.7-2 | 1.7.29-4 | 1.12.4-v4.2.7 | v3.5.25-251215 | 3.10 | v1.14.30 |
-| v4.2.3,v4.2.4 | **MicroOS-5.5-v4.2.3** | v1.33.7-3 | 1.7.29-4 | 1.12.4-v4.2.8 | v3.5.27-260305 | 3.10 | v1.14.34 |
-| v4.3.0 | **MicroOS-5.5-v4.3.0** | v1.34.5 | 2.2.1-5 | 1.14.2-v4.3.4 | v3.5.28-260325 | 3.10 | v1.15.10 |
+| v4.0.9 | **MicroOS-5.5-v4.0.9** | v1.31.14-2 | 1.7.23-4 | 1.12.4-v4.0.20 | v3.5.25-251215 | 3.10 | v4.0.39 |
+| v4.1.0 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.4 |
+| v4.1.1 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.5 |
+| v4.1.2 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.9 |
+| v4.1.3 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.12.4-v4.1.2 | v3.5.21 | 3.10 | v4.1.11 |
+| v4.1.5 | **MicroOS-5.5-v4.1.5** | v1.32.11-2 | 1.7.27-4 | 1.12.4-v4.1.5 | v3.5.25-251215 | 3.10 | v4.1.25 |
+| v4.2.0 | **MicroOS-5.5-v4.2.0** | v1.33.6 | 1.7.27-4 | 1.12.4-v4.2.3 | v3.5.21-251117 | 3.10 | v4.2.6 |
+| v4.2.1 | **MicroOS-5.5-v4.2.1** | v1.33.7-1 | 1.7.29-4 | 1.12.4-v4.2.4 | v3.5.25-251215 | 3.10 | v4.2.15 |
+| v4.2.2 | **MicroOS-5.5-v4.2.2** | v1.33.7-2 | 1.7.29-4 | 1.12.4-v4.2.7 | v3.5.25-251215 | 3.10 | v4.2.24 |
+| v4.2.3,v4.2.4 | **MicroOS-5.5-v4.2.3** | v1.33.7-3 | 1.7.29-4 | 1.12.4-v4.2.8 | v3.5.27-260305 | 3.10 | v4.2.26 |
+| v4.3.0 | **MicroOS-5.5-v4.3.0** | v1.34.5 | 2.2.1-5 | 1.14.2-v4.3.4 | v3.5.28-260325 | 3.10 | v4.3.3 |
+
+:::info
+The **kube-ovn (chart)** column is the `acp/chart-cpaas-kube-ovn` Helm chart version, which tracks the ACP release line (for example, ACP v4.2.2 ships chart `v4.2.24`). It is **not** the Kube-OVN component (binary) version such as `v1.14.x` or `v1.15.x`.
+
+Use this chart version — not the component version — when you set the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource and when you patch the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision`. See the provider-specific upgrade guides for the procedure.
+:::

--- a/docs/en/overview/providers/index.mdx
+++ b/docs/en/overview/providers/index.mdx
@@ -24,6 +24,18 @@ Immutable Infrastructure supports multiple infrastructure platforms through plug
 | [VMware vSphere](./vmware-vsphere.mdx) | VMware vSphere virtualization platform | ✅ Available |
 | [Bare Metal](./bare-metal.mdx) | Bare-metal servers without virtualization | 📋 Planned |
 
+## Control Plane Endpoint
+
+Each cluster's Kubernetes API server (`kube-apiserver`, port `6443`) is reached through a control plane endpoint — a virtual IP (VIP) or load balancer address that fronts the control plane nodes. How that endpoint is provided differs by provider, which determines what you must prepare before cluster creation.
+
+| Provider | Control plane endpoint | Mechanism | What you prepare |
+|----------|------------------------|-----------|------------------|
+| Huawei DCS | You provide it | An external load balancer that fronts the control plane nodes, or a single control plane node reached directly | Provision the load balancer before cluster creation and supply its address and port in `DCSCluster.spec.controlPlaneLoadBalancer` |
+| Huawei Cloud Stack | The provider creates it | An HCS Elastic Load Balance (ELB) instance created automatically during cluster reconciliation | Plan the ELB inputs — VIP subnet, VIP address, bandwidth, and public-IP preference — in `HCSCluster.spec.controlPlaneLoadBalancer` |
+| VMware vSphere | You provide it | An external load balancer that fronts the control plane nodes | Provision the load balancer and allocate the control plane VIP before cluster creation; the documented flow does not deploy an in-cluster VIP component |
+
+Huawei Cloud Stack is the only provider that creates the control plane load balancer for you. For Huawei DCS and VMware vSphere, the load balancer — including its VIP allocation and backend (real-server) maintenance — is prepared and owned outside the cluster. Bare Metal is planned; its control plane endpoint model will be documented when the provider is released.
+
 ## Fleet Essentials Plugin
 
 Fleet Essentials is a core plugin that provides a shared web UI framework for cluster management. Infrastructure Providers can extend it through UI extension anchors to add platform-specific pages and workflows.

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -185,7 +185,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended version; on an existing cluster the chart revision must be patched separately (see step 3 below). |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately (see step 3 below). This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the HCS provider watches it independently of the Kubernetes control plane rollout.
 
@@ -243,7 +243,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
      cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
    ```
 
-   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn** column of the target row.
+   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
 
    3.2. **Patch the `AppRelease` chart revision on the workload cluster**
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -245,7 +245,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 
    # Confirm the installed revision matches the target version and the chart phase is Success
    kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.cpaas-kube-ovn.installedRevision}{"\n"}Phase: {.status.charts.cpaas-kube-ovn.phase}{"\n"}'
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
    ```
 
    The Kube-OVN upgrade is complete when `installedRevision` equals the **kube-ovn** value from the OS Support Matrix row and `phase` is `Success`. Any other `phase` value (`Downloading`, `Installing`, `Upgrading`, `Syncing`, `HealthChecking`) means the reconciliation is still in progress; the failure phases are `DownloadFailed`, `DeployFailed`, and `NotReady`.

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -185,7 +185,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the HCS provider reconciles the Kube-OVN AppRelease from this annotation |
+| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended version; on an existing cluster the chart revision must be patched separately (see step 3 below). |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the HCS provider watches it independently of the Kubernetes control plane rollout.
 
@@ -226,29 +226,62 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 
    Keep `spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the referenced control plane pool uses persistent disks. The replacement machine must reuse the same fixed hostname and disk slot after the old machine is removed.
 
-3. **Update the Kube-OVN version annotation on the `Cluster` resource**
+3. **Upgrade the Kube-OVN chart on the workload cluster**
 
-   If the target ACP row in the OS Support Matrix shows a different **kube-ovn** value than the current cluster, patch the annotation on the `Cluster` resource so the HCS provider reconciles the new Kube-OVN AppRelease.
+   Kube-OVN is a Core lifecycle component, but on immutable OS the HCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
+
+   :::warning
+   **Why two steps are required on HCS**
+
+   The HCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
+   :::
+
+   3.1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
 
    ```bash
    kubectl annotate cluster <cluster-name> -n cpaas-system \
      cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
    ```
 
-   Kube-OVN is a Core lifecycle component, but on immutable OS the HCS provider drives its delivery from this annotation; the annotation does not update automatically when `spec.version` changes.
+   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn** column of the target row.
 
-   The HCS provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Confirm the reconciliation has completed against the new target version before you move on. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster):
+   3.2. **Patch the `AppRelease` chart revision on the workload cluster**
+
+   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
 
    ```bash
-   # Overall AppRelease state — the Sync and Health columns must report a Success-equivalent reason
+   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+   ```
+
+   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
+
+   3.3. **Wait for reconciliation to complete**
+
+   Watch the chart phase and the installed revision:
+
+   ```bash
+   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
    kubectl get apprelease cni-kube-ovn -n cpaas-system
 
-   # Confirm the installed revision matches the target version and the chart phase is Success
+   # Installed revision and chart phase
    kubectl get apprelease cni-kube-ovn -n cpaas-system \
      -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
    ```
 
-   The Kube-OVN upgrade is complete when `installedRevision` equals the **kube-ovn** value from the OS Support Matrix row and `phase` is `Success`. Any other `phase` value (`Downloading`, `Installing`, `Upgrading`, `Syncing`, `HealthChecking`) means the reconciliation is still in progress; the failure phases are `DownloadFailed`, `DeployFailed`, and `NotReady`.
+   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
+
+   | Phase | Meaning | `installedRevision` |
+   |---|---|---|
+   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
+   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
+   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
+
+   :::warning
+   Do not declare the upgrade complete on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. The chart is only considered upgraded when `phase` is `Success` **and** `installedRevision` matches the target.
+   :::
+
+   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
 
 4. **Verify Upgrade Progress**
 
@@ -287,11 +320,14 @@ Procedure:
 
 - **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
 - **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the kube-ovn annotation was changed, restore the previous value on the `Cluster` resource:
+- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check used in step 3.
 
   ```bash
   kubectl annotate cluster <cluster-name> -n cpaas-system \
     cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
+
+  kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+    -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
   ```
 
 If the new control plane never reached etcd quorum, the `KubeadmControlPlane` controller may refuse to roll back any machine because its preflight checks block on an unhealthy etcd. Recover etcd quorum first (operator intervention) before retrying the rollback.

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -109,7 +109,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the DCS provider reconciles the Kube-OVN AppRelease from this annotation |
+| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended version; on an existing cluster the chart revision must be patched separately (see step 3 below). |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the DCS provider watches it independently of the Kubernetes control plane rollout.
 
@@ -196,29 +196,62 @@ Before you start, collect every required value from the target ACP row in the OS
 
    Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same MicroOS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
 
-3. **Update the Kube-OVN version annotation on the `Cluster` resource**
+3. **Upgrade the Kube-OVN chart on the workload cluster**
 
-   If the target ACP row in the OS Support Matrix shows a different **kube-ovn** value than the current cluster, patch the annotation on the `Cluster` resource so the DCS provider reconciles the new Kube-OVN AppRelease.
+   Kube-OVN is a Core lifecycle component, but on immutable OS the DCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
+
+   :::warning
+   **Why two steps are required on DCS**
+
+   The DCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
+   :::
+
+   3.1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
 
    ```bash
    kubectl annotate cluster <cluster-name> -n cpaas-system \
      cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
    ```
 
-   Kube-OVN is a Core lifecycle component, but on immutable OS the DCS provider drives its delivery from this annotation; the annotation does not update automatically when `spec.version` changes.
+   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn** column of the target row.
 
-   The DCS provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Confirm the reconciliation has completed against the new target version before you move on. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster):
+   3.2. **Patch the `AppRelease` chart revision on the workload cluster**
+
+   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
 
    ```bash
-   # Overall AppRelease state — the Sync and Health columns must report a Success-equivalent reason
+   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+   ```
+
+   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
+
+   3.3. **Wait for reconciliation to complete**
+
+   Watch the chart phase and the installed revision:
+
+   ```bash
+   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
    kubectl get apprelease cni-kube-ovn -n cpaas-system
 
-   # Confirm the installed revision matches the target version and the chart phase is Success
+   # Installed revision and chart phase
    kubectl get apprelease cni-kube-ovn -n cpaas-system \
      -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
    ```
 
-   The Kube-OVN upgrade is complete when `installedRevision` equals the **kube-ovn** value from the OS Support Matrix row and `phase` is `Success`. Any other `phase` value (`Downloading`, `Installing`, `Upgrading`, `Syncing`, `HealthChecking`) means the reconciliation is still in progress; the failure phases are `DownloadFailed`, `DeployFailed`, and `NotReady`.
+   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
+
+   | Phase | Meaning | `installedRevision` |
+   |---|---|---|
+   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
+   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
+   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
+
+   :::warning
+   Do not declare the upgrade complete on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. The chart is only considered upgraded when `phase` is `Success` **and** `installedRevision` matches the target.
+   :::
+
+   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
 
 4. **Monitor the rolling update**
 
@@ -267,11 +300,14 @@ Procedure:
 
 - **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
 - **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the kube-ovn annotation was changed, restore the previous value on the `Cluster` resource:
+- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check used in step 3.
 
   ```bash
   kubectl annotate cluster <cluster-name> -n cpaas-system \
     cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
+
+  kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+    -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
   ```
 
 If the new control plane never reached etcd quorum, the `KubeadmControlPlane` controller may refuse to roll back any machine because its preflight checks block on an unhealthy etcd. Recover etcd quorum first (operator intervention) before retrying the rollback.

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -215,7 +215,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
    # Confirm the installed revision matches the target version and the chart phase is Success
    kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.cpaas-kube-ovn.installedRevision}{"\n"}Phase: {.status.charts.cpaas-kube-ovn.phase}{"\n"}'
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
    ```
 
    The Kube-OVN upgrade is complete when `installedRevision` equals the **kube-ovn** value from the OS Support Matrix row and `phase` is `Success`. Any other `phase` value (`Downloading`, `Installing`, `Upgrading`, `Syncing`, `HealthChecking`) means the reconciliation is still in progress; the failure phases are `DownloadFailed`, `DeployFailed`, and `NotReady`.

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -109,7 +109,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended version; on an existing cluster the chart revision must be patched separately (see step 3 below). |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately (see step 3 below). This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the DCS provider watches it independently of the Kubernetes control plane rollout.
 
@@ -213,7 +213,7 @@ Before you start, collect every required value from the target ACP row in the OS
      cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
    ```
 
-   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn** column of the target row.
+   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
 
    3.2. **Patch the `AppRelease` chart revision on the workload cluster**
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -87,7 +87,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the vSphere provider reconciles the Kube-OVN AppRelease from this annotation |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the vSphere provider reconciles the Kube-OVN AppRelease from this annotation. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the vSphere provider watches it independently of the Kubernetes control plane rollout.
 
@@ -153,7 +153,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
 2. **Update the Kube-OVN version annotation on the `Cluster` resource**
 
-   If the target ACP row in the OS Support Matrix shows a different **kube-ovn** value than the current cluster, patch the annotation on the `Cluster` resource so the vSphere provider reconciles the new Kube-OVN AppRelease.
+   If the target ACP row in the OS Support Matrix shows a different **kube-ovn (chart)** value than the current cluster, patch the annotation on the `Cluster` resource so the vSphere provider reconciles the new Kube-OVN AppRelease.
 
    :::info
    **Prerequisite — Kube-OVN reconcile gating annotation (vSphere only)**

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -176,18 +176,30 @@ Before you start, collect every required value from the target ACP row in the OS
 
    Kube-OVN is a Core lifecycle component, but on immutable OS the vSphere provider drives its delivery from this annotation; the annotation does not update automatically when `spec.version` changes.
 
-   The vSphere provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Confirm the reconciliation has completed against the new target version before you move on. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster):
+   The vSphere provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster) to follow the reconciliation:
 
    ```bash
-   # Overall AppRelease state — the Sync and Health columns must report a Success-equivalent reason
+   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
    kubectl get apprelease cni-kube-ovn -n cpaas-system
 
-   # Confirm the installed revision matches the target version and the chart phase is Success
+   # Installed revision and chart phase
    kubectl get apprelease cni-kube-ovn -n cpaas-system \
      -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
    ```
 
-   The Kube-OVN upgrade is complete when `installedRevision` equals the **kube-ovn** value from the OS Support Matrix row and `phase` is `Success`. Any other `phase` value (`Downloading`, `Installing`, `Upgrading`, `Syncing`, `HealthChecking`) means the reconciliation is still in progress; the failure phases are `DownloadFailed`, `DeployFailed`, and `NotReady`.
+   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
+
+   | Phase | Meaning | `installedRevision` |
+   |---|---|---|
+   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
+   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
+   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
+
+   :::warning
+   Do not declare the upgrade complete on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. The chart is only considered upgraded when `phase` is `Success` **and** `installedRevision` matches the target.
+   :::
+
+   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
 
 3. **Monitor the control plane rollout**
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -155,6 +155,20 @@ Before you start, collect every required value from the target ACP row in the OS
 
    If the target ACP row in the OS Support Matrix shows a different **kube-ovn** value than the current cluster, patch the annotation on the `Cluster` resource so the vSphere provider reconciles the new Kube-OVN AppRelease.
 
+   :::info
+   **Prerequisite — Kube-OVN reconcile gating annotation (vSphere only)**
+
+   On vSphere, the provider reconciles the Kube-OVN `AppRelease` only when the `Cluster` resource carries the annotation `cpaas.io/network-type: kube-ovn`. This annotation is normally set at cluster creation. If it is missing, the steps below will succeed at writing the version annotation but the Kube-OVN `AppRelease` will not be reconciled. Verify before proceeding:
+
+   ```bash
+   kubectl get cluster <cluster_name> -n <namespace> \
+     -o jsonpath='{.metadata.annotations.cpaas\.io/network-type}{"\n"}'
+   # Expected output: kube-ovn
+   ```
+
+   This precondition is vSphere-specific. The DCS and Huawei Cloud Stack providers use the `DCSCluster` / `HCSCluster` `spec.networkType` field instead and do not require this annotation.
+   :::
+
    ```bash
    kubectl annotate cluster <cluster_name> -n <namespace> \
      cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
@@ -170,7 +184,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
    # Confirm the installed revision matches the target version and the chart phase is Success
    kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.cpaas-kube-ovn.installedRevision}{"\n"}Phase: {.status.charts.cpaas-kube-ovn.phase}{"\n"}'
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
    ```
 
    The Kube-OVN upgrade is complete when `installedRevision` equals the **kube-ovn** value from the OS Support Matrix row and `phase` is `Success`. Any other `phase` value (`Downloading`, `Installing`, `Upgrading`, `Syncing`, `HealthChecking`) means the reconciliation is still in progress; the failure phases are `DownloadFailed`, `DeployFailed`, and `NotReady`.


### PR DESCRIPTION
## Summary

Backport of #93 to `release-1.0`. Clean cherry-pick of the same commits, no conflicts.

Hardens Kube-OVN upgrade guidance and the control plane endpoint model for Immutable Infrastructure clusters:

1. **AppRelease status jsonpath fix** — verification commands use the `status.charts.*` wildcard, since `status.charts` is keyed by the chart name, not the release name.
2. **Kube-OVN chart upgrade procedure** — on DCS and HCS the provider reconciles only the AppRelease `spec.values` block, so the `cpaas.io/kube-ovn-version` annotation alone does not move the chart on an existing cluster. The step is rewritten into annotation + direct AppRelease patch + verification, with the observed `Upgrading -> HealthChecking -> Success` phase sequence.
3. **vSphere prerequisite annotation** — added verification of `cpaas.io/network-type: kube-ovn`, which vSphere requires to reconcile the Kube-OVN AppRelease.
4. **OS Support Matrix kube-ovn column** — corrected from component (binary) version to `acp/chart-cpaas-kube-ovn` Helm chart version; column renamed `kube-ovn (chart)`.
5. **Control plane endpoint model per provider** — added a "Control Plane Endpoint" comparison table to the providers overview; made the DCS LoadBalancer Configuration step explicit that the provider does not create the load balancer; stated in the vSphere parameter checklist that the control plane VIP is served by an externally provisioned load balancer.

## Verification

- `yarn lint` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
