### PR TITLE
docs: align customer-facing OS naming to Alauda OS (backport #101 to release-1.0, AIT-70977)

### DIFF
--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -259,7 +259,7 @@ spec:
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `.spec.template.spec.imageName` | string | Yes | HCS image name. Use the image identifier published in the current release's OS support matrix; placeholder shown as `<microos-version>` in the manifest above. The exact name moves with each MicroOS release, so do not hardcode the example value across versions. |
+| `.spec.template.spec.imageName` | string | Yes | HCS image name. Use the image identifier published in the current release's OS support matrix; placeholder shown as `<alaudaos-version>` in the manifest above. The exact name moves with each Alauda OS release, so do not hardcode the example value across versions. |
 | `.spec.template.spec.flavorName` | string | Yes | Provider-recognized HCS API value matched against `Flavor.Name`. Do not use the tenant UI display name |
 | `.spec.template.spec.availabilityZone` | string | No | Provider-recognized HCS API value matched against `ZoneName`. Do not use the tenant UI display name |
 | `.spec.template.spec.rootVolume.type` | string | Yes | Volume type (`SSD` or `SATA`) |
@@ -425,7 +425,7 @@ The HCS controller also injects files while resolving cloud-init data. It writes
 
 **Note:** HCS also supports creating a single-control-plane cluster by setting `spec.replicas: 1` and preparing one control plane config entry in the referenced `HCSMachineConfigPool`. Treat this as a creation-only topology, and leave the rollout strategy unset in that create manifest. The upgrade flow in this documentation does not support single-control-plane HCS clusters.
 
-Use the [OS Support Matrix](../overview/os-support-matrix.mdx) only for the component versions it explicitly lists, such as coredns and etcd image tags for supported MicroOS images. It is not a complete source for all HCS manifest values. Before you apply this YAML, also use the approved release baseline for values such as `imageRepository`, DNS image repository, Kube-OVN version, Kube-OVN join CIDR, Pod CIDR, and Service CIDR.
+Use the [OS Support Matrix](../overview/os-support-matrix.mdx) only for the component versions it explicitly lists, such as coredns and etcd image tags for supported Alauda OS images. It is not a complete source for all HCS manifest values. Before you apply this YAML, also use the approved release baseline for values such as `imageRepository`, DNS image repository, Kube-OVN version, Kube-OVN join CIDR, Pod CIDR, and Service CIDR.
 
 ### Configure HCSCluster
 

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -43,7 +43,7 @@ For detailed installation instructions, refer to the [Installation Guide](../ins
 ### 3. Virtual Machine Template Preparation
 
 For Kubernetes installation, you must:
-- Upload the MicroOS image to the DCS platform
+- Upload the Alauda OS image to the DCS platform
 - Create a virtual machine template based on this image
 - Ensure the template includes all necessary Kubernetes components
 - Use DCS VM templates `4.2.1` or later if you plan to use persistent disks, because safe shutdown and disk detach depend on guest tools
@@ -131,7 +131,7 @@ Step 5: Review
 **Prerequisites Check**:
 
 Before creating a cluster, ensure:
-- DCS VM Templates exist in the DCS platform, and the MicroOS version matches the Kubernetes version
+- DCS VM Templates exist in the DCS platform, and the Alauda OS version matches the Kubernetes version
 - A LoadBalancer for the Kubernetes API Server has been set up
 
 **Version Constraint**: Only the latest Kubernetes version supported by the platform can be created.

--- a/docs/en/create-cluster/index.mdx
+++ b/docs/en/create-cluster/index.mdx
@@ -20,7 +20,7 @@ This section provides instructions for creating Kubernetes clusters on different
 Before creating a cluster, configure the required infrastructure resources:
 
 - **[Infrastructure Resources](../infrastructure/)** - Configure cloud credentials, IP pools, and machine templates
-- **CPU Baseline** - For x86_64 cluster nodes that use ACP-provided MicroOS images, the underlying CPUs must support the `x86-64-v2` ISA baseline. For details, see [OS Support Matrix](../overview/os-support-matrix.mdx).
+- **CPU Baseline** - For x86_64 cluster nodes that use ACP-provided Alauda OS images, the underlying CPUs must support the `x86-64-v2` ISA baseline. For details, see [OS Support Matrix](../overview/os-support-matrix.mdx).
 
 ## Platform-Specific Instructions
 

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -138,7 +138,7 @@ Use the following table to record the required values and validation results.
 
 | Parameter | Placeholder | Required | Validation or Notes | Example | Actual Value |
 |-----------|-------------|----------|---------------------|---------|--------------|
-| VM template name | `<template_name>` | Yes | Used to clone control plane and worker nodes. | `microos-k8s-template` | - |
+| VM template name | `<template_name>` | Yes | Used to clone control plane and worker nodes. | `alaudaos-k8s-template` | - |
 | vCenter credential secret name | `<credentials_secret_name>` | Yes | Use a stable name such as `<cluster_name>-vsphere-credentials`. | `demo-cluster-vsphere-credentials` | - |
 | Clone mode | `<clone_mode>` | Yes | Allowed values: `linkedClone`, `fullClone`. Default is `linkedClone`. `linkedClone` requires the VM template to have at least one snapshot; if none exists, CAPV falls back to `fullClone`. When `linkedClone` is used, `diskGiB` is ignored; the system disk stays at the template's size. Choose `fullClone` if you need `diskGiB` to take effect. | `linkedClone` | - |
 | Power-off mode | `<power_off_mode>` | Yes | Allowed values: `hard`, `soft`, `trySoft`. Default is `hard`. `soft` and `trySoft` require VMware Tools / `open-vm-tools` in the template for graceful shutdown; `trySoft` falls back to `hard` after the guest-soft-power-off timeout. | `trySoft` | - |

--- a/docs/en/global/disaster_recovery.mdx
+++ b/docs/en/global/disaster_recovery.mdx
@@ -4,7 +4,7 @@ title: Global Cluster Disaster Recovery
 queries:
   - global cluster disaster recovery on immutable infrastructure
   - immutable infra etcd sync
-  - microos global dr
+  - alauda os global dr
   - vmware vsphere global cluster disaster recovery
   - immutable os disaster recovery
 ---

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -3,7 +3,7 @@ weight: 20
 title: Installing the global Cluster
 queries:
   - install global cluster on immutable infrastructure
-  - microos global cluster installation
+  - alauda os global cluster installation
   - install platform on huawei dcs huawei cloud stack
   - install global cluster on vmware vsphere immutable infrastructure
   - immutable os global install
@@ -12,13 +12,13 @@ queries:
 
 # Installing the global Cluster
 
-This document describes how to install the `global` cluster onto Immutable Infrastructure. The `global` cluster is the platform control plane and is provisioned through Cluster API. Use this path when the platform control plane must run on an immutable operating system such as MicroOS.
+This document describes how to install the `global` cluster onto Immutable Infrastructure. The `global` cluster is the platform control plane and is provisioned through Cluster API. Use this path when the platform control plane must run on an immutable operating system such as Alauda OS.
 
 ## When to Use This Path
 
 Choose this installation path when all of the following conditions apply:
 
-- You want the `global` cluster to run on an immutable operating system. MicroOS is the supported image today.
+- You want the `global` cluster to run on an immutable operating system. Alauda OS is the supported image today.
 - Your infrastructure is one of the documented providers: Huawei DCS, VMware vSphere, or Huawei Cloud Stack. Bare-metal support for the `global` cluster is planned.
 - You can run a temporary KIND host that has network access to the target IaaS platform.
 
@@ -36,7 +36,7 @@ The following prerequisites apply to every provider:
 - IP and hostname planning for the `global` control plane and worker nodes. See [Infrastructure Resources](../infrastructure/index.mdx) for the resource model used by each provider.
 - A stable Kubernetes API endpoint for the `global` cluster, such as a VIP or load balancer address.
 - A platform access address, registry address, and Pod and Service CIDR ranges.
-- For x86_64 nodes that use ACP-provided MicroOS images, the underlying CPUs must support the `x86-64-v2` ISA baseline. See [OS Support Matrix](../overview/os-support-matrix.mdx).
+- For x86_64 nodes that use ACP-provided Alauda OS images, the underlying CPUs must support the `x86-64-v2` ISA baseline. See [OS Support Matrix](../overview/os-support-matrix.mdx).
 
 <Directive type="warning" title="Naming Convention (Required)">
   This rule applies to **every** infrastructure provider supported by this install path — Huawei DCS, Huawei Cloud Stack, VMware vSphere, and any provider added in the future. Every manifest you author in Step 4 must follow it. Misnaming these resources has two distinct failure modes, both detailed below; one breaks initial provisioning, the other only surfaces during disaster recovery.
@@ -55,8 +55,8 @@ Before installation, record the supported version set for the delivery package:
 | Core Package version | Provides the installer, local registry, and base platform payload. |
 | Kubeadm provider chart version | Must match the Cluster API control plane resources used by the global manifest. |
 | Infrastructure provider chart version | Use the VMware vSphere, DCS, or HCS provider chart version delivered with the target release. |
-| MicroOS image or VM template | Must contain the Kubernetes version used by `K8S_VERSION`. |
-| `K8S_VERSION` | Use v-prefixed semver that matches the target MicroOS image, such as `v<major>.<minor>.<patch>`. |
+| Alauda OS image or VM template | Must contain the Kubernetes version used by `K8S_VERSION`. |
+| `K8S_VERSION` | Use v-prefixed semver that matches the target Alauda OS image, such as `v<major>.<minor>.<patch>`. |
 
 ## Procedure
 
@@ -77,7 +77,7 @@ export SERVICE_CIDR="100.4.0.0/16"
 export K8S_VERSION="<target-kubernetes-version>"
 export INGRESS_CLASS_NAME="global-alb2"
 export HCS_SECRET_NAME="global-secret"
-# Use v-prefixed semver that matches the target MicroOS image.
+# Use v-prefixed semver that matches the target Alauda OS image.
 ```
 
 Use `LOCAL_REGISTRY_ADDRESS` when pushing packages from the KIND host. Use `BOOTSTRAP_REGISTRY_ADDRESS` in AppRelease chart repository values because provider Pods read the chart repository from inside the bootstrap KIND network. Use `NODE_REGISTRY_ADDRESS` in Cluster API registry annotations because provisioned `global` nodes must pull images through an address reachable from their subnet.
@@ -563,7 +563,7 @@ Use the DCS resource fields from [Creating Clusters on Huawei DCS](../create-clu
 - Set `Cluster.metadata.name` and `DCSCluster.metadata.name` to `global` (the infra cluster shares the CAPI `Cluster` name). Prefix every other CAPI resource and provider resource with `global-`; the wiring fragment below uses `KubeadmControlPlane.metadata.name: global-kcp`.
 - Add `Cluster.metadata.labels.is-global: "true"` and `Cluster.metadata.labels.cluster-type: DCS`.
 - Add `Cluster.metadata.annotations["cpaas.io/registry-address"]` with `${NODE_REGISTRY_ADDRESS}`.
-- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for MicroOS.
+- Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for Alauda OS.
 - Keep the release manifest's non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries.
 - For a normal non-DR deployment, do not set `DCSCluster.spec.encryptionProviderConfigRef` and do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
 - Keep `/var/cpaas` as platform state. If you need the disk to survive rolling replacement, declare it in `DCSIpHostnamePool.spec.pool[].persistentDisk`; do not rely on `DCSMachineTemplate` template disks as preserved state.
@@ -1174,7 +1174,7 @@ After the installer accepts the request, the install runs through several phases
 | Phase | What is happening | First place to watch |
 |---|---|---|
 | Bootstrap | The bootstrap KIND, embedded registry, and Cluster API providers are running on the KIND host. Completed in Step 2 and Step 3. | KIND host terminal; `kubectl get pods -n cpaas-system` |
-| Infrastructure provisioning | The Cluster API provider creates VMs from the MicroOS template on the target IaaS platform. | `kubectl get machines -n cpaas-system` |
+| Infrastructure provisioning | The Cluster API provider creates VMs from the Alauda OS template on the target IaaS platform. | `kubectl get machines -n cpaas-system` |
 | Control plane bootstrap | `KubeadmControlPlane` bootstraps the first control plane node, etcd starts, and additional control plane nodes join. | `kubectl get kubeadmcontrolplane -n cpaas-system` |
 | Network and core add-ons | The CAPI provider reconciles Kube-OVN, CoreDNS, and kube-proxy on the new cluster. | `kubectl --kubeconfig <global-kubeconfig> get pods -n kube-system` |
 | Platform installation | The installer imports Cluster API resources into the new `global` cluster, deploys the base operator, and installs the selected plugins. | Installer progress API; installer log |

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -3,14 +3,14 @@ weight: 30
 title: Upgrading the global Cluster
 queries:
   - upgrade global cluster on immutable infrastructure
-  - microos global cluster upgrade
+  - alauda os global cluster upgrade
   - upgrade platform on huawei dcs huawei cloud stack
   - immutable os global upgrade
 ---
 
 # Upgrading the global Cluster
 
-This document describes how to upgrade a `global` cluster that runs on Immutable Infrastructure. Upgrades replace nodes with new MicroOS images managed by the Cluster API provider; in-place node upgrades are not used.
+This document describes how to upgrade a `global` cluster that runs on Immutable Infrastructure. Upgrades replace nodes with new Alauda OS images managed by the Cluster API provider; in-place node upgrades are not used.
 
 ## When to Use This Path
 
@@ -26,7 +26,7 @@ For traditional-OS `global` clusters, use <ExternalSiteLink name="acp" href="/up
 Like workload clusters, the `global` cluster on Immutable Infrastructure follows a two-phase upgrade.
 
 1. **Phase 1 — Distribution Version**: aligned and agnostic extensions are upgraded to the target Distribution Version. The procedure is shared with workload clusters; see [Upgrading Clusters](../upgrade-cluster/index.mdx) for the Phase 1 mechanics.
-2. **Phase 2 — Kubernetes and OS Image**: nodes are replaced with new MicroOS images that contain the target Kubernetes version. This document focuses on Phase 2 for the `global` cluster.
+2. **Phase 2 — Kubernetes and OS Image**: nodes are replaced with new Alauda OS images that contain the target Kubernetes version. This document focuses on Phase 2 for the `global` cluster.
 
 <Directive type="info" title="Phase 1 Compatibility">
   Before starting Phase 2, verify that every workload cluster falls within the Compatible Versions matrix of the target Distribution Version. Workload clusters that are out of range must be upgraded first.
@@ -36,7 +36,7 @@ Like workload clusters, the `global` cluster on Immutable Infrastructure follows
 
 - The `global` cluster has completed Phase 1 (Distribution Version upgrade).
 - An etcd backup of the `global` cluster has been taken and verified.
-- The new MicroOS image and the matching `KubeadmControlPlane` and `MachineDeployment` versions are available on the platform's registry.
+- The new Alauda OS image and the matching `KubeadmControlPlane` and `MachineDeployment` versions are available on the platform's registry.
 - A maintenance window plan that accounts for rolling control plane replacement.
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and OS images are pre-staged. See [Cross-Version Upgrade Preparation](../upgrade-cluster/index.mdx#cross-version-preparation).
 
@@ -46,7 +46,7 @@ After installation, the Cluster API controllers that manage the `global` cluster
 
 ### Step 1 — Update the global Cluster Manifest
 
-Update the Cluster API manifests of the `global` cluster to reference the new MicroOS image and Kubernetes version. The manifest fields to update are provider-specific.
+Update the Cluster API manifests of the `global` cluster to reference the new Alauda OS image and Kubernetes version. The manifest fields to update are provider-specific.
 
 <Tabs>
   <Tab label="Huawei DCS">
@@ -55,7 +55,7 @@ For DCS, create new immutable infrastructure templates instead of editing templa
 
 Update the control plane resources:
 
-- Create a new `DCSMachineTemplate` for the target image and set `spec.template.spec.vmTemplateName` to the MicroOS template that matches the target Kubernetes version.
+- Create a new `DCSMachineTemplate` for the target image and set `spec.template.spec.vmTemplateName` to the Alauda OS template that matches the target Kubernetes version.
 - Keep preserved node-local data, including `/var/cpaas`, in `DCSIpHostnamePool.spec.pool[].persistentDisk`. Do not move preserved disks back into `DCSMachineTemplate`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `DCSMachineTemplate`.
@@ -106,7 +106,7 @@ For HCS, create new immutable infrastructure templates instead of editing templa
 
 Update the control plane resources:
 
-- Create a new `HCSMachineTemplate` for the target image and set `spec.template.spec.imageName` to the MicroOS image that matches the target Kubernetes version.
+- Create a new `HCSMachineTemplate` for the target image and set `spec.template.spec.imageName` to the Alauda OS image that matches the target Kubernetes version.
 - Keep preserved node-local data, including `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. Do not move preserved disks back into `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 - Leave runtime identity fields unset in the new template, including `spec.template.spec.providerID` and `spec.template.spec.serverId`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.

--- a/docs/en/how-to/migrate-hcs-node-fqdn-hostname.mdx
+++ b/docs/en/how-to/migrate-hcs-node-fqdn-hostname.mdx
@@ -30,7 +30,7 @@ Two conditions must both be true for a node to expose the supported hostname / F
 
 Existing nodes booted under the older controller continue to use the cloud-init user-data they received on first boot, so editing manifests or re-applying user-data does not retroactively change their hostname behavior. The supported migration path is to replace those nodes through Cluster API rolling replacement, with the upgraded controller already installed and Ready on the management cluster.
 
-Manual on-node edits to `/etc/hostname` and `/etc/hosts` do not persist on MicroOS / SLE Micro. Cloud-init re-renders these files on every boot, including reboots triggered by `transactional-update`, OS patching, or `systemctl reboot`.
+Manual on-node edits to `/etc/hostname` and `/etc/hosts` do not persist on an immutable-OS node. Cloud-init re-renders these files on every boot, including reboots triggered by `transactional-update`, OS patching, or `systemctl reboot`.
 
 ## Prerequisites
 

--- a/docs/en/how-to/troubleshoot-workload-cluster-huawei-cloud-stack.mdx
+++ b/docs/en/how-to/troubleshoot-workload-cluster-huawei-cloud-stack.mdx
@@ -53,7 +53,7 @@ Indicators that you are hitting this pattern:
 
 Upgrade the `cluster-api-provider-hcs` plugin to v1.0.1 or later, then trigger a rolling replacement of the affected control plane and worker machines so the new cloud-init runs on freshly booted VMs. The step-by-step procedure is documented in [Configure FQDN Hostname on Existing HCS Clusters](./migrate-hcs-node-fqdn-hostname.mdx).
 
-Manual edits to `/etc/hostname` and `/etc/hosts` on an existing MicroOS / SLE Micro node do not persist: cloud-init re-renders these files on every boot, including reboots triggered by `transactional-update`, OS patching, or `systemctl reboot`. Rolling replacement is the supported migration path.
+Manual edits to `/etc/hostname` and `/etc/hosts` on an existing immutable-OS node do not persist: cloud-init re-renders these files on every boot, including reboots triggered by `transactional-update`, OS patching, or `systemctl reboot`. Rolling replacement is the supported migration path.
 
 ### Prevent
 

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -37,7 +37,7 @@ Prepare the following inputs before you create or edit any cluster manifests:
 | `externalGlobalDomain` | HCS credential `Secret` | HCS platform access domain | Yes | Use the HCS platform domain that the provider should call |
 | `schema` | HCS credential `Secret` | HCS administrator | No | Optional API scheme for the HCS IAM endpoint. If omitted, the provider uses `https` |
 | `region` | HCS credential `Secret` | HCS administrator | Yes | Tenant administrators cannot retrieve this value from the HCS UI |
-| `imageName` | `HCSMachineTemplate` | HCS image inventory | Yes | Use the validated HCS image name for the selected MicroOS image |
+| `imageName` | `HCSMachineTemplate` | HCS image inventory | Yes | Use the validated HCS image name for the selected Alauda OS image |
 | `flavorName` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `Flavor.Name`, not the tenant UI display name |
 | `availabilityZone` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `ZoneName`, not the tenant UI display name |
 | Root, temporary data volume, and persistent disk layout | `HCSMachineTemplate`, `HCSMachineConfigPool` | Cluster storage plan | Yes | Plan disk sizes and mount points before you write the template and pool. Put disks that can be recreated with the VM in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`. Put disks that must survive VM replacement, such as `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` |
@@ -72,7 +72,7 @@ Prepare the VM image, flavor, availability zone, temporary data volume layout, a
 
 | Input | Guidance |
 |-------|----------|
-| `imageName` | Use the validated HCS image name for the MicroOS image you want to deploy |
+| `imageName` | Use the validated HCS image name for the Alauda OS image you want to deploy |
 | `flavorName` | Use the provider-recognized HCS API value matched against `Flavor.Name`. Do not use the tenant UI display name |
 | `availabilityZone` | Use the provider-recognized HCS API value matched against `ZoneName`. Do not use the tenant UI display name |
 | Root and temporary data volumes | Plan system and temporary data disks in advance. Control plane templates typically use temporary data volumes for `/var/lib/etcd`, `/var/lib/kubelet`, and `/var/lib/containerd`. Worker templates typically use temporary data volumes for `/var/lib/kubelet` and `/var/lib/containerd`. |
@@ -82,7 +82,7 @@ Prepare the VM image, flavor, availability zone, temporary data volume layout, a
 
 ## Version and Component Baseline
 
-Use the [OS Support Matrix](../overview/os-support-matrix.mdx) only for the component versions it explicitly lists, such as Kubernetes, coredns, etcd, and pause versions for supported MicroOS images.
+Use the [OS Support Matrix](../overview/os-support-matrix.mdx) only for the component versions it explicitly lists, such as Kubernetes, coredns, etcd, and pause versions for supported Alauda OS images.
 
 The OS Support Matrix is not a complete source for all HCS manifest values. Before writing YAML, also get the approved release baseline for values such as the container image repository, DNS image repository, Kube-OVN version, Kube-OVN join CIDR, Pod CIDR, and Service CIDR. If your release does not publish a complete baseline source yet, use values validated for your environment by the platform or release owner.
 

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -487,12 +487,12 @@ Machine templates define the virtual machine specifications (VM template, CPU, m
 #### Prerequisites
 
 - IP Pool has been created
-- VM Template has been created in the DCS platform using MicroOS image
+- VM Template has been created in the DCS platform using Alauda OS image
 - ConfigMap YAML has been applied to the global cluster
 
 **VM Template and ConfigMap**:
 
-Each MicroOS release includes a ConfigMap YAML that maps VM templates to Kubernetes versions. Apply this YAML before creating machine templates:
+Each Alauda OS release includes a ConfigMap YAML that maps VM templates to Kubernetes versions. Apply this YAML before creating machine templates:
 
 ```yaml
 apiVersion: v1
@@ -500,11 +500,11 @@ data:
   corednsTag: 1.12.4-v4.2.3
   etcdTag: v3.5.21-251117
   kubernetesVersion: v1.33.6
-  vmImageVersion: MicroOS-5.5-v4.2.0
+  vmImageVersion: alaudaos-42.m55.202512081125-0.x86_64
 kind: ConfigMap
 metadata:
   labels:
-    cpaas.io/dcs-vm-template: microos5.5-4.2.0
+    cpaas.io/dcs-vm-template: <vm-template-name>
     cpaas.io/distribution-version: v4.2.0
     cpaas.io/kubernetes-version: v1.33
   name: 420-dcs-vm-template

--- a/docs/en/overview/os-support-matrix.mdx
+++ b/docs/en/overview/os-support-matrix.mdx
@@ -5,32 +5,45 @@ title: OS Support Matrix
 
 # OS Support Matrix
 
-This document lists the versions of Kubernetes components included in different MicroOS images.
+This document lists the versions of Kubernetes components included in different Alauda OS images.
 
 ## CPU Baseline
 
-ACP-provided MicroOS images on x86_64 require CPUs that meet the `x86-64-v2` ISA baseline. x86_64 hardware that does not support `x86-64-v2` is outside the supported baseline for these images.
+ACP-provided Alauda OS images on x86_64 require CPUs that meet the `x86-64-v2` ISA baseline. x86_64 hardware that does not support `x86-64-v2` is outside the supported baseline for these images.
 
-This requirement applies when you create or upgrade cluster nodes with ACP-provided MicroOS images.
+This requirement applies when you create or upgrade cluster nodes with ACP-provided Alauda OS images.
 
 ## Version Mapping
 
-| ACP Version | MicroOS Image Version | Kubernetes Version | containerd | coredns | etcd | pause | kube-ovn (chart) |
+| ACP Version | Alauda OS Image Version | Kubernetes Version | containerd | coredns | etcd | pause | kube-ovn (chart) |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| v4.0.9 | **MicroOS-5.5-v4.0.9** | v1.31.14-2 | 1.7.23-4 | 1.12.4-v4.0.20 | v3.5.25-251215 | 3.10 | v4.0.39 |
-| v4.1.0 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.4 |
-| v4.1.1 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.5 |
-| v4.1.2 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.9 |
-| v4.1.3 | **MicroOS-5.5-v4.1.0** | v1.32.7 | 1.7.27-4 | 1.12.4-v4.1.2 | v3.5.21 | 3.10 | v4.1.11 |
-| v4.1.5 | **MicroOS-5.5-v4.1.5** | v1.32.11-2 | 1.7.27-4 | 1.12.4-v4.1.5 | v3.5.25-251215 | 3.10 | v4.1.25 |
-| v4.2.0 | **MicroOS-5.5-v4.2.0** | v1.33.6 | 1.7.27-4 | 1.12.4-v4.2.3 | v3.5.21-251117 | 3.10 | v4.2.6 |
-| v4.2.1 | **MicroOS-5.5-v4.2.1** | v1.33.7-1 | 1.7.29-4 | 1.12.4-v4.2.4 | v3.5.25-251215 | 3.10 | v4.2.15 |
-| v4.2.2 | **MicroOS-5.5-v4.2.2** | v1.33.7-2 | 1.7.29-4 | 1.12.4-v4.2.7 | v3.5.25-251215 | 3.10 | v4.2.24 |
-| v4.2.3,v4.2.4 | **MicroOS-5.5-v4.2.3** | v1.33.7-3 | 1.7.29-4 | 1.12.4-v4.2.8 | v3.5.27-260305 | 3.10 | v4.2.26 |
-| v4.3.0 | **MicroOS-5.5-v4.3.0** | v1.34.5 | 2.2.1-5 | 1.14.2-v4.3.4 | v3.5.28-260325 | 3.10 | v4.3.3 |
+| v4.0.9 | **alaudaos-40.m55.202602090414-0.x86_64** | v1.31.14-2 | 1.7.23-4 | 1.12.4-v4.0.20 | v3.5.25-251215 | 3.10 | v4.0.39 |
+| v4.1.0 | **alaudaos-41.m55.202509250202-0.x86_64** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.4 |
+| v4.1.1 | **alaudaos-41.m55.202509250202-0.x86_64** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.5 |
+| v4.1.2 | **alaudaos-41.m55.202509250202-0.x86_64** | v1.32.7 | 1.7.27-4 | 1.11.3-v4.1.0 | v3.5.21 | 3.10 | v4.1.9 |
+| v4.1.3 | **alaudaos-41.m55.202509250202-0.x86_64** | v1.32.7 | 1.7.27-4 | 1.12.4-v4.1.2 | v3.5.21 | 3.10 | v4.1.11 |
+| v4.1.5 | **alaudaos-41.m55.202602090413-0.x86_64** | v1.32.11-2 | 1.7.27-4 | 1.12.4-v4.1.5 | v3.5.25-251215 | 3.10 | v4.1.25 |
+| v4.2.0 | **alaudaos-42.m55.202512081125-0.x86_64** | v1.33.6 | 1.7.27-4 | 1.12.4-v4.2.3 | v3.5.21-251117 | 3.10 | v4.2.6 |
+| v4.2.1 | **alaudaos-42.m55.202512180913-0.x86_64** | v1.33.7-1 | 1.7.29-4 | 1.12.4-v4.2.4 | v3.5.25-251215 | 3.10 | v4.2.15 |
+| v4.2.2 | **alaudaos-42.m55.202602110741-0.x86_64** | v1.33.7-2 | 1.7.29-4 | 1.12.4-v4.2.7 | v3.5.25-251215 | 3.10 | v4.2.24 |
+| v4.2.3,v4.2.4 | **alaudaos-42.m55.202603160804-0.x86_64** | v1.33.7-3 | 1.7.29-4 | 1.12.4-v4.2.8 | v3.5.27-260305 | 3.10 | v4.2.26 |
+| v4.3.0 | **alaudaos-43.m55.202604161208-0.x86_64** | v1.34.5 | 2.2.1-5 | 1.14.2-v4.3.4 | v3.5.28-260325 | 3.10 | v4.3.3 |
 
 :::info
 The **kube-ovn (chart)** column is the `acp/chart-cpaas-kube-ovn` Helm chart version, which tracks the ACP release line (for example, ACP v4.2.2 ships chart `v4.2.24`). It is **not** the Kube-OVN component (binary) version such as `v1.14.x` or `v1.15.x`.
 
 Use this chart version — not the component version — when you set the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource and when you patch the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision`. See the provider-specific upgrade guides for the procedure.
 :::
+
+## Image Format by Provider
+
+A single Alauda OS image build (one row in the matrix above) is delivered in different file formats. Choose the format that matches your infrastructure provider when you download the image and upload it to the target platform:
+
+| Provider | Image format |
+| :--- | :--- |
+| Huawei DCS | `qcow2` |
+| Huawei Cloud Stack (HCS) | `qcow2` |
+| VMware vSphere | `vmdk` |
+| Bare metal | `iso` |
+
+The format does not change the OS content — it only changes the packaging for the target platform. The version identifier in the matrix above is format-independent; append the provider's format when you reference the downloaded file.

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -87,7 +87,7 @@ See [Creating Clusters on Huawei DCS](../../create-cluster/huawei-dcs.mdx) for Y
 
 ## Supported Kubernetes Versions
 
-The DCS Provider supports Kubernetes versions as defined in the [OS Support Matrix](../../overview/os-support-matrix.mdx). Each MicroOS release includes a specific Kubernetes version, and VM templates must be created using the corresponding MicroOS images.
+The DCS Provider supports Kubernetes versions as defined in the [OS Support Matrix](../../overview/os-support-matrix.mdx). Each Alauda OS release includes a specific Kubernetes version, and VM templates must be created using the corresponding Alauda OS images.
 
 ## Architecture
 
@@ -281,7 +281,7 @@ The following tables map the most commonly used custom resource fields to the DC
   - `Domain user` (LDAP/AD-backed; requires DCS domain authentication configured by your DCS administrator).
 
   See [Credential User Types](../../infrastructure/huawei-dcs.mdx#user-types) for selection criteria and DCS-side requirements.
-- Virtual machine templates with MicroOS images
+- Virtual machine templates with Alauda OS images
 - DCS VM templates `4.2.1` or later when you use pool-managed persistent disks, because safe shutdown and disk detach depend on guest tools
 - Shared storage with cross-host access capability
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -69,7 +69,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The Distribution Version upgrade is complete.
 - The control plane is reachable.
 - All nodes are healthy and in `Ready` state.
-- The target VM image is present in the HCS environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the image is not present when the new `HCSMachineTemplate` is applied.
+- The target VM image is present in the HCS environment under the same name as the **Alauda OS Image Version** value in the OS Support Matrix row. The upgrade fails if the image is not present when the new `HCSMachineTemplate` is applied.
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM images are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - Review the Kubernetes upgrade path and version skew policy.
@@ -176,13 +176,13 @@ Upgrading the Kubernetes version involves updating both the control plane softwa
 
 #### Required Values From the OS Support Matrix \{#required-values}
 
-The authoritative mapping between an ACP release, its MicroOS image, the Kubernetes version, the matching CoreDNS, etcd, and Kube-OVN versions lives in [OS Support Matrix](../overview/os-support-matrix.mdx). Locate the row that corresponds to the target ACP version before you start; the row supplies every value the procedure below needs.
+The authoritative mapping between an ACP release, its Alauda OS image, the Kubernetes version, the matching CoreDNS, etcd, and Kube-OVN versions lives in [OS Support Matrix](../overview/os-support-matrix.mdx). Locate the row that corresponds to the target ACP version before you start; the row supplies every value the procedure below needs.
 
 The cells you read from that row map to the upgrade manifests as follows:
 
 | OS Support Matrix column | Used to set | Where it lands |
 |---|---|---|
-| **MicroOS Image Version** | `HCSMachineTemplate.spec.template.spec.imageName` | Control plane and worker `HCSMachineTemplate` |
+| **Alauda OS Image Version** | `HCSMachineTemplate.spec.template.spec.imageName` | Control plane and worker `HCSMachineTemplate` |
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
@@ -202,7 +202,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 
    In `new-cp-template.yaml`:
    - Set `metadata.name` to `<new-template-name>`.
-   - Set `spec.template.spec.imageName` to the **MicroOS Image Version** value from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx).
+   - Set `spec.template.spec.imageName` to the **Alauda OS Image Version** value from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx).
    - Strip server-generated metadata (`resourceVersion`, `uid`, `generation`, `creationTimestamp`, `managedFields`, `kubectl.kubernetes.io/last-applied-configuration` annotation) and the entire `status` field.
    - Leave runtime identity fields unset, including `spec.template.spec.providerID` and `spec.template.spec.serverId`. The HCS provider sets `providerID` to `hcs://<cluster-name>/<machine-name>` and `serverId` to the HCS ECS instance ID after the VM is created; pre-filling them in the template breaks the controller's identity binding.
 
@@ -212,7 +212,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 
 2. **Patch the `KubeadmControlPlane` with the target Kubernetes values**
 
-   Update the `KubeadmControlPlane` resource in a single edit to keep `spec.version`, the CoreDNS image tag, the etcd image tag, and the infrastructure template reference consistent with the same MicroOS release:
+   Update the `KubeadmControlPlane` resource in a single edit to keep `spec.version`, the CoreDNS image tag, the etcd image tag, and the infrastructure template reference consistent with the same Alauda OS release:
 
    - `spec.version` ← **Kubernetes Version** from the OS Support Matrix row
    - `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` ← **coredns** column from the same row
@@ -223,7 +223,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
      kubectl edit kubeadmcontrolplane <kcp-name> -n cpaas-system
      ```
 
-   Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same MicroOS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
+   Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same Alauda OS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
 
    Keep `spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the referenced control plane pool uses persistent disks. The replacement machine must reuse the same fixed hostname and disk slot after the old machine is removed.
 

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -23,7 +23,7 @@ This page covers only the Kubernetes step of the upgrade. The full ACP upgrade f
 - <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="Upgrade the global cluster (Core, Aligned, Agnostic)" />
 - <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html" children="Upgrade workload clusters (Core, Aligned, Agnostic)" />
 
-Use this page when the same cluster runs on an immutable operating system, because the Kubernetes step on immutable OS replaces nodes from a new MicroOS-based VM template rather than upgrading binaries in place.
+Use this page when the same cluster runs on an immutable operating system, because the Kubernetes step on immutable OS replaces nodes from a new Alauda OS-based VM template rather than upgrading binaries in place.
 :::
 
 :::info
@@ -100,13 +100,13 @@ YAML-based upgrades do not depend on Fleet Essentials.
 
 ### Required Values From the OS Support Matrix \{#required-values}
 
-The authoritative mapping between an ACP release, its MicroOS image, the Kubernetes version, the matching CoreDNS, etcd, and Kube-OVN versions lives in [OS Support Matrix](../overview/os-support-matrix.mdx). Locate the row that corresponds to the target ACP version before you start; the row supplies every value the YAML steps below need.
+The authoritative mapping between an ACP release, its Alauda OS image, the Kubernetes version, the matching CoreDNS, etcd, and Kube-OVN versions lives in [OS Support Matrix](../overview/os-support-matrix.mdx). Locate the row that corresponds to the target ACP version before you start; the row supplies every value the YAML steps below need.
 
 The cells you read from that row map to the upgrade manifests as follows:
 
 | OS Support Matrix column | Used to set | Where it lands |
 |---|---|---|
-| **MicroOS Image Version** | `DCSMachineTemplate.spec.template.spec.vmTemplateName` (new VM template the cloned nodes are built from) | Control plane and worker `DCSMachineTemplate` |
+| **Alauda OS Image Version** | `DCSMachineTemplate.spec.template.spec.vmTemplateName` (new VM template the cloned nodes are built from) | Control plane and worker `DCSMachineTemplate` |
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
@@ -114,7 +114,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the DCS provider watches it independently of the Kubernetes control plane rollout.
 
-Confirm with the cluster's platform owner that the target MicroOS image has already been uploaded to the DCS platform under the same name as the **MicroOS Image Version** value in the matrix row. The upgrade fails if that VM template is not present on DCS when the `DCSMachineTemplate` is applied.
+Confirm with the cluster's platform owner that the target Alauda OS image has already been uploaded to the DCS platform under the same name as the **Alauda OS Image Version** value in the matrix row. The upgrade fails if that VM template is not present on DCS when the `DCSMachineTemplate` is applied.
 
 ### Upgrade Control Plane Infrastructure
 
@@ -166,7 +166,7 @@ Upgrading the control plane machine template lets you roll out updated VM specif
 
 ### Upgrade Control Plane Kubernetes Version
 
-Upgrading the control plane Kubernetes version on immutable OS is a delete-recreate workflow. The control plane VMs are replaced one by one from a new `DCSMachineTemplate` that points at the target MicroOS VM template, and the `KubeadmControlPlane` resource is patched to carry the matching Kubernetes version, CoreDNS image tag, and etcd image tag.
+Upgrading the control plane Kubernetes version on immutable OS is a delete-recreate workflow. The control plane VMs are replaced one by one from a new `DCSMachineTemplate` that points at the target Alauda OS VM template, and the `KubeadmControlPlane` resource is patched to carry the matching Kubernetes version, CoreDNS image tag, and etcd image tag.
 
 Before you start, collect every required value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
 
@@ -174,7 +174,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
 1. **Create a new `DCSMachineTemplate` for the target Kubernetes version**
 
-   Copy the existing control-plane template and update `metadata.name` to a new name and `spec.template.spec.vmTemplateName` to the **MicroOS Image Version** value read from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx). Keep pool-managed persistent disks in `DCSIpHostnamePool.spec.pool[].persistentDisk` rather than reintroducing them as template disks.
+   Copy the existing control-plane template and update `metadata.name` to a new name and `spec.template.spec.vmTemplateName` to the **Alauda OS Image Version** value read from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx). Keep pool-managed persistent disks in `DCSIpHostnamePool.spec.pool[].persistentDisk` rather than reintroducing them as template disks.
 
    ```bash
    kubectl get dcsmachinetemplate <current-cp-template-name> -n cpaas-system -o yaml > new-cp-template.yaml
@@ -184,7 +184,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
 2. **Patch the `KubeadmControlPlane` with the target Kubernetes values**
 
-   Update the `KubeadmControlPlane` resource in a single edit to keep `spec.version`, the CoreDNS image tag, the etcd image tag, and the infrastructure template reference consistent with the same MicroOS release:
+   Update the `KubeadmControlPlane` resource in a single edit to keep `spec.version`, the CoreDNS image tag, the etcd image tag, and the infrastructure template reference consistent with the same Alauda OS release:
 
    - `spec.version` ← **Kubernetes Version** from the OS Support Matrix row
    - `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` ← **coredns** column from the same row
@@ -195,7 +195,7 @@ Before you start, collect every required value from the target ACP row in the OS
      kubectl edit kubeadmcontrolplane <kcp-name> -n cpaas-system
      ```
 
