### PR TITLE
docs(upgrade-cluster): document cross-version pre-staging for immutable OS

### DIFF
--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -38,6 +38,7 @@ Like workload clusters, the `global` cluster on Immutable Infrastructure follows
 - An etcd backup of the `global` cluster has been taken and verified.
 - The new MicroOS image and the matching `KubeadmControlPlane` and `MachineDeployment` versions are available on the platform's registry.
 - A maintenance window plan that accounts for rolling control plane replacement.
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and OS images are pre-staged. See [Cross-Version Upgrade Preparation](../upgrade-cluster/index.mdx#cross-version-preparation).
 
 ## Procedure
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -70,6 +70,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The control plane is reachable.
 - All nodes are healthy and in `Ready` state.
 - The target VM image is present in the HCS environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the image is not present when the new `HCSMachineTemplate` is applied.
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM images are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - Review the Kubernetes upgrade path and version skew policy.
 - Any node-local state that must survive replacement is declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`, not in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
@@ -110,12 +111,6 @@ Every upgrade step on this page therefore creates a new `HCSMachineTemplate` wit
 
 The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. HCS clusters do not currently expose a Fleet Essentials UI upgrade path; use the YAML procedure documented below, or the two-step upgrade flow built into the ACP Core platform — see <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
 :::
-
-## Cross-Version Upgrades  \{#cross-version-upgrades}
-
-When the target ACP version is more than one Kubernetes minor above the cluster's current version, upgrade the Kubernetes version one minor at a time — for example, v1.32 → v1.33 → v1.34. Kubernetes only supports single-minor upgrades, and each intermediate Kubernetes minor uses the matching VM image and Core images from its OS Support Matrix row.
-
-Before starting a cross-version upgrade, complete the [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation) so the intermediate Core images and VM images required for each hop are already staged.
 
 ## Control Plane Upgrades
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -111,6 +111,12 @@ Every upgrade step on this page therefore creates a new `HCSMachineTemplate` wit
 The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. HCS clusters do not currently expose a Fleet Essentials UI upgrade path; use the YAML procedure documented below, or the two-step upgrade flow built into the ACP Core platform — see <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
 :::
 
+## Cross-Version Upgrades  \{#cross-version-upgrades}
+
+When the target ACP version is more than one Kubernetes minor above the cluster's current version, upgrade the Kubernetes version one minor at a time — for example, v1.32 → v1.33 → v1.34. Kubernetes only supports single-minor upgrades, and each intermediate Kubernetes minor uses the matching VM image and Core images from its OS Support Matrix row.
+
+Before starting a cross-version upgrade, complete the [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation) so the intermediate Core images and VM images required for each hop are already staged.
+
 ## Control Plane Upgrades
 
 Control plane upgrades update the Kubernetes API server, etcd, scheduler, and controller manager, along with the underlying VM infrastructure.

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -395,17 +395,6 @@ Worker Node Pools cannot be upgraded until the Control Plane Node Pool upgrade c
 | Control Plane upgrading | ❌ Disabled: "Wait for the Control Plane Node Pool upgrade to complete" |
 | Control Plane upgraded | ✅ Enabled |
 
-### Cross-Version Upgrades
-
-When upgrading across multiple minor versions (for example, v1.32 → v1.34):
-
-1. Upgrade Control Plane to v1.33
-2. Wait for completion
-3. Upgrade Control Plane to v1.34
-4. Repeat for Worker Pools
-
-**Why**: Kubernetes only supports single minor version upgrades. Each intermediate Kubernetes minor uses the matching VM template and Core images from its OS Support Matrix row, so the intermediate Core images and VM templates must be pre-staged before the cross-version upgrade starts. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
-
 ### Troubleshooting
 
 | Issue | Solution |

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -62,6 +62,7 @@ Before you start, ensure all of the following prerequisites are met:
 - All nodes are healthy and in Ready state
 - The IP Pool has sufficient capacity for rolling updates
 - The VM template supports the target Kubernetes version. See [OS Support Matrix](../overview/os-support-matrix.mdx) for version mapping
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation)
 - The target Kubernetes version is compatible with your workloads and add-ons
 - DCS VM templates are `4.2.1` or later if you use pool-managed persistent disks, because safe shutdown and disk detach depend on guest tools
 - If you rely on pool-managed persistent disks, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0`
@@ -403,7 +404,7 @@ When upgrading across multiple minor versions (for example, v1.32 → v1.34):
 3. Upgrade Control Plane to v1.34
 4. Repeat for Worker Pools
 
-**Why**: Kubernetes only supports single minor version upgrades.
+**Why**: Kubernetes only supports single minor version upgrades. Each intermediate Kubernetes minor uses the matching VM template and Core images from its OS Support Matrix row, so the intermediate Core images and VM templates must be pre-staged before the cross-version upgrade starts. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 
 ### Troubleshooting
 

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -103,6 +103,41 @@ See platform-specific guides:
 
 ---
 
+## Preparing for Cross-Version Upgrades  \{#cross-version-preparation}
+
+When the target ACP Distribution Version is more than one Kubernetes minor above the cluster's current version, additional preparation is required before starting Phase 2. Single-minor upgrades skip this section.
+
+On Immutable Infrastructure, each Kubernetes minor is baked into a matching OS image, and each Kubernetes minor maps to a specific ACP version row in [OS Support Matrix](../overview/os-support-matrix.mdx). The Kubernetes version therefore moves forward one minor at a time, stepping through the OS image of each intermediate ACP row. The ACP Core (Distribution Version) itself is still upgraded directly to the target version through the Cluster Version Operator — only the Kubernetes version steps through the intermediate minors.
+
+Identify every ACP minor between the current and target versions, use the latest patch in each row, and complete the following pre-staging for each intermediate version before starting Phase 2.
+
+### Step 1 — Pre-sync intermediate Core images to the registry
+
+For each intermediate ACP version, download its Core package and synchronize only its images into the registry. Do not request a Core upgrade to the intermediate version.
+
+```bash
+bash upgrade.sh --only-sync-image
+```
+
+See <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#sync-upgrade-artifacts" children="Sync upgrade artifacts" /> for command options.
+
+This places the intermediate-version CoreDNS, etcd, and Kube-OVN chart images in the registry so the staged Kubernetes rollout can pull them when `KubeadmControlPlane` is patched to the matching OS Support Matrix row. In an air-gapped environment, missing intermediate images prevent the new control plane components from starting.
+
+Aligned plugins do not need an extra `violet push` for the intermediate versions; they move directly to the target version with the Core upgrade, and the Kube-OVN chart used by each intermediate Kubernetes hop is already covered by the Core image sync above.
+
+### Step 2 — Stage intermediate OS images for the provisioning mechanism
+
+For each intermediate ACP version, make the matching OS image (the **MicroOS Image Version** value from the OS Support Matrix row) available to the node provisioning mechanism so the Kubernetes step can replace nodes from each image in turn:
+
+- **IaaS providers (Huawei DCS, VMware vSphere, Huawei Cloud Stack)**: upload the OS image and register it as a VM template (or VM image, depending on the platform) under the exact name listed in the OS Support Matrix row.
+- **Bare metal**: make the OS image available to the node re-provisioning flow used by your cluster.
+
+The control plane and worker rollouts then step through the intermediate OS images one at a time, matched to the staged Kubernetes minor, until the cluster reaches the target ACP version row.
+
+After completing both steps, continue with the platform-specific procedure below.
+
+---
+
 ## Platform-Specific Instructions
 
 Select your platform for detailed upgrade instructions:

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -134,7 +134,9 @@ For each intermediate ACP version, make the matching OS image (the **MicroOS Ima
 
 The control plane and worker rollouts then step through the intermediate OS images one at a time, matched to the staged Kubernetes minor, until the cluster reaches the target ACP version row.
 
-After completing both steps, continue with the platform-specific procedure below.
+### Step 3 — Apply the platform-specific procedure for each intermediate version
+
+Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for `KubeadmControlPlane` and `MachineDeployment` values. For each hop, complete the provider's standard procedure — control plane first, then workers, per the Kubernetes version skew policy — before starting the next. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
 
 ---
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -44,6 +44,7 @@ Before you begin, ensure the following conditions are met:
 - The control plane is healthy and reachable.
 - All nodes are in the `Ready` state.
 - The target VM template is present in the vSphere environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the template is not present when the new `VSphereMachineTemplate` is applied.
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - The machine config pools have enough capacity for rolling updates.
 - Review the Kubernetes upgrade path and version skew policy.
@@ -74,12 +75,6 @@ Upgrades rely on Cluster API's rolling replacement mechanism. Each cluster has f
 
 vSphere clusters do not currently expose a Fleet Essentials UI upgrade path. Use the YAML procedure documented below, or the two-step upgrade flow built into the ACP Core platform — see <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
 :::
-
-## Cross-Version Upgrades  \{#cross-version-upgrades}
-
-When the target ACP version is more than one Kubernetes minor above the cluster's current version, upgrade the Kubernetes version one minor at a time — for example, v1.32 → v1.33 → v1.34. Kubernetes only supports single-minor upgrades, and each intermediate Kubernetes minor uses the matching VM template and Core images from its OS Support Matrix row.
-
-Before starting a cross-version upgrade, complete the [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation) so the intermediate Core images and VM templates required for each hop are already staged.
 
 ## Required Values From the OS Support Matrix \{#required-values}
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -75,6 +75,12 @@ Upgrades rely on Cluster API's rolling replacement mechanism. Each cluster has f
 vSphere clusters do not currently expose a Fleet Essentials UI upgrade path. Use the YAML procedure documented below, or the two-step upgrade flow built into the ACP Core platform — see <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
 :::
 
+## Cross-Version Upgrades  \{#cross-version-upgrades}
+
+When the target ACP version is more than one Kubernetes minor above the cluster's current version, upgrade the Kubernetes version one minor at a time — for example, v1.32 → v1.33 → v1.34. Kubernetes only supports single-minor upgrades, and each intermediate Kubernetes minor uses the matching VM template and Core images from its OS Support Matrix row.
+
+Before starting a cross-version upgrade, complete the [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation) so the intermediate Core images and VM templates required for each hop are already staged.
+
 ## Required Values From the OS Support Matrix \{#required-values}
 
 The authoritative mapping between an ACP release, its VM template, the Kubernetes version, the matching CoreDNS, etcd, and Kube-OVN versions lives in [OS Support Matrix](../overview/os-support-matrix.mdx). Locate the row that corresponds to the target ACP version before you start; the row supplies every value the steps below need.


### PR DESCRIPTION
## Summary

Adds a shared **Preparing for Cross-Version Upgrades** section to the immutable infrastructure upgrade overview and references it from every provider page (Huawei DCS, VMware vSphere, Huawei Cloud Stack) and the global cluster upgrade page.

## Why

When the target ACP Distribution Version is more than one Kubernetes minor above the cluster's current version (for example, 4.0 → 4.3 spans 1.31 → 1.34), customers on Immutable Infrastructure must pre-stage two kinds of intermediate-version artifacts before starting Phase 2:

1. **Intermediate Core images in the registry** — each intermediate Kubernetes minor uses the CoreDNS, etcd, and Kube-OVN chart image tags from the matching OS Support Matrix row; without those images staged, the rollout cannot pull the matching control-plane components in an air-gapped environment.
2. **Intermediate OS images available to the node provisioning mechanism** — the Kubernetes step replaces nodes from each intermediate OS image in turn.

The current docs only document the single-minor case (one target OS template uploaded). For cross-version upgrades the pre-staging instructions were missing on every immutable infrastructure page.

Clarification baked into the new section: the ACP Core (Distribution Version) itself still moves directly to the target version through CVO — only the Kubernetes version steps through the intermediate minors. Aligned plugins also move directly to the target version with the Core upgrade; no extra `violet push` is required for the intermediate versions.

## What changed

- `upgrade-cluster/index.mdx` — new `## Preparing for Cross-Version Upgrades` section (anchor `#cross-version-preparation`) with Step 1 (pre-sync intermediate Core images via `upgrade.sh --only-sync-image`, without requesting a Core upgrade) and Step 2 (stage intermediate OS images for the provisioning mechanism). Step 2 uses neutral wording covering both IaaS providers (VM template / VM image) and bare metal (re-provisioning flow).
- `upgrade-cluster/huawei-dcs.mdx` — cross-version prerequisite bullet added; existing `### Cross-Version Upgrades` section's "Why" extended to reference the shared preparation.
- `upgrade-cluster/vmware-vsphere.mdx`, `huawei-cloud-stack.mdx` — new `## Cross-Version Upgrades` section pointing to the shared preparation. HCS uses "VM image", vSphere uses "VM template", matching each page's local convention.
- `global/upgrade.mdx` — cross-version prerequisite bullet added to Common Prerequisites.
- `upgrade-cluster/bare-metal.mdx` left untouched (page is Planned; its upgrade mechanism is not yet documented).

## Where to backport

- `release-1.0` — target files are identical between master and release-1.0, so a clean cherry-pick is expected after this lands.

## Verification

- `yarn lint docs/en/upgrade-cluster` — 0 errors, 0 warnings
- `yarn lint docs/en/global` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guidance for performing Kubernetes upgrades across multiple minor versions with detailed instructions for each platform
  * Included prerequisites and step-by-step preparation procedures required before initiating cross-version upgrades
  * Documented image pre-staging requirements for intermediate Core images and OS templates
  * Updated upgrade procedures to clarify cross-version upgrade workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/alauda/immutable-infra-docs/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->