### PR TITLE
docs: warn against uninstalling etcd sync plugin while global DR is inconsistent

### DIFF
--- a/docs/en/global/disaster_recovery.mdx
+++ b/docs/en/global/disaster_recovery.mdx
@@ -37,6 +37,10 @@ After the primary and standby clusters are installed, operate DR as a separate l
 - Execute failover and failback with an approved operations procedure.
 - Reconcile provider-specific resources after a failover.
 
+<Directive type="warning" title="Verify consistency before uninstalling the etcd synchronization plugin">
+A disaster recovery switchover and a DR-aware `global` cluster upgrade both uninstall the etcd synchronization plugin. Before that uninstall, confirm that the standby `global` cluster data is consistent with the primary. On Immutable Infrastructure, workload-cluster nodes are backed by Cluster API `Machine` objects, so an incorrect owner-reference resolution after an inconsistent sync can delete those `Machine` objects and destroy the backing virtual machines. If the consistency check reports missing or surplus keys, do not uninstall the plugin; resolve the inconsistency or contact technical support first. For the detailed switchover and upgrade procedures, see <ExternalSiteLink name="acp" href="/install/global_dr.html" children="Global Cluster Disaster Recovery" /> and <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="Upgrade the global cluster" />.
+</Directive>
+
 ## Provider Notes
 
 <Tabs>


### PR DESCRIPTION
## What
Add a warning to the Immutable Infrastructure `global` cluster DR entry point: a DR switchover and a DR-aware `global` upgrade both uninstall the etcd synchronization plugin, and that must not happen while the standby is inconsistent with the primary.

- `global/disaster_recovery.mdx` — *Operational Scope*: add a WARNING directive with the immutable-OS angle (workload nodes are CAPI `Machine` objects → deletion destroys the backing VM) and cross-links to the acp-docs switchover and upgrade procedures.

## Why
Uninstalling the etcd sync plugin while primary/standby are inconsistent can cause owner references to resolve incorrectly and delete workload-cluster node `Machine` objects. On immutable infrastructure those `Machine`s back real VMs, so deletion destroys the node's VM. Applies to all versions.

## Scope
`master` only; no procedure duplicated (links to the authoritative acp-docs pages). Backport to `release-1.0` will follow as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)