-   Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same MicroOS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
+   Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same Alauda OS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
 
 3. **Upgrade the Kube-OVN chart on the workload cluster**
 
@@ -268,12 +268,12 @@ Before you start, collect every required value from the target ACP row in the OS
 
 Worker node Kubernetes upgrades are managed through `MachineDeployment` resources. Worker upgrades carry fewer fields than the control plane: the CoreDNS and etcd image tags are part of `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration`, which `MachineDeployment` does not have. Worker nodes inherit Kubernetes component versions from the new VM template; the `MachineDeployment` only needs the target Kubernetes version and the new template reference.
 
-Before you start, read the **MicroOS Image Version** and **Kubernetes Version** cells from the target ACP row in the [OS Support Matrix](../overview/os-support-matrix.mdx) as described in [Required Values From the OS Support Matrix](#required-values).
+Before you start, read the **Alauda OS Image Version** and **Kubernetes Version** cells from the target ACP row in the [OS Support Matrix](../overview/os-support-matrix.mdx) as described in [Required Values From the OS Support Matrix](#required-values).
 
 #### Procedure
 
 1. **Create a new `DCSMachineTemplate` for worker nodes**
-   - Create a new `DCSMachineTemplate` with a `vmTemplateName` set to the **MicroOS Image Version** value from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx)
+   - Create a new `DCSMachineTemplate` with a `vmTemplateName` set to the **Alauda OS Image Version** value from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx)
    - Keep `/var/cpaas` and any other upgrade-preserved disks in `DCSIpHostnamePool.spec.pool[].persistentDisk` rather than reintroducing them as template disks
 
 2. **Update the `MachineDeployment`**

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -127,7 +127,7 @@ Aligned plugins do not need an extra `violet push` for the intermediate versions
 
 ### Step 2 — Stage intermediate OS images for the provisioning mechanism
 
