### PR TITLE
docs: update DCS persistent disk isThin guidance

### DIFF
--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -238,7 +238,7 @@ Follow these steps in order to provision a functional cluster (control plane **a
 
 **Note**: Infrastructure resources (Secret, control-plane `DCSIpHostnamePool`, control-plane `DCSMachineTemplate`) should be configured separately. See [Infrastructure Resources for Huawei DCS](../infrastructure/huawei-dcs.mdx) for instructions.
 
-If you need any disk to survive rolling replacement, declare it in the matching `DCSIpHostnamePool.spec.pool[].persistentDisk` entry. This includes the platform-required `/var/cpaas` disk.
+If you need any disk to survive rolling replacement, declare it in the matching `DCSIpHostnamePool.spec.pool[].persistentDisk` entry. This includes the platform-required `/var/cpaas` disk. The provider creates new persistent volumes as independent persistent normal volumes. When the DCS environment requires an explicit thin-provisioning setting, set `persistentDisk[].isThin`; if you omit it, the provider does not send `isThin` and DCS uses the platform default.
 
 ### Resolving Placeholder Values \{#resolving-placeholders}
 

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -90,6 +90,8 @@ spec:
             - defaults
 ```
 
+Use `isThin` only when the DCS environment requires an explicit thin-provisioning value. If omitted, the provider does not send `isThin` and DCS uses the platform default. New persistent volumes are created as independent persistent normal volumes.
+
 Use the IP pool status to confirm that preserved disks are detached from old VMs and attached to replacement VMs during the rolling replacement.
 
   </Tab>

--- a/docs/en/how-to/dcs_persistent_disk_upgrade.mdx
+++ b/docs/en/how-to/dcs_persistent_disk_upgrade.mdx
@@ -34,7 +34,7 @@ The current model moves upgrade-preserved disks into `DCSIpHostnamePool.spec.poo
 1. Claims the existing disk from the old VM.
 2. Safely stops the old VM.
 3. Detaches the disk.
-4. Converts stock volumes to independent shared volumes when needed.
+4. Converts stock volumes to independent persistent volumes when needed.
 5. Deletes the old VM.
 6. Reattaches the disk to the replacement VM.
 7. Boots the replacement VM, which mounts the existing filesystem without reformatting it.
@@ -161,6 +161,8 @@ The spec interacts with the live disk attributes in three ways:
 - `datastoreName` or `datastoreClusterName` — must point to the same storage target as the live disk
 - `pciType` — must match the live disk PCI type. If omitted, the provider uses the default `VIRTIO`; verify the live disk PCI type before omitting this field, because a non-`VIRTIO` live disk can fail the strict claim match
 
+`isThin` is creation-only. It is sent only when the provider creates a new DCS persistent volume. It is not compared during existing-volume claim and does not convert existing volumes.
+
 **Filesystem (affects guest-side initialization, not the claim check):**
 
 - `format` — used only when initializing a fresh disk. If the live disk already has a filesystem, the existing format is preserved and `mkfs` is skipped.
@@ -248,7 +250,7 @@ kubectl get dcsiphostnamepool <iphostname-pool-name> -n cpaas-system -o yaml
 During the transition, each record appears under `status.persistentDiskStatus`. The stable phases to watch for are:
 
 - `phase: Attached` while the old VM still owns the disk
-- `phase: Available` after the disk is detached (and converted from a stock volume to an independent shared volume when needed)
+- `phase: Available` after the disk is detached (and converted from a stock volume to an independent persistent volume when needed)
 - `phase: Attached` again after the replacement VM reattaches the disk
 
 Transient phases (`Attaching`, `Detaching`) may briefly appear during the corresponding operations; `Deleting` appears when a disk is being permanently removed, for example during pool or cluster cleanup. The full phase set is `Creating`, `Available`, `Attaching`, `Attached`, `Detaching`, `Deleting`, `Error`.

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -331,6 +331,7 @@ spec:
 | `slot` | Disk position within the IP slot. It determines attach order, guest device naming, and the sequence number used during volume claim and reattach. |
 | `quantityGB` | Disk size in GB. |
 | `datastoreName` / `datastoreClusterName` | Specify exactly one storage target for the persistent disk. |
+| `isThin` | Optional. Controls DCS thin provisioning for newly created persistent volumes. If omitted, the provider does not send `isThin` and DCS uses the platform default. |
 | `path` | Mount path inside the guest OS. `/var/cpaas` is the platform-required path. |
 | `format` | Filesystem used when the disk is first initialized. If the replacement VM sees an existing filesystem, formatting is skipped. |
 | `options` | `mkfs` options applied only when the disk is first formatted. |
@@ -340,9 +341,10 @@ spec:
 **Update rules:**
 
 - You can append new `persistentDisk` entries to an existing IP slot. The controller attaches the newly added disk to the running VM on the DCS side, but it does not format or mount the disk inside the guest OS. Guest formatting and mounting take effect only after the VM is replaced and the replacement VM runs the generated disk setup during bootstrap.
+- The controller creates new persistent volumes as independent persistent normal volumes. When it reuses an existing volume, it only requires the volume to be independent and persistent; it does not require a specific DCS volume type.
 - Do not delete existing `persistentDisk` entries from the spec. The webhook rejects removal.
 - Treat `format`, `options`, and `pciType` as immutable after creation.
-- Treat `quantityGB` and datastore changes as rollout-sensitive changes. The webhook performs best-effort platform validation when the pool carries a cluster label.
+- Treat `quantityGB` and datastore changes as rollout-sensitive changes. The webhook performs best-effort platform validation when the pool carries a cluster label. `isThin` is creation-only: changing it does not validate, reconcile, or convert existing volumes, and affects only persistent volumes created later.
 - Treat `path` and `mountOptions` changes as guest-side changes that take effect on replacement machines during rolling updates.
 
 ---

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -197,8 +197,10 @@ Declare any upgrade-preserved disk in the matching `DCSIpHostnamePool.spec.pool[
 - On replacement nodes, the guest disk setup logic checks for an existing filesystem. If the disk is already formatted, it skips `mkfs` and mounts the disk directly.
 - Persistent-disk workflows require one-by-one replacement, so keep `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0`.
 - You can append new `persistentDisk` entries, but deleting existing entries is not supported. The controller attaches the newly added disk to the running VM on the DCS side, but it does not format or mount the disk inside the guest OS. Guest formatting and mounting take effect only after the VM is replaced and the replacement VM runs the generated disk setup during bootstrap.
+- The controller creates new persistent volumes as independent persistent normal volumes. When it reuses an existing volume, it only requires the volume to be independent and persistent; it does not require a specific DCS volume type.
 - Treat `format`, `options`, and `pciType` as immutable after creation.
-- Treat `quantityGB` and datastore changes as rollout-sensitive changes. The webhook performs best-effort validation against the DCS platform when it has enough cluster context.
+- Use `isThin` only when the DCS environment requires an explicit thin-provisioning value for newly created persistent volumes. If omitted, the provider does not send `isThin` and DCS uses the platform default.
+- Treat `quantityGB` and datastore changes as rollout-sensitive changes. The webhook performs best-effort validation against the DCS platform when it has enough cluster context. `isThin` is creation-only: changing it does not validate, reconcile, or convert existing volumes, and affects only persistent volumes created later.
 
 To inspect the runtime state of persistent disks during node operations, check `status.persistentDiskStatus` on the pool:
 
@@ -481,7 +483,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
    **Important Notes**
    - The `pool` array must include **all existing entries** plus the new entries you want to add
    - Copy the existing entries from the exported YAML to avoid data loss
-   - `kubectl patch --type='merge'` replaces the entire `spec.pool` array, so copy every existing `persistentDisk` block unchanged unless you are intentionally adding new disks
+   - `kubectl patch --type='merge'` replaces the entire `spec.pool` array, so copy every existing `persistentDisk` block unchanged, including `isThin` if it is present, unless you are intentionally adding new disks
    - Ensure each new entry has unique `ip`, `hostname`, and `machineName` values
    - If new worker nodes also need the platform-required `/var/cpaas` disk, declare it in each new entry's `persistentDisk`
    - Network parameters (`mask`, `gateway`, `dns`) typically match existing entries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@alauda/doom": "^2.5.1"
+    "@alauda/doom": "^2.5.2"
   },
   "scripts": {
     "dev": "doom dev",

--- a/yarn.lock
+++ b/yarn.lock
@@ -27,14 +27,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@alauda/doom@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@alauda/doom@npm:2.5.1"
+"@alauda/doom@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "@alauda/doom@npm:2.5.2"
   dependencies:
     "@alauda/doc-stream-sdk": "npm:0.1.0"
     "@alauda/doom-export": "npm:^0.4.1"
     "@cspell/eslint-plugin": "npm:^10.0.0"
-    "@eslint-react/eslint-plugin": "npm:^5.7.6"
+    "@eslint-react/eslint-plugin": "npm:^5.8.3"
     "@eslint/js": "npm:^10.0.1"
     "@inquirer/prompts": "npm:^8.4.3"
     "@openapi-contrib/openapi-schema-to-json-schema": "npm:^5.1.0"
@@ -42,20 +42,20 @@ __metadata:
     "@rsbuild/plugin-sass": "npm:^1.5.2"
     "@rsbuild/plugin-svgr": "npm:^2.0.2"
     "@rsbuild/plugin-yaml": "npm:^1.0.4"
-    "@rspress/core": "npm:2.0.11"
-    "@rspress/plugin-algolia": "npm:2.0.11"
-    "@rspress/plugin-sitemap": "npm:2.0.11"
-    "@rspress/shared": "npm:2.0.11"
-    "@shikijs/transformers": "npm:^4.0.2"
+    "@rspress/core": "npm:2.0.12"
+    "@rspress/plugin-algolia": "npm:2.0.12"
+    "@rspress/plugin-sitemap": "npm:2.0.12"
+    "@rspress/shared": "npm:2.0.12"
+    "@shikijs/transformers": "npm:^4.1.0"
     "@total-typescript/ts-reset": "npm:^0.6.1"
-    "@types/react": "npm:^19.2.14"
+    "@types/react": "npm:^19.2.15"
     ab64: "npm:^0.1.6"
     chokidar: "npm:^5.0.0"
     clsx: "npm:^2.1.1"
     commander: "npm:^14.0.3"
     ejs: "npm:^5.0.2"
     es-toolkit: "npm:^1.46.1"
-    eslint: "npm:^10.3.0"
+    eslint: "npm:^10.4.0"
     eslint-plugin-mdx: "npm:^3.7.0"
     globals: "npm:^17.6.0"
     hastscript: "npm:^9.0.1"
@@ -68,13 +68,13 @@ __metadata:
     mdast-util-to-markdown: "npm:^2.1.2"
     mdast-util-to-string: "npm:^4.0.0"
     mermaid: "npm:^11.15.0"
-    openai: "npm:^6.37.0"
+    openai: "npm:^6.38.0"
     openapi-types: "npm:^12.1.3"
     p-ratelimit: "npm:^1.0.1"
     picomatch: "npm:^4.0.4"
     pluralize: "npm:^8.0.0"
     react-markdown: "npm:^10.1.0"
-    react-tooltip: "npm:^6.0.2"
+    react-tooltip: "npm:^6.0.3"
     rehype-raw: "npm:^7.0.0"
     rehype-sanitize: "npm:^6.0.0"
     remark-directive: "npm:^4.0.0"
@@ -95,7 +95,7 @@ __metadata:
     tinyglobby: "npm:^0.2.16"
     type-fest: "npm:^5.6.0"
     typescript: "npm:^6.0.3"
-    typescript-eslint: "npm:^8.59.3"
+    typescript-eslint: "npm:^8.59.4"
     unified: "npm:^11.0.5"
     unified-lint-rule: "npm:^3.0.1"
     unist-util-position: "npm:^5.0.0"
@@ -105,7 +105,7 @@ __metadata:
     yoctocolors: "npm:^2.1.2"
   bin:
     doom: lib/cli/index.js
-  checksum: 10c0/c7f317b39f2d58aac13ff7cfefab8873b5ba59a5449600df141b584a38957ac146e5aaae2188a64b31a733c98dc1146c2bc0d3bd460c087ee4906800f9257b51
+  checksum: 10c0/5c08b22cf70148cb490105679f586cb9eabcd402a35904515ee2225f0e1332e34a96bf5d9477176daeefaa0d19b52f999a9c50055716f429e58411b14f06a7dd
   languageName: node
   linkType: hard
 
@@ -1020,118 +1020,118 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-react/ast@npm:5.7.9":
-  version: 5.7.9
-  resolution: "@eslint-react/ast@npm:5.7.9"
+"@eslint-react/ast@npm:5.8.5":
+  version: 5.8.5
+  resolution: "@eslint-react/ast@npm:5.8.5"
   dependencies:
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/typescript-estree": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     string-ts: "npm:^2.3.1"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/e1e0258eb6c21e94bc8af860e6140170d8a31b13b00c9de9604cfbd5b67bd6984a2d99a51e2b3b26c3a6e45aa1dfd7a3c9f67da6f0a79b87cc0342e8cfc78d9a
+  checksum: 10c0/94aae573a3ee56b198ba3fd10681785fee49fdbda2e240e6042edf610fdc20b5163bab0f1db8b5cddf2f3a69d6a4a152960f8422f803deb15c0ea495ef38cb64
   languageName: node
   linkType: hard
 
-"@eslint-react/core@npm:5.7.9":
-  version: 5.7.9
-  resolution: "@eslint-react/core@npm:5.7.9"
+"@eslint-react/core@npm:5.8.5":
+  version: 5.8.5
+  resolution: "@eslint-react/core@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/jsx": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@eslint-react/var": "npm:5.7.9"
-    "@typescript-eslint/scope-manager": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/jsx": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@eslint-react/var": "npm:5.8.5"
+    "@typescript-eslint/scope-manager": "npm:^8.59.4"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/dd4d71e54c48ce123caccafd1c5025b4c0eefa977f30b2161205389d6fb7e70e095c2be86c8fb9dc5773487786221dae3f8fd56417b31b3fc2cf8aab05fe4365
+  checksum: 10c0/e0a0b7bb86701b7b0cef02d594a9f2449ac2206fac16e9b9d0c941d3799e756601d5f5a363344a49e1d77d7daddafb8e8c78eed29f0b2fb6280855a609696d0f
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint-plugin@npm:^5.7.6":
-  version: 5.7.9
-  resolution: "@eslint-react/eslint-plugin@npm:5.7.9"
+"@eslint-react/eslint-plugin@npm:^5.8.3":
+  version: 5.8.5
+  resolution: "@eslint-react/eslint-plugin@npm:5.8.5"
   dependencies:
-    "@eslint-react/shared": "npm:5.7.9"
-    eslint-plugin-react-dom: "npm:5.7.9"
-    eslint-plugin-react-jsx: "npm:5.7.9"
-    eslint-plugin-react-naming-convention: "npm:5.7.9"
-    eslint-plugin-react-rsc: "npm:5.7.9"
-    eslint-plugin-react-web-api: "npm:5.7.9"
-    eslint-plugin-react-x: "npm:5.7.9"
+    "@eslint-react/shared": "npm:5.8.5"
+    eslint-plugin-react-dom: "npm:5.8.5"
+    eslint-plugin-react-jsx: "npm:5.8.5"
+    eslint-plugin-react-naming-convention: "npm:5.8.5"
+    eslint-plugin-react-rsc: "npm:5.8.5"
+    eslint-plugin-react-web-api: "npm:5.8.5"
+    eslint-plugin-react-x: "npm:5.8.5"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/69f6269ce88a604bd9c9e4c9586ba989564a5c070ec6d88bcc131b1013bef6f2860842f833c1132e4fa2c109dfee94bbb92d088e62884fcef98c7c704d292164
+  checksum: 10c0/0f9d78b0a9a7cacba171e126bd667097c32678e81f067be23af9bac18c5ca805734cc625f98859b8ad9fb27d17340e37132f2b9aca0a58a3c962387eaed90c37
   languageName: node
   linkType: hard
 
-"@eslint-react/eslint@npm:5.7.9":
-  version: 5.7.9
-  resolution: "@eslint-react/eslint@npm:5.7.9"
+"@eslint-react/eslint@npm:5.8.5":
+  version: 5.8.5
+  resolution: "@eslint-react/eslint@npm:5.8.5"
   dependencies:
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@typescript-eslint/utils": "npm:^8.59.4"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/514f516d8d75e3d68d4a221689990beeaa38c1361a2953f793135d4df55c506aaa55a0578547552c60c820f68d27368e1aca6cd105f6f201a1680a7f89285bce
+  checksum: 10c0/855c2810a35566618abacee985486003e40020ce6f93fc8499a7cd35c2d67402515e1b6e74c3bea800c0abfde6f62e777efc4d245c1de711fb6fe89ac4a18255
   languageName: node
   linkType: hard
 
-"@eslint-react/jsx@npm:5.7.9":
-  version: 5.7.9
-  resolution: "@eslint-react/jsx@npm:5.7.9"
+"@eslint-react/jsx@npm:5.8.5":
+  version: 5.8.5
+  resolution: "@eslint-react/jsx@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@eslint-react/var": "npm:5.7.9"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@eslint-react/var": "npm:5.8.5"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/c9509a76bf9d9d517d1809e3a8e3479f8ea162d715f1bcfa3b900c4a2b8a359c7080bb3f4cb893aa8620d69cf28b4a3ab5ce39d07113b8cb9552f98dd33c6fd9
+  checksum: 10c0/b6a55412419f8beb419d45dc8d05a493c2e6a9ef58446cb9b114c285a7e2337191d512421a2d97a3f1eadd61971c039822ec170b9aa3814ca771aba6da0be2a1
   languageName: node
   linkType: hard
 
-"@eslint-react/shared@npm:5.7.9":
-  version: 5.7.9
-  resolution: "@eslint-react/shared@npm:5.7.9"
+"@eslint-react/shared@npm:5.8.5":
+  version: 5.8.5
+  resolution: "@eslint-react/shared@npm:5.8.5"
   dependencies:
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     ts-pattern: "npm:^5.9.0"
     zod: "npm:^4.4.3"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/e7f841df4972f3b21048e13ef8b28a6081c12b76819667a7964a00df8cbe1efa20e8049f6f07ca660f45ee2076c6ebf9469d47ef9f3f3b8ce263bebbf421696d
+  checksum: 10c0/22bbd6cbaeaa32a4a3778b00878d668744215c81c0f11d1c637eb7544dd3c70f733a5e78f34b1e7e5590ad494485727505b890de3ffdd41c43c66dbbf0a9ae33
   languageName: node
   linkType: hard
 
-"@eslint-react/var@npm:5.7.9":
-  version: 5.7.9
-  resolution: "@eslint-react/var@npm:5.7.9"
+"@eslint-react/var@npm:5.8.5":
+  version: 5.8.5
+  resolution: "@eslint-react/var@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@typescript-eslint/scope-manager": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@typescript-eslint/scope-manager": "npm:^8.59.4"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/30c6992b8b29dec08aa83f076744422229c7e0e9a15de5727c1cb0e4fb9498f20b53aadbf5e53a97eb22a13ea5008a9c510d56f521a91cd98e4b9e44303d4043
+  checksum: 10c0/50b7ea82ac38175087bdc6a5e02964210fe35400546efdc3dc3d65cdfd2dac503266506f63ef0d1f91b8bd60d287761ae23ee62634ddc67793d85cd2464993a6
   languageName: node
   linkType: hard
 
@@ -1986,11 +1986,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rsbuild/core@npm:^2.0.5":
-  version: 2.0.6
-  resolution: "@rsbuild/core@npm:2.0.6"
+"@rsbuild/core@npm:^2.0.6":
+  version: 2.0.7
+  resolution: "@rsbuild/core@npm:2.0.7"
   dependencies:
-    "@rspack/core": "npm:~2.0.3"
+    "@rspack/core": "npm:~2.0.4"
     "@swc/helpers": "npm:^0.5.21"
   peerDependencies:
     core-js: ">= 3.0.0"
@@ -1999,7 +1999,7 @@ __metadata:
       optional: true
   bin:
     rsbuild: bin/rsbuild.js
-  checksum: 10c0/51c161ee113f16819bd120526829b6a7c2d40b7db088da96e798e1b0ce80fcf8745d97e99f4d8c0f926e3048526d214e723862763054d94d9782164c1d22ae83
+  checksum: 10c0/e7ef31d9d092100a02ea2251ef3105dd7c7011878dc94a1b1e74529d61a1e7f25301f841a02b5e34cb5ae5e8788a5683575bd7e60384bea2af8543325d019076
   languageName: node
   linkType: hard
 
@@ -2067,51 +2067,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-arm64@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-darwin-arm64@npm:2.0.3"
+"@rspack/binding-darwin-arm64@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-darwin-arm64@npm:2.0.4"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-darwin-x64@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-darwin-x64@npm:2.0.3"
+"@rspack/binding-darwin-x64@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-darwin-x64@npm:2.0.4"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-gnu@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.0.3"
+"@rspack/binding-linux-arm64-gnu@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-linux-arm64-gnu@npm:2.0.4"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-arm64-musl@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-arm64-musl@npm:2.0.3"
+"@rspack/binding-linux-arm64-musl@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-linux-arm64-musl@npm:2.0.4"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-gnu@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-x64-gnu@npm:2.0.3"
+"@rspack/binding-linux-x64-gnu@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-linux-x64-gnu@npm:2.0.4"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rspack/binding-linux-x64-musl@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-linux-x64-musl@npm:2.0.3"
+"@rspack/binding-linux-x64-musl@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-linux-x64-musl@npm:2.0.4"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rspack/binding-wasm32-wasi@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-wasm32-wasi@npm:2.0.3"
+"@rspack/binding-wasm32-wasi@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-wasm32-wasi@npm:2.0.4"
   dependencies:
     "@emnapi/core": "npm:1.10.0"
     "@emnapi/runtime": "npm:1.10.0"
@@ -2120,41 +2120,41 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-arm64-msvc@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.0.3"
+"@rspack/binding-win32-arm64-msvc@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-win32-arm64-msvc@npm:2.0.4"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-ia32-msvc@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.0.3"
+"@rspack/binding-win32-ia32-msvc@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-win32-ia32-msvc@npm:2.0.4"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rspack/binding-win32-x64-msvc@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding-win32-x64-msvc@npm:2.0.3"
+"@rspack/binding-win32-x64-msvc@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding-win32-x64-msvc@npm:2.0.4"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@rspack/binding@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/binding@npm:2.0.3"
+"@rspack/binding@npm:2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/binding@npm:2.0.4"
   dependencies:
-    "@rspack/binding-darwin-arm64": "npm:2.0.3"
-    "@rspack/binding-darwin-x64": "npm:2.0.3"
-    "@rspack/binding-linux-arm64-gnu": "npm:2.0.3"
-    "@rspack/binding-linux-arm64-musl": "npm:2.0.3"
-    "@rspack/binding-linux-x64-gnu": "npm:2.0.3"
-    "@rspack/binding-linux-x64-musl": "npm:2.0.3"
-    "@rspack/binding-wasm32-wasi": "npm:2.0.3"
-    "@rspack/binding-win32-arm64-msvc": "npm:2.0.3"
-    "@rspack/binding-win32-ia32-msvc": "npm:2.0.3"
-    "@rspack/binding-win32-x64-msvc": "npm:2.0.3"
+    "@rspack/binding-darwin-arm64": "npm:2.0.4"
+    "@rspack/binding-darwin-x64": "npm:2.0.4"
+    "@rspack/binding-linux-arm64-gnu": "npm:2.0.4"
+    "@rspack/binding-linux-arm64-musl": "npm:2.0.4"
+    "@rspack/binding-linux-x64-gnu": "npm:2.0.4"
+    "@rspack/binding-linux-x64-musl": "npm:2.0.4"
+    "@rspack/binding-wasm32-wasi": "npm:2.0.4"
+    "@rspack/binding-win32-arm64-msvc": "npm:2.0.4"
+    "@rspack/binding-win32-ia32-msvc": "npm:2.0.4"
+    "@rspack/binding-win32-x64-msvc": "npm:2.0.4"
   dependenciesMeta:
     "@rspack/binding-darwin-arm64":
       optional: true
@@ -2176,15 +2176,15 @@ __metadata:
       optional: true
     "@rspack/binding-win32-x64-msvc":
       optional: true
-  checksum: 10c0/7089971775d41224f2299189ae253eefff3533970b34008202f3e6b72776c9e238efc3412aca68aa95fec9c0f1155b25d96d40581332ecd0e35514718f5c612c
+  checksum: 10c0/a7477adea7edf8f0c73bc2fd780742515d4ffbc294ba14cdb73e1d4cd88ac69f8d85870f778b983846d2696e008001e7ae9d09989f18a36739ec8df4881aa151
   languageName: node
   linkType: hard
 
-"@rspack/core@npm:~2.0.3":
-  version: 2.0.3
-  resolution: "@rspack/core@npm:2.0.3"
+"@rspack/core@npm:~2.0.4":
+  version: 2.0.4
+  resolution: "@rspack/core@npm:2.0.4"
   dependencies:
-    "@rspack/binding": "npm:2.0.3"
+    "@rspack/binding": "npm:2.0.4"
   peerDependencies:
     "@module-federation/runtime-tools": ^0.24.1 || ^2.0.0
     "@swc/helpers": ">=0.5.1"
@@ -2193,7 +2193,7 @@ __metadata:
       optional: true
     "@swc/helpers":
       optional: true
-  checksum: 10c0/767a1545f19cfc983994684c1725bcc4cefffc49095f7194376f840d1137cd4f9f93c40e58e091757da57a517f9219fd316c0e5c080f2b6040b11be976e6988b
+  checksum: 10c0/a89e13e3838b49d1cce58431852a143240dd3913a58a559fbedc40723fca85a9f344571ad99e7bb27dc17ef934f946e1ddc47f333e115711b48ff25dc0ac6654
   languageName: node
   linkType: hard
 
@@ -2210,15 +2210,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rspress/core@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/core@npm:2.0.11"
+"@rspress/core@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/core@npm:2.0.12"
   dependencies:
     "@mdx-js/mdx": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"
-    "@rsbuild/core": "npm:^2.0.5"
+    "@rsbuild/core": "npm:^2.0.6"
     "@rsbuild/plugin-react": "npm:~2.0.0"
-    "@rspress/shared": "npm:2.0.11"
+    "@rspress/shared": "npm:2.0.12"
     "@shikijs/rehype": "npm:^4.0.2"
     "@types/unist": "npm:^3.0.3"
     "@unhead/react": "npm:^2.1.15"
@@ -2237,7 +2237,7 @@ __metadata:
     react-lazy-with-preload: "npm:^2.2.1"
     react-reconciler: "npm:0.33.0"
     react-render-to-markdown: "npm:19.0.1"
-    react-router-dom: "npm:^7.15.0"
+    react-router-dom: "npm:^7.15.1"
     rehype-external-links: "npm:^3.0.0"
     rehype-raw: "npm:^7.0.0"
     remark-cjk-friendly: "npm:^2.0.1"
@@ -2254,39 +2254,39 @@ __metadata:
     unist-util-visit-children: "npm:^3.0.0"
   bin:
     rspress: bin/rspress.js
-  checksum: 10c0/962d0ce4b401d6b82e9e0acedcc615832c29b76fbef8af983af343a08df5ffc85134cb3670dcc410ecb7ad192e858f5f7730256580e5754d2b42f248bee2ab32
+  checksum: 10c0/3de5e86107077e2ed769f59815e2804aedf3be616af3b14037bdbc9bbeea8c7106238d4912815848433f382f9c0708e546045ccb290b37d386035f86330b8dc8
   languageName: node
   linkType: hard
 
-"@rspress/plugin-algolia@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/plugin-algolia@npm:2.0.11"
+"@rspress/plugin-algolia@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/plugin-algolia@npm:2.0.12"
   dependencies:
     "@docsearch/css": "npm:^4.6.3"
     "@docsearch/react": "npm:^4.6.3"
   peerDependencies:
     "@rspress/core": ^2.0.10
-  checksum: 10c0/3693fa981c78b4e93816b08524b1e715ca8c03aa400461f271e405842f0a6f586e801b9560714398725fdbde60fc4cb7a0722213d93fe16e79cdb4d8f18ad6c2
+  checksum: 10c0/4ae7c5195decab8e259b4773386b28211bdfc3d13a06f87ea946592976e5a092214f0db82e0a3e74f589ba69236421859ee245afdbacaef5b551e2e821662c12
   languageName: node
   linkType: hard
 
-"@rspress/plugin-sitemap@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/plugin-sitemap@npm:2.0.11"
+"@rspress/plugin-sitemap@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/plugin-sitemap@npm:2.0.12"
   peerDependencies:
     "@rspress/core": ^2.0.10
-  checksum: 10c0/4583ceaa147713877f4ebaf5e74529d5569254b039d0bb7cd2be33f02c533bd4a82c4181d787da8e59c9adefdc4188337c0a277ee00f302f15f8f515cf5f2eb4
+  checksum: 10c0/86f4803df1abaaac140f7cfc7c8199bacbf2e900dc23f4a770223c9230e67731b4e6d97be6d313fc8e911c71bdd5f341b5f444163209b8dc8ddc9d7d68c315d4
   languageName: node
   linkType: hard
 
-"@rspress/shared@npm:2.0.11":
-  version: 2.0.11
-  resolution: "@rspress/shared@npm:2.0.11"
+"@rspress/shared@npm:2.0.12":
+  version: 2.0.12
+  resolution: "@rspress/shared@npm:2.0.12"
   dependencies:
-    "@rsbuild/core": "npm:^2.0.5"
+    "@rsbuild/core": "npm:^2.0.6"
     "@shikijs/rehype": "npm:^4.0.2"
     unified: "npm:^11.0.5"
-  checksum: 10c0/2d396c95019f8af01165e9506f4edc6033eb6e6609d6fa359c3a5b3a982cc15b39931eacb041cee67f4b16fdee896ccae0371a8ff4a139bf98b686015d48b115
+  checksum: 10c0/caeb2b513e44160d6664568223595308e89729974660f1ed0456b5b2d5351681fd5289acfeca46c51953fa4311920231dffca7810cc65083121f8480f521dca1
   languageName: node
   linkType: hard
 
@@ -2300,6 +2300,19 @@ __metadata:
     "@types/hast": "npm:^3.0.4"
     hast-util-to-html: "npm:^9.0.5"
   checksum: 10c0/0a8c56d50b2f67334e5e128b89f1e85844f60ae1dfbd4171e6e92242398678f6eaf91cd02f8418ac4abf4d81774e0ec9a83274a2e3f609c410e577520eadb0f5
+  languageName: node
+  linkType: hard
+
+"@shikijs/core@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@shikijs/core@npm:4.1.0"
+  dependencies:
+    "@shikijs/primitive": "npm:4.1.0"
+    "@shikijs/types": "npm:4.1.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+    hast-util-to-html: "npm:^9.0.5"
+  checksum: 10c0/5df53c2a61839f4b2f2da26f0b0ae91a16569ea81ab88a3ff53af9201876594436d71ad1f4893f647df61c46e9ad2f883d1d3b33a997a947d2c9c3dabfb706db
   languageName: node
   linkType: hard
 
@@ -2344,6 +2357,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/primitive@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@shikijs/primitive@npm:4.1.0"
+  dependencies:
+    "@shikijs/types": "npm:4.1.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/8e5187e954217dda922fe9b4c12f02b921fed9c9b864fbef330fc87abb799afe5e9fff36f416730dcd81c980bea1392ea01d4931b70f14be8471ec70c059316e
+  languageName: node
+  linkType: hard
+
 "@shikijs/rehype@npm:^4.0.2":
   version: 4.0.2
   resolution: "@shikijs/rehype@npm:4.0.2"
@@ -2367,13 +2391,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/transformers@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@shikijs/transformers@npm:4.0.2"
+"@shikijs/transformers@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@shikijs/transformers@npm:4.1.0"
   dependencies:
-    "@shikijs/core": "npm:4.0.2"
-    "@shikijs/types": "npm:4.0.2"
-  checksum: 10c0/7c3ce7d356d1b02061b5ab4ff5d91098b45cca1f961e64a496c5fb9d2854fce6c7e033f113819b9290cd188efb4016f625fb70f590572ccb1f36983768fca3ff
+    "@shikijs/core": "npm:4.1.0"
+    "@shikijs/types": "npm:4.1.0"
+  checksum: 10c0/f77ea4e6e5d1f4ccbd3b72b78b088c6ced6dbdfdaf3a4c7ed51368747935c0207eb136722d8322a58aff084d1fa1ec8c7bbe51691ad8843371dd87ed5394849e
   languageName: node
   linkType: hard
 
@@ -2384,6 +2408,16 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
   checksum: 10c0/9df16cf9988fef0e8ac6e438bc90805ccea707700d169e8e16ab87617d14fb2eeac2a7ead310aa88398c04d1dde95f877c1b695567578e40e6845bce2f65fc73
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:4.1.0":
+  version: 4.1.0
+  resolution: "@shikijs/types@npm:4.1.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/e8e318603bbdeca761de3d874984fe0f896978dda51c3df36c5878189f9c1f64fa25a4f5c6e07215606affefcd35efaa9eafbe502fb0ab61d4d0d65a9afb3c1d
   languageName: node
   linkType: hard
 
@@ -2966,12 +3000,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^19.2.14":
-  version: 19.2.14
-  resolution: "@types/react@npm:19.2.14"
+"@types/react@npm:^19.2.15":
+  version: 19.2.15
+  resolution: "@types/react@npm:19.2.15"
   dependencies:
     csstype: "npm:^3.2.2"
-  checksum: 10c0/7d25bf41b57719452d86d2ac0570b659210402707313a36ee612666bf11275a1c69824f8c3ee1fdca077ccfe15452f6da8f1224529b917050eb2d861e52b59b7
+  checksum: 10c0/b554eab715bb14e581f0ae60e5cefe91e1a5e06c31022b543a9806cf224aa056f21e4fb46208e46eb934d86ca0b247ebc82377192a0dead303cb28b8764c6e67
   languageName: node
   linkType: hard
 
@@ -3003,105 +3037,105 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.3"
+"@typescript-eslint/eslint-plugin@npm:8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.59.4"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@typescript-eslint/scope-manager": "npm:8.59.3"
-    "@typescript-eslint/type-utils": "npm:8.59.3"
-    "@typescript-eslint/utils": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+    "@typescript-eslint/scope-manager": "npm:8.59.4"
+    "@typescript-eslint/type-utils": "npm:8.59.4"
+    "@typescript-eslint/utils": "npm:8.59.4"
+    "@typescript-eslint/visitor-keys": "npm:8.59.4"
     ignore: "npm:^7.0.5"
     natural-compare: "npm:^1.4.0"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
-    "@typescript-eslint/parser": ^8.59.3
+    "@typescript-eslint/parser": ^8.59.4
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/c316ba4af95c7408c65279005099386c1547c184929b7027a1041a2450537d5ce7bd9276e0d6774ae384f9e4482e392dc3305686442d64777c448d76f39fd665
+  checksum: 10c0/53639bb5cbb5cb22d5e8d52c404a217cb1af4b1c3a8f6f3bb15824807b4db4bed49008d3b3f7688295285e764c7aff3b682b56dece3013a81de83f47bdf2b36c
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/parser@npm:8.59.3"
+"@typescript-eslint/parser@npm:8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/parser@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:8.59.3"
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+    "@typescript-eslint/scope-manager": "npm:8.59.4"
+    "@typescript-eslint/types": "npm:8.59.4"
+    "@typescript-eslint/typescript-estree": "npm:8.59.4"
+    "@typescript-eslint/visitor-keys": "npm:8.59.4"
     debug: "npm:^4.4.3"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/a5e16163e6fdeff411272e8fa2e26b48c28aae3003ff2a6b52e7c7727061170afde11261feefba0b578399774a6c9b26e5d58d593e66b25f88a4552e6012d9e2
+  checksum: 10c0/7dccab1bec898aee2c8aa8e08560ce6d439ef174358e98d5d92ee3f8a9fc0b044534ce0eecf57521f284858f937ec968941200c1df9ffd0baa0795bffa3de97d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/project-service@npm:8.59.3"
+"@typescript-eslint/project-service@npm:8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/project-service@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
+    "@typescript-eslint/tsconfig-utils": "npm:^8.59.4"
+    "@typescript-eslint/types": "npm:^8.59.4"
     debug: "npm:^4.4.3"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/14caf773ce7198e097e7cf1ba65b0dfd0553696b5ffc1842f0f5bbc877450d1aab599dd0209b1bca66e4a03ba176051dfa13e30005b8f0a96453d7a01e8d8ba6
+  checksum: 10c0/ba466e3b4091f79bd9ae8c29591d4858760293c2bc5d355642b9bf04b9c6fcd4418ff255485aaaf005edb84f6aaefeb53a3c1627bbbb70a905a4786d20f0b06a
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.59.3, @typescript-eslint/scope-manager@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/scope-manager@npm:8.59.3"
+"@typescript-eslint/scope-manager@npm:8.59.4, @typescript-eslint/scope-manager@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/scope-manager@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
-  checksum: 10c0/716c342e3e4963431696f4a68c616e0afdb619a94fabf448d032a9a676d75d39d60926cd6b47ccd712c722f7cf549a2f623f97049017f36e953dd9b7b348e9bd
+    "@typescript-eslint/types": "npm:8.59.4"
+    "@typescript-eslint/visitor-keys": "npm:8.59.4"
+  checksum: 10c0/0e4701f8c3384c7406f372cb06762d6bf943aba3afe2c231e4e942ee2e8b4cd4e9e7667ec503502dc4a159b826892dbe1487e2a8d143e190c850744b2a329857
   languageName: node
   linkType: hard
 
-"@typescript-eslint/tsconfig-utils@npm:8.59.3, @typescript-eslint/tsconfig-utils@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.3"
+"@typescript-eslint/tsconfig-utils@npm:8.59.4, @typescript-eslint/tsconfig-utils@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.59.4"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/326c07ae30e04734b28830ff74fbc8478f58671f0111a540854064d5a1cd15ed22056453165200ce342de9758e4ce45c827068017701dfb8390ec1c6b3c990ab
+  checksum: 10c0/ef6cf20eb93cb5e12439bc9713f5d9c619d516aefd3ecd4f111d9b23ef9f36e5c13f1bbcd55faa6a4b788b146b2a8724a418504107d4d377d0463f419fe9e1f3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:8.59.3, @typescript-eslint/type-utils@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/type-utils@npm:8.59.3"
+"@typescript-eslint/type-utils@npm:8.59.4, @typescript-eslint/type-utils@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/type-utils@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
-    "@typescript-eslint/utils": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.4"
+    "@typescript-eslint/typescript-estree": "npm:8.59.4"
+    "@typescript-eslint/utils": "npm:8.59.4"
     debug: "npm:^4.4.3"
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/ff0dfb47fafe6046c0cf08b1790db41dc8e0b93dfa5bdd69f78d1cb58880b85bfb7930079c417664498a203b894381b228141efc27f427d1969c6aecc25e63b9
+  checksum: 10c0/93b1a96c395b22da81990655d2fc86d627f5ad815d33faa474b83463c27d34de86a8efedce6cd911d479fcfdc5a758476efa350933f5f97a4181fd226c4ccb6d
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.59.3, @typescript-eslint/types@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/types@npm:8.59.3"
-  checksum: 10c0/3f7836ce108c3098935180221abce6d9dbf3583216b895525b0a1fc8d0207ebe1ba9e571dbb45eddacd14ef99563350b9b51df3091258211f8d267f02b9a80c1
+"@typescript-eslint/types@npm:8.59.4, @typescript-eslint/types@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/types@npm:8.59.4"
+  checksum: 10c0/5bb831f9acf98057b3dce6ebfc1df5f1796e701cdf035e71fdee6d0bb7f7e7d9c428bac38f46db4e08381ad8903424fcfbe55bcae223a6244b9133de8e0be190
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:8.59.3, @typescript-eslint/typescript-estree@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/typescript-estree@npm:8.59.3"
+"@typescript-eslint/typescript-estree@npm:8.59.4, @typescript-eslint/typescript-estree@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/typescript-estree@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/project-service": "npm:8.59.3"
-    "@typescript-eslint/tsconfig-utils": "npm:8.59.3"
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/visitor-keys": "npm:8.59.3"
+    "@typescript-eslint/project-service": "npm:8.59.4"
+    "@typescript-eslint/tsconfig-utils": "npm:8.59.4"
+    "@typescript-eslint/types": "npm:8.59.4"
+    "@typescript-eslint/visitor-keys": "npm:8.59.4"
     debug: "npm:^4.4.3"
     minimatch: "npm:^10.2.2"
     semver: "npm:^7.7.3"
@@ -3109,32 +3143,32 @@ __metadata:
     ts-api-utils: "npm:^2.5.0"
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/d23d4efa17ebfceaca741e0656f4cc69f6429fad0bba87fa79cf08b6b67e487282241fd4211ae69d1b9eae1e5746db849e2e29518a385ee981a55f297db58906
+  checksum: 10c0/2f427f9ba3ea1c7d1f476883f9769827c7082ff3cefcb189dcdb2dc33b16fa459e40894152d42583df90d0ed1041a1043830ecba5326c0b1de6becb9cf22fcee
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.59.3, @typescript-eslint/utils@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/utils@npm:8.59.3"
+"@typescript-eslint/utils@npm:8.59.4, @typescript-eslint/utils@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/utils@npm:8.59.4"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.59.3"
-    "@typescript-eslint/types": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
+    "@typescript-eslint/scope-manager": "npm:8.59.4"
+    "@typescript-eslint/types": "npm:8.59.4"
+    "@typescript-eslint/typescript-estree": "npm:8.59.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/a8299781be03e43f9a0f4006e607cfaa1094e2d5b1a208e7f2b994841884f08b557ce51d97d128b892b335a99b1bffa151eb4c0173aafec5d012783656e222f0
+  checksum: 10c0/f2e7f6237defd49e578731762e8736e7316e4873e326d48ec56651dcd0204962367f3e91692939e1636f443a8ded524336b7ee0874b6267940e77f5dc8fce175
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:8.59.3":
-  version: 8.59.3
-  resolution: "@typescript-eslint/visitor-keys@npm:8.59.3"
+"@typescript-eslint/visitor-keys@npm:8.59.4":
+  version: 8.59.4
+  resolution: "@typescript-eslint/visitor-keys@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/types": "npm:8.59.3"
+    "@typescript-eslint/types": "npm:8.59.4"
     eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/124c1ecece3f1ea954a05b150f8ec89b1c790276baa6e60c542a006cf3e14ce2c6152f95f06740e73609c36c6db0eeba98caba572d19db0befaef8aaba6f9569
+  checksum: 10c0/fcef4078988d725f0e56104038cc903d78cb5527e10e4da2c29ae7cb65e5b46c6a8f3f20d2be3e83b4cbaf27a723d1d2b31027006b5f1d43bf1fb0baed8e7641
   languageName: node
   linkType: hard
 
@@ -4623,113 +4657,113 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-dom@npm:5.7.9":
-  version: 5.7.9
-  resolution: "eslint-plugin-react-dom@npm:5.7.9"
+"eslint-plugin-react-dom@npm:5.8.5":
+  version: 5.8.5
+  resolution: "eslint-plugin-react-dom@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/jsx": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/jsx": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     compare-versions: "npm:^6.1.1"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/d4d76d6ef31ff147ab32aff6f583b00e97225e5b9a6250943ccee77598867e92ee57d6563d1b7e2f8f66f25cea815865ab031cf7cf81cc5766955e2e50e9bfe4
+  checksum: 10c0/feeefddf595adaa575c276d9ad2dd541dcead09f94442bdc2cc4ec32b5e6531b41adf13976a96ab8de578446b3e82cde7af7eebf99338c56a8d7d37fd7008978
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-jsx@npm:5.7.9":
-  version: 5.7.9
-  resolution: "eslint-plugin-react-jsx@npm:5.7.9"
+"eslint-plugin-react-jsx@npm:5.8.5":
+  version: 5.8.5
+  resolution: "eslint-plugin-react-jsx@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/core": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/jsx": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/core": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/jsx": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/1d788ebfb75476bc4078778efd22ac6c6c65f70b5f3d130005c8871f38884792ac73ddb1c34bf904cf01710ff93cef7fb20b085f871cb1b33874c5ba7fca7a6d
+  checksum: 10c0/bef899e8969c38c1aa0048496bc3f95277a46201915da51f6034561071d96a7bcefdc83cf3def8db7b0fe7818773a26bc8b12ff3be386132186d240dbf4b4a5c
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-naming-convention@npm:5.7.9":
-  version: 5.7.9
-  resolution: "eslint-plugin-react-naming-convention@npm:5.7.9"
+"eslint-plugin-react-naming-convention@npm:5.8.5":
+  version: 5.8.5
+  resolution: "eslint-plugin-react-naming-convention@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/core": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/var": "npm:5.7.9"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/core": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/var": "npm:5.8.5"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/4422741fb8c66b2414011bd9dd4eda69c2c8aff990c2a7e5cc4a0778d327f5e0b6bf7aad41d829cbb5db9b9d7be967443343f3bc89ef1beca9c40e8892120ad8
+  checksum: 10c0/61469aefcc5cb9b1d43a0140c733d1a017d53824dbd3f3db702f8f467fa36df9a49915d1c0a142195a1ff48f5673dde029cd1cf79877641c084774ba9f741d7c
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-rsc@npm:5.7.9":
-  version: 5.7.9
-  resolution: "eslint-plugin-react-rsc@npm:5.7.9"
+"eslint-plugin-react-rsc@npm:5.8.5":
+  version: 5.8.5
+  resolution: "eslint-plugin-react-rsc@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/core": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@eslint-react/var": "npm:5.7.9"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/core": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@eslint-react/var": "npm:5.8.5"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/64e446bbb02ce4d12a6e798ac1e49b5ff5c823adf2739d3b3faec6341c6eb46fa84e8da2119148d2736f9a8fc1d053108fbb8db1ddd1c2ef58117620dc26ba6a
+  checksum: 10c0/9bcb8ac4d9b5134c3b38985d213b30b9239d1629dd1e8e5f83594cb1436c5317659c805a91fc6cb9eef49a8c61e560eb4d1181352d091053156d2c0af869b389
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-web-api@npm:5.7.9":
-  version: 5.7.9
-  resolution: "eslint-plugin-react-web-api@npm:5.7.9"
+"eslint-plugin-react-web-api@npm:5.8.5":
+  version: 5.8.5
+  resolution: "eslint-plugin-react-web-api@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/core": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@eslint-react/var": "npm:5.7.9"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/core": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@eslint-react/var": "npm:5.8.5"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     birecord: "npm:^0.1.1"
     ts-pattern: "npm:^5.9.0"
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/5f1ffd2ecdff27135b272988bd082e2395bcc9eed878b8dfd20a40e62a6cac8510770d049622e0b64692ae383b93eaeea07fc0147e92dc22bbf1a66a3fd4cd30
+  checksum: 10c0/09560ff0c64468ac135dcc5a933fe9ce7a2e59322ce502f9cac1bed6a1fe6caeb71b5ad6fa4188f022a2912340f3e827601245c08f535fbdc06595550972eeaa
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-x@npm:5.7.9":
-  version: 5.7.9
-  resolution: "eslint-plugin-react-x@npm:5.7.9"
+"eslint-plugin-react-x@npm:5.8.5":
+  version: 5.8.5
+  resolution: "eslint-plugin-react-x@npm:5.8.5"
   dependencies:
-    "@eslint-react/ast": "npm:5.7.9"
-    "@eslint-react/core": "npm:5.7.9"
-    "@eslint-react/eslint": "npm:5.7.9"
-    "@eslint-react/jsx": "npm:5.7.9"
-    "@eslint-react/shared": "npm:5.7.9"
-    "@eslint-react/var": "npm:5.7.9"
-    "@typescript-eslint/scope-manager": "npm:^8.59.3"
-    "@typescript-eslint/type-utils": "npm:^8.59.3"
-    "@typescript-eslint/types": "npm:^8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:^8.59.3"
-    "@typescript-eslint/utils": "npm:^8.59.3"
+    "@eslint-react/ast": "npm:5.8.5"
+    "@eslint-react/core": "npm:5.8.5"
+    "@eslint-react/eslint": "npm:5.8.5"
+    "@eslint-react/jsx": "npm:5.8.5"
+    "@eslint-react/shared": "npm:5.8.5"
+    "@eslint-react/var": "npm:5.8.5"
+    "@typescript-eslint/scope-manager": "npm:^8.59.4"
+    "@typescript-eslint/type-utils": "npm:^8.59.4"
+    "@typescript-eslint/types": "npm:^8.59.4"
+    "@typescript-eslint/typescript-estree": "npm:^8.59.4"
+    "@typescript-eslint/utils": "npm:^8.59.4"
     compare-versions: "npm:^6.1.1"
     string-ts: "npm:^2.3.1"
     ts-api-utils: "npm:^2.5.0"
@@ -4737,7 +4771,7 @@ __metadata:
   peerDependencies:
     eslint: ^10.3.0
     typescript: "*"
-  checksum: 10c0/7352d2cecfce56719dc80a0bb42def91d03fb880957d44d5e7af0d1305e8485ca6cd075c47bf5473de89679a63442165387877746826207f58ae60caac663c36
+  checksum: 10c0/4e5aaded0e3d2a79599f3354757ff6775e04eec95bc3ff1a466e3ed4690e8f854f3dbb4b5310c32e09180aaded7e0631b6b3f21ab938aad4d3c7767ac318dca2
   languageName: node
   linkType: hard
 
@@ -4774,7 +4808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^10.3.0":
+"eslint@npm:^10.4.0":
   version: 10.4.0
   resolution: "eslint@npm:10.4.0"
   dependencies:
@@ -7299,9 +7333,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"openai@npm:^6.37.0":
-  version: 6.38.0
-  resolution: "openai@npm:6.38.0"
+"openai@npm:^6.38.0":
+  version: 6.39.0
+  resolution: "openai@npm:6.39.0"
   peerDependencies:
     ws: ^8.18.0
     zod: ^3.25 || ^4.0
@@ -7312,7 +7346,7 @@ __metadata:
       optional: true
   bin:
     openai: bin/cli
-  checksum: 10c0/5557c3f4c33c4232939763bce0f1d548596a7d1dfdb24a59f5177a972a369e583f196cd67e9352e6ca6379ad842e44d83f3ef993c0f320888b457bad878203ba
+  checksum: 10c0/cc3d07840795be58776b5a4b372d53d3acab88298022a1191cc9471bfd06401663488113ff3002b6c2b89011270969328608dccbf53100357461da71004cb385
   languageName: node
   linkType: hard
 
@@ -7768,7 +7802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^7.15.0":
+"react-router-dom@npm:^7.15.1":
   version: 7.15.1
   resolution: "react-router-dom@npm:7.15.1"
   dependencies:
@@ -7796,16 +7830,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^6.0.2":
-  version: 6.0.3
-  resolution: "react-tooltip@npm:6.0.3"
+"react-tooltip@npm:^6.0.3":
+  version: 6.0.4
+  resolution: "react-tooltip@npm:6.0.4"
   dependencies:
     "@floating-ui/dom": "npm:1.7.6"
     clsx: "npm:2.1.1"
   peerDependencies:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
-  checksum: 10c0/f8ecdd2797535eb4ba5d197e02856e854e8b47b3747750a712ac9384da55d7d934f48ff0b2f57d48255dbefc2127c0c7434c8cb1ae27d41cdfd7b029c6011bbc
+  checksum: 10c0/9cabc51b960df92264ddccdd6d68758054ab7c90a4f0efb64230463519e06d924c091e22eab68142fdd0e4bc3184daa1e1577904accb9cff7b7eb39c2f122e39
   languageName: node
   linkType: hard
 
@@ -8223,7 +8257,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
-    "@alauda/doom": "npm:^2.5.1"
+    "@alauda/doom": "npm:^2.5.2"
   languageName: unknown
   linkType: soft
 
@@ -9114,18 +9148,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript-eslint@npm:^8.59.3":
-  version: 8.59.3
-  resolution: "typescript-eslint@npm:8.59.3"
+"typescript-eslint@npm:^8.59.4":
+  version: 8.59.4
+  resolution: "typescript-eslint@npm:8.59.4"
   dependencies:
-    "@typescript-eslint/eslint-plugin": "npm:8.59.3"
-    "@typescript-eslint/parser": "npm:8.59.3"
-    "@typescript-eslint/typescript-estree": "npm:8.59.3"
-    "@typescript-eslint/utils": "npm:8.59.3"
+    "@typescript-eslint/eslint-plugin": "npm:8.59.4"
+    "@typescript-eslint/parser": "npm:8.59.4"
+    "@typescript-eslint/typescript-estree": "npm:8.59.4"
+    "@typescript-eslint/utils": "npm:8.59.4"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
     typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/7bd251921d583be5a29565118a5babc068e7c1e893d30a0dbea4215ed20cebcad186b419ba747e001b48339e18c4a2cf6c936e013a77b225692f7f48331839f6
+  checksum: 10c0/96241e50eac4e646e56b7950405aa861ff2f744e4268c98e240ee702db0b45463a1e9146f09fbc71bfd8dc53b2b3c43c2f1fab6a92154c7e1c2b7373bcd5c90e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Cherry-pick PR #98 from release-1.0 into master
- Update DCS persistent disk isThin guidance across DCS docs
- Keep @alauda/doom at ^2.5.2 and refresh yarn.lock for master

## Validation
- yarn install --immutable
- yarn build
- yarn lint
- git diff HEAD~1..HEAD --check

Cherry-picked-from: a4601c4d635d38592371cb3eb1cbb03ba6ebda57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Huawei DCS cluster creation and management guides with clarified persistent disk handling.
  * Clarified that thin-provisioning settings apply only to newly created volumes, not existing ones.
  * Updated guidance on persistent volume creation, reuse, and immutability constraints during rolling replacements.
  * Refined scaling and upgrade instructions to preserve persistent disk configurations.

* **Chores**
  * Updated development dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->