### PR TITLE
docs(upgrade-cluster): document cross-version pre-staging for immutable OS (release-1.0)

### DIFF
--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -38,6 +38,7 @@ Like workload clusters, the `global` cluster on Immutable Infrastructure follows
 - An etcd backup of the `global` cluster has been taken and verified.
 - The new MicroOS image and the matching `KubeadmControlPlane` and `MachineDeployment` versions are available on the platform's registry.
 - A maintenance window plan that accounts for rolling control plane replacement.
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and OS images are pre-staged. See [Cross-Version Upgrade Preparation](../upgrade-cluster/index.mdx#cross-version-preparation).
 
 ## Procedure
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -70,6 +70,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The control plane is reachable.
 - All nodes are healthy and in `Ready` state.
 - The target VM image is present in the HCS environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the image is not present when the new `HCSMachineTemplate` is applied.
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM images are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - Review the Kubernetes upgrade path and version skew policy.
 - Any node-local state that must survive replacement is declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`, not in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -62,6 +62,7 @@ Before you start, ensure all of the following prerequisites are met:
 - All nodes are healthy and in Ready state
 - The IP Pool has sufficient capacity for rolling updates
 - The VM template supports the target Kubernetes version. See [OS Support Matrix](../overview/os-support-matrix.mdx) for version mapping
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation)
 - The target Kubernetes version is compatible with your workloads and add-ons
 - DCS VM templates are `4.2.1` or later if you use pool-managed persistent disks, because safe shutdown and disk detach depend on guest tools
 - If you rely on pool-managed persistent disks, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0`
@@ -393,17 +394,6 @@ Worker Node Pools cannot be upgraded until the Control Plane Node Pool upgrade c
 | Control Plane not started | ❌ Disabled: "Upgrade the Control Plane Node Pool first" |
 | Control Plane upgrading | ❌ Disabled: "Wait for the Control Plane Node Pool upgrade to complete" |
 | Control Plane upgraded | ✅ Enabled |
-
-### Cross-Version Upgrades
-
-When upgrading across multiple minor versions (for example, v1.32 → v1.34):
-
-1. Upgrade Control Plane to v1.33
-2. Wait for completion
-3. Upgrade Control Plane to v1.34
-4. Repeat for Worker Pools
-
-**Why**: Kubernetes only supports single minor version upgrades.
 
 ### Troubleshooting
 

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -103,6 +103,43 @@ See platform-specific guides:
 
 ---
 
+## Preparing for Cross-Version Upgrades  \{#cross-version-preparation}
+
+When the target ACP Distribution Version is more than one Kubernetes minor above the cluster's current version, additional preparation is required before starting Phase 2. Single-minor upgrades skip this section.
+
+On Immutable Infrastructure, each Kubernetes minor is baked into a matching OS image, and each Kubernetes minor maps to a specific ACP version row in [OS Support Matrix](../overview/os-support-matrix.mdx). The Kubernetes version therefore moves forward one minor at a time, stepping through the OS image of each intermediate ACP row. The ACP Core (Distribution Version) itself is still upgraded directly to the target version through the Cluster Version Operator — only the Kubernetes version steps through the intermediate minors.
+
+Identify every ACP minor between the current and target versions, use the latest patch in each row, and complete the following pre-staging for each intermediate version before starting Phase 2.
+
+### Step 1 — Pre-sync intermediate Core images to the registry
+
+For each intermediate ACP version, download its Core package and synchronize only its images into the registry. Do not request a Core upgrade to the intermediate version.
+
+```bash
+bash upgrade.sh --only-sync-image
+```
+
+See <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#sync-upgrade-artifacts" children="Sync upgrade artifacts" /> for command options.
+
+This places the intermediate-version CoreDNS, etcd, and Kube-OVN chart images in the registry so the staged Kubernetes rollout can pull them when `KubeadmControlPlane` is patched to the matching OS Support Matrix row. In an air-gapped environment, missing intermediate images prevent the new control plane components from starting.
+
+Aligned plugins do not need an extra `violet push` for the intermediate versions; they move directly to the target version with the Core upgrade, and the Kube-OVN chart used by each intermediate Kubernetes hop is already covered by the Core image sync above.
+
+### Step 2 — Stage intermediate OS images for the provisioning mechanism
+
+For each intermediate ACP version, make the matching OS image (the **MicroOS Image Version** value from the OS Support Matrix row) available to the node provisioning mechanism so the Kubernetes step can replace nodes from each image in turn:
+
+- **IaaS providers (Huawei DCS, VMware vSphere, Huawei Cloud Stack)**: upload the OS image and register it as a VM template (or VM image, depending on the platform) under the exact name listed in the OS Support Matrix row.
+- **Bare metal**: make the OS image available to the node re-provisioning flow used by your cluster.
+
+The control plane and worker rollouts then step through the intermediate OS images one at a time, matched to the staged Kubernetes minor, until the cluster reaches the target ACP version row.
+
+### Step 3 — Apply the platform-specific procedure for each intermediate version
+
+Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for `KubeadmControlPlane` and `MachineDeployment` values. For each hop, complete the provider's standard procedure — control plane first, then workers, per the Kubernetes version skew policy — before starting the next. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
+
+---
+
 ## Platform-Specific Instructions
 
 Select your platform for detailed upgrade instructions:

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -44,6 +44,7 @@ Before you begin, ensure the following conditions are met:
 - The control plane is healthy and reachable.
 - All nodes are in the `Ready` state.
 - The target VM template is present in the vSphere environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the template is not present when the new `VSphereMachineTemplate` is applied.
+- For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - The machine config pools have enough capacity for rolling updates.
 - Review the Kubernetes upgrade path and version skew policy.


### PR DESCRIPTION
## Summary

Backport of #99 to `release-1.0`. Clean cherry-pick, no conflicts.

Adds a shared **Preparing for Cross-Version Upgrades** section to the immutable infrastructure upgrade overview (`upgrade-cluster/index.mdx`, anchor `#cross-version-preparation`) and a Prerequisites bullet pointing to it from each provider page (Huawei DCS, VMware vSphere, Huawei Cloud Stack) and the global cluster upgrade page. The shared section covers Step 1 (pre-sync intermediate Core images via `upgrade.sh --only-sync-image`), Step 2 (stage intermediate OS images for the node provisioning mechanism, covering IaaS and bare metal), and Step 3 (apply the platform-specific Phase 2 procedure for each intermediate version, control plane first then workers per Kubernetes version skew policy).

## Verification

- `yarn lint docs/en/upgrade-cluster` — 0 errors, 0 warnings
- `yarn lint docs/en/global` — 0 errors, 0 warnings

## Back-port Notes

No dev dependency bump. Target files were identical between master and release-1.0 before the master merge, so the cherry-pick applied without conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)