-For each intermediate ACP version, make the matching OS image (the **MicroOS Image Version** value from the OS Support Matrix row) available to the node provisioning mechanism so the Kubernetes step can replace nodes from each image in turn:
+For each intermediate ACP version, make the matching OS image (the **Alauda OS Image Version** value from the OS Support Matrix row) available to the node provisioning mechanism so the Kubernetes step can replace nodes from each image in turn:
 
 - **IaaS providers (Huawei DCS, VMware vSphere, Huawei Cloud Stack)**: upload the OS image and register it as a VM template (or VM image, depending on the platform) under the exact name listed in the OS Support Matrix row.
 - **Bare metal**: make the OS image available to the node re-provisioning flow used by your cluster.

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -43,7 +43,7 @@ Before you begin, ensure the following conditions are met:
 - The distribution-version upgrade is complete.
 - The control plane is healthy and reachable.
 - All nodes are in the `Ready` state.
-- The target VM template is present in the vSphere environment under the same name as the **MicroOS Image Version** value in the OS Support Matrix row. The upgrade fails if the template is not present when the new `VSphereMachineTemplate` is applied.
+- The target VM template is present in the vSphere environment under the same name as the **Alauda OS Image Version** value in the OS Support Matrix row. The upgrade fails if the template is not present when the new `VSphereMachineTemplate` is applied.
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - The machine config pools have enough capacity for rolling updates.
@@ -84,7 +84,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 
 | OS Support Matrix column | Used to set | Where it lands |
 |---|---|---|
