### PR TITLE
docs(AIT-65694): document DCS multi-NIC pool configuration

### DIFF
--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -27,7 +27,7 @@ Before creating clusters, ensure all of the following prerequisites are met:
 Configure the following infrastructure resources before creating a cluster:
 
 - **[Cloud Credential](../infrastructure/huawei-dcs.mdx#cloud-credentials)** - DCS platform access information
-- **[IP Pool](../infrastructure/huawei-dcs.mdx#ip-pools)** - Network configuration for cluster nodes and any IP-slot persistent disks such as `/var/cpaas`
+- **[IP Pool](../infrastructure/huawei-dcs.mdx#ip-pools)** - Network configuration for cluster nodes, additional NICs, and any IP-slot persistent disks such as `/var/cpaas`
 - **[Machine Template](../infrastructure/huawei-dcs.mdx#machine-templates)** - VM specifications for control plane and worker nodes, excluding pool-managed persistent disks
 
 See [Infrastructure Resources for Huawei DCS](../infrastructure/huawei-dcs.mdx) for detailed configuration instructions.
@@ -240,6 +240,8 @@ Follow these steps in order to provision a functional cluster (control plane **a
 
 If you need any disk to survive rolling replacement, declare it in the matching `DCSIpHostnamePool.spec.pool[].persistentDisk` entry. This includes the platform-required `/var/cpaas` disk. The provider creates new persistent volumes as independent persistent normal volumes. When the DCS environment requires an explicit thin-provisioning setting, set `persistentDisk[].isThin`; if you omit it, the provider does not send `isThin` and DCS uses the platform default.
 
+If the cluster needs additional NICs, declare them in `DCSIpHostnamePool.spec.pool[].additionNic[]` before the corresponding Machines are created. The provider applies additional NICs only during new VM creation. Existing VMs do not receive hot-added NICs when the Pool is edited later.
+
 ### Resolving Placeholder Values \{#resolving-placeholders}
 
 The example manifests below use `<placeholder>` syntax for values that are environment-specific. Several of these have a canonical source of truth that you should query rather than hand-pick:
@@ -274,6 +276,7 @@ Before creating control plane resources, plan the network architecture and deplo
 
 **Requirements**:
 - **Network segmentation**: Plan IP address ranges for control plane nodes
+- **Additional NICs**: If nodes require storage, management, or isolated application networks, plan `DCSIpHostnamePool.spec.pool[].additionNic[]` values for each IP slot, including DVS and Port Group names
 - **Load balancer**: Deploy and configure access to the API server
 - **API server address**: Prepare a stable VIP or load balancer address for the Kubernetes API Server
 - **Connectivity**: Ensure network connectivity between all components
@@ -524,6 +527,13 @@ kubectl get machines -n cpaas-system
 kubectl get clustermodule <cluster-name> -o jsonpath='{.status.base.deployStatus}'
 ```
 
+For clusters that use additional NICs, also verify that the provider recorded them on the matching `DCSMachine` objects:
+
+```bash
+kubectl -n cpaas-system get dcsmachine -l cluster.x-k8s.io/cluster-name=<cluster-name> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.networkConfig.ip}{"\t"}{.status.additionalNic}{"\n"}{end}'
+```
+
 ### Expected Results
 
 A successfully created cluster should show:
@@ -532,6 +542,7 @@ A successfully created cluster should show:
 - All worker nodes (if deployed): **Running**
 - Kubernetes nodes: **Ready**
 - Cluster Module Status: **Completed**
+- For multi-NIC clusters, each created VM has the expected additional NICs in `DCSMachine.status.additionalNic`, and the guest OS shows the corresponding `ethN` interfaces.
 
 ---
 

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -170,6 +170,8 @@ DCS Provider supports two credential user types, selected by the optional Secret
 
 IP pools define the network configuration (IP addresses, subnet masks, gateways, DNS) for cluster nodes. Each pool can contain multiple node entries, and each node can have multiple network interface configurations.
 
+For DCS multi-NIC clusters, each IP entry can declare `additionNic` items. These additional NICs are bound to the IP slot and are applied when the provider creates a new VM. Updating `additionNic` on an existing Pool does not hot-add NICs to already-running VMs.
+
 For DCS persistent disks, each IP entry can also declare `persistentDisk` items. These disks are bound to the IP slot instead of the VM lifecycle, so they can be detached from an old VM and reattached to a replacement VM during rolling upgrades. Use this mechanism for the platform-required `/var/cpaas` disk and for any other node-local data that must survive delete-recreate operations. Since DCS provider `v1.0.16`, this `persistentDisk` declaration is supported through YAML only.
 
 ### Using the Web UI
@@ -179,7 +181,7 @@ For DCS persistent disks, each IP entry can also declare `persistentDisk` items.
 - Cloud Credential has been created
 
 :::info
-Since DCS provider `v1.0.16`, the IP Pool web UI covers IP, hostname, and NIC settings only. It does not expose `DCSIpHostnamePool.spec.pool[].persistentDisk`. Configure persistent disks through YAML manifests.
+Since DCS provider `v1.0.16`, the IP Pool web UI covers standard IP, hostname, and network settings only. It does not expose `DCSIpHostnamePool.spec.pool[].persistentDisk`. Configure persistent disks through YAML manifests.
 :::
 
 #### Creating an IP Pool
@@ -227,7 +229,7 @@ The IP Pool form consists of a list of **Pools**. Each Pool represents one node 
 **Tips**:
 - At least one node entry is required
 - Exactly one Node IP configuration is required per node
-- Additional NIC IPs are optional for multi-NIC scenarios (e.g., storage network separation)
+- `additionNic[]` entries are optional for multi-NIC scenarios, such as storage network separation
 
 #### Managing IP Pools
 
@@ -255,6 +257,13 @@ spec:
     dns: "<dns>"
     hostname: "<hostname-1>"
     machineName: "<machine-name-1>"
+    additionNic:
+    - ip: "<additional-ip-1>"
+      mask: "<additional-mask>"
+      gateway: "<additional-gateway>"
+      dns: "<additional-dns>"
+      dvSwitchName: "<additional-dvs>"
+      portGroupName: "<additional-port-group>"
   - ip: "<ip-2>"
     mask: "<mask>"
     gateway: "<gateway>"
@@ -279,10 +288,40 @@ spec:
 | `.spec.pool[].dns` | string | DNS server IP (use ',' to separate multiple servers) | No |
 | `.spec.pool[].machineName` | string | Name of the virtual machine in the DCS platform | No |
 | `.spec.pool[].hostname` | string | Hostname of the virtual machine | No |
+| `.spec.pool[].additionNic[]` | []object | Additional NICs for the VM created from this IP slot. The provider applies them only when creating a new VM. | No |
+| `.spec.pool[].additionNic[].ip` | string | Additional NIC IP address for the generated guest network configuration. This is not the Kubernetes Node IP. | Recommended* |
+| `.spec.pool[].additionNic[].mask` | string | Additional NIC subnet mask for the generated guest network configuration. | Recommended* |
+| `.spec.pool[].additionNic[].gateway` | string | Gateway for the additional NIC network. Confirm route behavior before setting this value. | No |
+| `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by commas when multiple values are required. | No |
+| `.spec.pool[].additionNic[].dvSwitchName` | string | DCS distributed virtual switch used to resolve the Port Group for the additional NIC. | Yes* |
+| `.spec.pool[].additionNic[].portGroupName` | string | DCS Port Group used to attach the additional NIC. | Yes* |
+
+\*Fields marked `Yes*` are required for the provider to resolve the target network and attach the additional NIC. Fields marked `Recommended*` are needed for the generated static guest network configuration. The CRD does not enforce these fields.
 
 :::warning
 You must configure machine information for a number of machines greater than or equal to the number of nodes you plan to deploy. Insufficient entries will prevent node deployment.
 :::
+
+### Additional NICs in the IP Pool \{#additional-nics}
+
+Declare additional NICs in `DCSIpHostnamePool.spec.pool[].additionNic[]`.
+
+Use this field when a node needs a secondary network, such as a storage, management, or application-isolation network. Keep the primary `.spec.pool[].ip` as the Kubernetes Node IP unless you intentionally plan a Node IP change.
+
+**How it takes effect:**
+
+- The provider copies `additionNic[]` from the Pool slot into `DCSMachine.status.additionalNic` when a new `DCSMachine` claims that slot.
+- The provider adds those NICs when it clones the DCS VM.
+- The guest OS configures the interfaces during first boot through the generated NetworkManager configuration.
+- Existing VMs are not hot-updated when the Pool is edited later.
+
+**Network boundaries:**
+
+- The DCS provider does not reserve additional NIC IP addresses on the DCS platform. Avoid IP conflicts before applying the Pool.
+- The referenced DVS and Port Group must already exist, and the target DCS hosts must be able to access them.
+- Provide both `dvSwitchName` and `portGroupName` for each additional NIC. The provider uses them to resolve the Port Group URN before cloning the VM.
+- The provider models IP, mask, gateway, DNS, DVS, and Port Group only. Route metrics, static routes, and NIC roles must be handled through MCP or guest OS configuration.
+- If an additional NIC has a gateway, verify that it does not unexpectedly take over the default route from the primary NIC.
 
 ### Persistent Disks in the IP Pool
 

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -35,7 +35,7 @@ Worker nodes are managed through Cluster API `Machine` resources, providing decl
 
 ### Step 1: Configure IP-Hostname Pool
 
-The IP-Hostname Pool defines the network configuration for worker node virtual machines. You must plan and configure the IP addresses, hostnames, DNS servers, and other network parameters before deployment.
+The IP-Hostname Pool defines the network configuration for worker node virtual machines. You must plan and configure the IP addresses, hostnames, DNS servers, additional NICs, and other network parameters before deployment.
 
 On Huawei DCS, the IP pool is also where you declare persistent disks that must survive VM replacement. Use `persistentDisk` for the platform-required `/var/cpaas` disk and for any other worker-node disk that must be preserved during delete-recreate operations. This workflow requires DCS provider `v1.0.16` or later.
 
@@ -62,6 +62,13 @@ spec:
     dns: "<worker-dns>"
     hostname: "<worker-hostname-1>"
     machineName: "<worker-machine-name-1>"
+    additionNic:
+    - ip: "<worker-additional-ip-1>"
+      mask: "<worker-additional-mask>"
+      gateway: "<worker-additional-gateway>"
+      dns: "<worker-additional-dns>"
+      dvSwitchName: "<additional-dvs>"
+      portGroupName: "<additional-port-group>"
     persistentDisk:
     - slot: 0
       quantityGB: 40
@@ -104,7 +111,16 @@ spec:
 | `.spec.pool[].dns` | string | DNS server IP addresses (comma-separated for multiple) | No |
 | `.spec.pool[].machineName` | string | Virtual machine name in the DCS platform | No |
 | `.spec.pool[].hostname` | string | Hostname for the virtual machine | No |
+| `.spec.pool[].additionNic[]` | []object | Additional NICs bound to this IP slot. Use this for storage, management, or isolated application networks. | No |
+| `.spec.pool[].additionNic[].ip` | string | Additional NIC IP address for the generated guest network configuration. | Recommended* |
+| `.spec.pool[].additionNic[].mask` | string | Additional NIC subnet mask for the generated guest network configuration. | Recommended* |
+| `.spec.pool[].additionNic[].gateway` | string | Gateway for the additional NIC network. Confirm route behavior before setting this value. | No |
+| `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by commas when multiple values are required. | No |
+| `.spec.pool[].additionNic[].dvSwitchName` | string | DCS distributed virtual switch used to resolve the Port Group for the additional NIC. | Yes* |
+| `.spec.pool[].additionNic[].portGroupName` | string | DCS Port Group used to attach the additional NIC. | Yes* |
 | `.spec.pool[].persistentDisk[]` | []object | Persistent disks bound to this IP slot. Use this for `/var/cpaas` and any disk that must survive node replacement. | No |
+
+\*Fields marked `Yes*` are required for the provider to resolve the target network and attach the additional NIC. Fields marked `Recommended*` are needed for the generated static guest network configuration. The CRD does not enforce these fields.
 
 ### Step 2: Configure Machine Template
 
@@ -206,6 +222,24 @@ To inspect the runtime state of persistent disks during node operations, check `
 
 ```bash
 kubectl get dcsiphostnamepool <cluster-name>-worker-pool -n cpaas-system -o yaml
+```
+
+### Additional NICs Managed by the IP Pool
+
+Declare worker additional NICs in `DCSIpHostnamePool.spec.pool[].additionNic[]`.
+
+- The provider applies `additionNic[]` only when it creates a new VM.
+- Existing worker VMs are not hot-updated when you edit the Pool.
+- New worker Machines use the `additionNic[]` values from the Pool slot they claim.
+- Each additional NIC should include both `dvSwitchName` and `portGroupName` so the provider can resolve the target DCS Port Group before VM clone.
+- If you also use `persistentDisk[]`, keep `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0` so fixed IP slots and preserved disks move one node at a time.
+- If an additional NIC has a gateway, verify that the guest OS route table still prefers the intended primary network for the default route.
+
+To inspect the runtime state of additional NICs, check `DCSMachine.status.additionalNic`:
+
+```bash
+kubectl -n cpaas-system get dcsmachine -l cluster.x-k8s.io/cluster-name=<cluster-name> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.networkConfig.ip}{"\t"}{.status.additionalNic}{"\n"}{end}'
 ```
 
 ### Step 3: Configure Bootstrap Template

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -66,7 +66,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The target Kubernetes version is compatible with your workloads and add-ons
 - DCS VM templates are `4.2.1` or later if you use pool-managed persistent disks, because safe shutdown and disk detach depend on guest tools
 - If you rely on pool-managed persistent disks, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0`
-- If the cluster uses additional NICs, keep the required `DCSIpHostnamePool.spec.pool[].additionNic[]` entries in place and confirm that the DCS DVS / Port Groups are reachable from the hosts that may receive replacement VMs
+- If the cluster uses additional NICs, keep the required `DCSIpHostnamePool.spec.pool[].additionNic[]` entries in place and confirm that the DCS DVS and Port Groups are reachable from the hosts that may receive replacement VMs
 
 :::warning
 **Disk Preservation Model**

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -66,6 +66,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The target Kubernetes version is compatible with your workloads and add-ons
 - DCS VM templates are `4.2.1` or later if you use pool-managed persistent disks, because safe shutdown and disk detach depend on guest tools
 - If you rely on pool-managed persistent disks, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0`
+- If the cluster uses additional NICs, keep the required `DCSIpHostnamePool.spec.pool[].additionNic[]` entries in place and confirm that the DCS DVS / Port Groups are reachable from the hosts that may receive replacement VMs
 
 :::warning
 **Disk Preservation Model**
@@ -84,6 +85,12 @@ Upgrades rely on Cluster API's rolling update mechanism. Each cluster has four d
 Pool-managed preservation requires one-by-one replacement, so keep `maxSurge = 0` on both `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate` and `MachineDeployment.spec.strategy.rollingUpdate`.
 
 If your existing cluster still keeps preserved data in the old template-disk layout, migrate it first by following [Migrate Existing Huawei DCS Clusters to Pool-Managed Persistent Disks](../how-to/dcs_persistent_disk_upgrade.mdx).
+:::
+
+:::info
+**Additional NICs During Rolling Replacement**
+
+Additional NICs are declared in `DCSIpHostnamePool.spec.pool[].additionNic[]`, not in `DCSMachineTemplate`. During an upgrade, each replacement VM uses the additional NICs from the Pool slot it claims. The upgrade template steps below should not move additional NIC settings into `DCSMachineTemplate`.
 :::
 
 :::warning
@@ -141,7 +148,7 @@ Upgrading the control plane machine template lets you roll out updated VM specif
    - Strip server-generated metadata (`resourceVersion`, `uid`, `generation`, `creationTimestamp`, `managedFields`, `kubectl.kubernetes.io/last-applied-configuration` annotation) and the entire `status` field from the copied manifest.
    - Leave `spec.template.spec.providerID` unset. The DCS provider sets `providerID` to `dcs://<machine-name>` once the VM is created; pre-filling it in the template breaks the controller's identity binding.
 
-   Keep pool-managed persistent disks, including `/var/cpaas`, in `DCSIpHostnamePool.spec.pool[].persistentDisk`.
+   Keep pool-managed persistent disks, including `/var/cpaas`, in `DCSIpHostnamePool.spec.pool[].persistentDisk`. Keep additional NICs in `DCSIpHostnamePool.spec.pool[].additionNic[]`.
 
 3. **Apply the updated template**
 
@@ -174,7 +181,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
 1. **Create a new `DCSMachineTemplate` for the target Kubernetes version**
 
-   Copy the existing control-plane template and update `metadata.name` to a new name and `spec.template.spec.vmTemplateName` to the **Alauda OS Image Version** value read from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx). Keep pool-managed persistent disks in `DCSIpHostnamePool.spec.pool[].persistentDisk` rather than reintroducing them as template disks.
+   Copy the existing control-plane template and update `metadata.name` to a new name and `spec.template.spec.vmTemplateName` to the **Alauda OS Image Version** value read from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx). Keep pool-managed persistent disks in `DCSIpHostnamePool.spec.pool[].persistentDisk` and additional NICs in `DCSIpHostnamePool.spec.pool[].additionNic[]` rather than reintroducing them as template fields.
 
    ```bash
    kubectl get dcsmachinetemplate <current-cp-template-name> -n cpaas-system -o yaml > new-cp-template.yaml
@@ -275,6 +282,7 @@ Before you start, read the **Alauda OS Image Version** and **Kubernetes Version*
 1. **Create a new `DCSMachineTemplate` for worker nodes**
    - Create a new `DCSMachineTemplate` with a `vmTemplateName` set to the **Alauda OS Image Version** value from the target row in the [OS Support Matrix](../overview/os-support-matrix.mdx)
    - Keep `/var/cpaas` and any other upgrade-preserved disks in `DCSIpHostnamePool.spec.pool[].persistentDisk` rather than reintroducing them as template disks
+   - Keep additional NICs in `DCSIpHostnamePool.spec.pool[].additionNic[]`
 
 2. **Update the `MachineDeployment`**
    - Set `spec.template.spec.version` to the **Kubernetes Version** value from the same OS Support Matrix row

--- a/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsiphostnamepools.yaml
+++ b/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsiphostnamepools.yaml
@@ -109,6 +109,12 @@ spec:
                               is nil, the Ignition template falls back to ext4. Immutable after
                               creation.
                             type: string
+                          isThin:
+                            description: |-
+                              IsThin is creation-only: it is sent only when creating new DCS
+                              persistent volumes, and is not validated or reconciled for existing
+                              volumes. Nil keeps the platform default.
+                            type: boolean
                           mountOptions:
                             items:
                               type: string

--- a/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsmachines.yaml
+++ b/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsmachines.yaml
@@ -203,8 +203,12 @@ spec:
                 type: array
               cdRomDatastoreUrn:
                 type: string
+              cdRomDetached:
+                type: boolean
               cdRomFile:
                 type: string
+              cdRomFileDeleted:
+                type: boolean
               conditions:
                 description: Conditions provide observations of the operational state
                   of a Cluster API resource.


### PR DESCRIPTION
## Summary

本 PR 补充 Huawei DCS 多网卡能力在产品文档中的说明，范围限定为产品化 Pool 配置，不包含 S1 手工迁移方案。

主要内容：
- 在 DCS 创建集群、基础设施、节点管理和升级文档中补充 `DCSIpHostnamePool.spec.pool[].additionNic[]` 的使用说明。
- 说明 `additionNic[]` 只在 provider 创建新 VM 时生效，编辑 Pool 不会热更新已有 VM。
- 说明运行时可通过 `DCSMachine.status.additionalNic` 查看 provider 记录的附加网卡信息。
- 在升级文档中说明附加网卡配置应保留在 `DCSIpHostnamePool`，不要迁移到 `DCSMachineTemplate`。
- 同步 Huawei DCS shared CRD：补充 `persistentDisk[].isThin`、`DCSMachine.status.cdRomDetached`、`DCSMachine.status.cdRomFileDeleted`。

## Validation

- `git diff --check`
- Review 了 6 个变更文件的产品文档范围、字段说明、锚点引用和 shared CRD 与 provider `origin/release-1.0` 的一致性。
- 确认没有新增 S1 多网卡迁移 how-to 文档。