-| **MicroOS Image Version** | `VSphereMachineTemplate.spec.template.spec.template` (target VM template name) | Control plane and worker `VSphereMachineTemplate` |
+| **Alauda OS Image Version** | `VSphereMachineTemplate.spec.template.spec.template` (target VM template name) | Control plane and worker `VSphereMachineTemplate` |
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |


### PR DESCRIPTION
## What

Backport of **#101** (MicroOS → Alauda OS, AIT-70977) onto the **release-1.0** line — including the OS-image-identifier naming-convention form (per request, the new form is carried, not just the brand purge).

## Backport scope

Cherry-picked the merged master commit; applied cleanly on release-1.0.

- Prose / queries: `MicroOS` → `Alauda OS`; upstream brand (`MicroOS / SLE Micro`) reworded to "immutable-OS node".
- **OS Support Matrix**: image-version column now uses the AIT-67967 Alauda OS naming convention form `alaudaos-<acp-minor>.m55.<build-timestamp>-0.x86_64` (lowercase, minor-anchored, RHCOS-literal variant mark, build timestamp from the published image). Added the **Image Format by Provider** section (DCS/HCS `qcow2`, vSphere `vmdk`, bare metal `iso`).
- `infrastructure/huawei-dcs.mdx`: ConfigMap `vmImageVersion` synced to the same form.
- Verified: zero `MicroOS` / `openSUSE` / `SLE Micro` remain under `docs/`. `doom lint`: 0 errors, 0 warnings. EN only.

Ref: AIT-70977 / AIT-67967
