### PR TITLE
docs(AIT-65694): fix DCS network parameter formats

### DIFF
--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -168,7 +168,7 @@ DCS Provider supports two credential user types, selected by the optional Secret
 
 ## IP Pools \{#ip-pools}
 
-IP pools define the network configuration (IP addresses, subnet masks, gateways, DNS) for cluster nodes. Each pool can contain multiple node entries, and each node can have multiple network interface configurations.
+IP pools define the network configuration (IP addresses, CIDR prefix lengths, gateways, DNS) for cluster nodes. Each pool can contain multiple node entries, and each node can have multiple network interface configurations.
 
 For DCS multi-NIC clusters, each IP entry can declare `additionNic` items. These additional NICs are bound to the IP slot and are applied when the provider creates a new VM. Updating `additionNic` on an existing Pool does not hot-add NICs to already-running VMs.
 
@@ -200,9 +200,9 @@ The IP Pool form consists of a list of **Pools**. Each Pool represents one node 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | IP | IP address | Yes | IP address for the Kubernetes Node |
-| Subnet Mask | CIDR | Yes | Subnet mask for the network |
+| Subnet Mask | CIDR prefix length | Yes | Network prefix length, for example `24` |
 | Gateway | IP address | Yes | Gateway IP address |
-| DNS | IP address | No | DNS server addresses (comma-separated for multiple) |
+| DNS | IP address | No | DNS server addresses (semicolon-separated for multiple) |
 | Hostname | text | No | Hostname for the virtual machine |
 | Machine Name | text | No | Virtual machine name in the DCS platform |
 | dvSwitch Name | dropdown | No | Virtual switch name (from DCS platform) |
@@ -213,16 +213,16 @@ The IP Pool form consists of a list of **Pools**. Each Pool represents one node 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | IP | IP address | Yes | Non-Node IP address (e.g., storage network) |
-| Subnet Mask | CIDR | Yes | Subnet mask for the network |
+| Subnet Mask | CIDR prefix length | Yes | Network prefix length, for example `24` |
 | Gateway | IP address | Yes | Gateway IP address |
-| DNS | IP address | No | DNS server addresses |
+| DNS | IP address | No | DNS server addresses (semicolon-separated for multiple) |
 | dvSwitch Name | dropdown | Yes | Virtual switch name (from DCS platform) |
 | Port Group Name | dropdown | Yes | Port group name (from DCS platform) |
 
 **Validation Rules**:
 - IP addresses must be unique within the same IP Pool
 - IP addresses must be valid IPv4 format
-- Subnet mask must be valid format
+- Mask must be a valid CIDR prefix length, such as `24`. Do not include `/` or use dotted-decimal format such as `255.255.255.0`.
 - IP address must be within the configured subnet range
 - Gateway must be a valid IPv4 address within the subnet range
 
@@ -252,26 +252,26 @@ metadata:
 spec:
   pool:
   - ip: "<ip-1>"
-    mask: "<mask>"
+    mask: "<cidr-prefix-length>"
     gateway: "<gateway>"
     dns: "<dns>"
     hostname: "<hostname-1>"
     machineName: "<machine-name-1>"
     additionNic:
     - ip: "<additional-ip-1>"
-      mask: "<additional-mask>"
+      mask: "<additional-cidr-prefix-length>"
       gateway: "<additional-gateway>"
       dns: "<additional-dns>"
       dvSwitchName: "<additional-dvs>"
       portGroupName: "<additional-port-group>"
   - ip: "<ip-2>"
-    mask: "<mask>"
+    mask: "<cidr-prefix-length>"
     gateway: "<gateway>"
     dns: "<dns>"
     hostname: "<hostname-2>"
     machineName: "<machine-name-2>"
   - ip: "<ip-3>"
-    mask: "<mask>"
+    mask: "<cidr-prefix-length>"
     gateway: "<gateway>"
     dns: "<dns>"
     hostname: "<hostname-3>"
@@ -283,16 +283,16 @@ spec:
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | `.spec.pool[].ip` | string | IP address for the virtual machine to be created | Yes |
-| `.spec.pool[].mask` | string | Subnet mask | Yes |
+| `.spec.pool[].mask` | string | CIDR prefix length without `/`, for example `24` | Yes |
 | `.spec.pool[].gateway` | string | Gateway IP address | Yes |
-| `.spec.pool[].dns` | string | DNS server IP (use ',' to separate multiple servers) | No |
+| `.spec.pool[].dns` | string | DNS server IPs (use `;` to separate multiple servers) | No |
 | `.spec.pool[].machineName` | string | Name of the virtual machine in the DCS platform | No |
 | `.spec.pool[].hostname` | string | Hostname of the virtual machine | No |
 | `.spec.pool[].additionNic[]` | []object | Additional NICs for the VM created from this IP slot. The provider applies them only when creating a new VM. | No |
 | `.spec.pool[].additionNic[].ip` | string | Additional NIC IP address for the generated guest network configuration. This is not the Kubernetes Node IP. | Recommended* |
-| `.spec.pool[].additionNic[].mask` | string | Additional NIC subnet mask for the generated guest network configuration. | Recommended* |
+| `.spec.pool[].additionNic[].mask` | string | Additional NIC CIDR prefix length without `/`, for example `24`. | Recommended* |
 | `.spec.pool[].additionNic[].gateway` | string | Gateway for the additional NIC network. Confirm route behavior before setting this value. | No |
-| `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by commas when multiple values are required. | No |
+| `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by semicolons when multiple values are required. | No |
 | `.spec.pool[].additionNic[].dvSwitchName` | string | DCS distributed virtual switch used to resolve the Port Group for the additional NIC. | Yes* |
 | `.spec.pool[].additionNic[].portGroupName` | string | DCS Port Group used to attach the additional NIC. | Yes* |
 
@@ -348,7 +348,7 @@ metadata:
 spec:
   pool:
   - ip: "<ip-1>"
-    mask: "<mask>"
+    mask: "<cidr-prefix-length>"
     gateway: "<gateway>"
     dns: "<dns>"
     hostname: "<hostname-1>"

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -168,7 +168,7 @@ DCS Provider supports two credential user types, selected by the optional Secret
 
 ## IP Pools \{#ip-pools}
 
-IP pools define the network configuration (IP addresses, CIDR prefix lengths, gateways, DNS) for cluster nodes. Each pool can contain multiple node entries, and each node can have multiple network interface configurations.
+IP pools define the network configuration (IP addresses, subnet masks, gateways, DNS) for cluster nodes. Each pool can contain multiple node entries, and each node can have multiple network interface configurations.
 
 For DCS multi-NIC clusters, each IP entry can declare `additionNic` items. These additional NICs are bound to the IP slot and are applied when the provider creates a new VM. Updating `additionNic` on an existing Pool does not hot-add NICs to already-running VMs.
 
@@ -200,7 +200,7 @@ The IP Pool form consists of a list of **Pools**. Each Pool represents one node 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | IP | IP address | Yes | IP address for the Kubernetes Node |
-| Subnet Mask | CIDR prefix length | Yes | Network prefix length, for example `24` |
+| Subnet Mask | CIDR prefix length | Yes | Subnet mask for the network, entered as a prefix length such as `24` |
 | Gateway | IP address | Yes | Gateway IP address |
 | DNS | IP address | No | DNS server addresses (semicolon-separated for multiple) |
 | Hostname | text | No | Hostname for the virtual machine |
@@ -213,7 +213,7 @@ The IP Pool form consists of a list of **Pools**. Each Pool represents one node 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | IP | IP address | Yes | Non-Node IP address (e.g., storage network) |
-| Subnet Mask | CIDR prefix length | Yes | Network prefix length, for example `24` |
+| Subnet Mask | CIDR prefix length | Yes | Subnet mask for the network, entered as a prefix length such as `24` |
 | Gateway | IP address | Yes | Gateway IP address |
 | DNS | IP address | No | DNS server addresses (semicolon-separated for multiple) |
 | dvSwitch Name | dropdown | Yes | Virtual switch name (from DCS platform) |
@@ -222,7 +222,7 @@ The IP Pool form consists of a list of **Pools**. Each Pool represents one node 
 **Validation Rules**:
 - IP addresses must be unique within the same IP Pool
 - IP addresses must be valid IPv4 format
-- Mask must be a valid CIDR prefix length, such as `24`. Do not include `/` or use dotted-decimal format such as `255.255.255.0`.
+- Subnet mask must be entered as a valid CIDR prefix length, such as `24`. Do not include `/` or use dotted-decimal format such as `255.255.255.0`.
 - IP address must be within the configured subnet range
 - Gateway must be a valid IPv4 address within the subnet range
 
@@ -283,14 +283,14 @@ spec:
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | `.spec.pool[].ip` | string | IP address for the virtual machine to be created | Yes |
-| `.spec.pool[].mask` | string | CIDR prefix length without `/`, for example `24` | Yes |
+| `.spec.pool[].mask` | string | Subnet mask in CIDR prefix-length format without `/`, for example `24` | Yes |
 | `.spec.pool[].gateway` | string | Gateway IP address | Yes |
 | `.spec.pool[].dns` | string | DNS server IPs (use `;` to separate multiple servers) | No |
 | `.spec.pool[].machineName` | string | Name of the virtual machine in the DCS platform | No |
 | `.spec.pool[].hostname` | string | Hostname of the virtual machine | No |
 | `.spec.pool[].additionNic[]` | []object | Additional NICs for the VM created from this IP slot. The provider applies them only when creating a new VM. | No |
 | `.spec.pool[].additionNic[].ip` | string | Additional NIC IP address for the generated guest network configuration. This is not the Kubernetes Node IP. | Recommended* |
-| `.spec.pool[].additionNic[].mask` | string | Additional NIC CIDR prefix length without `/`, for example `24`. | Recommended* |
+| `.spec.pool[].additionNic[].mask` | string | Additional NIC subnet mask in CIDR prefix-length format without `/`, for example `24`. | Recommended* |
 | `.spec.pool[].additionNic[].gateway` | string | Gateway for the additional NIC network. Confirm route behavior before setting this value. | No |
 | `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by semicolons when multiple values are required. | No |
 | `.spec.pool[].additionNic[].dvSwitchName` | string | DCS distributed virtual switch used to resolve the Port Group for the additional NIC. | Yes* |

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -106,14 +106,14 @@ spec:
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | `.spec.pool[].ip` | string | IP address for the worker virtual machine | Yes |
-| `.spec.pool[].mask` | string | CIDR prefix length without `/`, for example `24` | Yes |
+| `.spec.pool[].mask` | string | Subnet mask in CIDR prefix-length format without `/`, for example `24` | Yes |
 | `.spec.pool[].gateway` | string | Gateway IP address | Yes |
 | `.spec.pool[].dns` | string | DNS server IP addresses (semicolon-separated for multiple) | No |
 | `.spec.pool[].machineName` | string | Virtual machine name in the DCS platform | No |
 | `.spec.pool[].hostname` | string | Hostname for the virtual machine | No |
 | `.spec.pool[].additionNic[]` | []object | Additional NICs bound to this IP slot. Use this for storage, management, or isolated application networks. | No |
 | `.spec.pool[].additionNic[].ip` | string | Additional NIC IP address for the generated guest network configuration. | Recommended* |
-| `.spec.pool[].additionNic[].mask` | string | Additional NIC CIDR prefix length without `/`, for example `24`. | Recommended* |
+| `.spec.pool[].additionNic[].mask` | string | Additional NIC subnet mask in CIDR prefix-length format without `/`, for example `24`. | Recommended* |
 | `.spec.pool[].additionNic[].gateway` | string | Gateway for the additional NIC network. Confirm route behavior before setting this value. | No |
 | `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by semicolons when multiple values are required. | No |
 | `.spec.pool[].additionNic[].dvSwitchName` | string | DCS distributed virtual switch used to resolve the Port Group for the additional NIC. | Yes* |

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -57,14 +57,14 @@ metadata:
 spec:
   pool:
   - ip: "<worker-ip-1>"
-    mask: "<worker-mask>"
+    mask: "<worker-cidr-prefix-length>"
     gateway: "<worker-gateway>"
     dns: "<worker-dns>"
     hostname: "<worker-hostname-1>"
     machineName: "<worker-machine-name-1>"
     additionNic:
     - ip: "<worker-additional-ip-1>"
-      mask: "<worker-additional-mask>"
+      mask: "<worker-additional-cidr-prefix-length>"
       gateway: "<worker-additional-gateway>"
       dns: "<worker-additional-dns>"
       dvSwitchName: "<additional-dvs>"
@@ -76,7 +76,7 @@ spec:
       path: /var/cpaas
       format: xfs
   - ip: "<worker-ip-2>"
-    mask: "<worker-mask>"
+    mask: "<worker-cidr-prefix-length>"
     gateway: "<worker-gateway>"
     dns: "<worker-dns>"
     hostname: "<worker-hostname-2>"
@@ -88,7 +88,7 @@ spec:
       path: /var/cpaas
       format: xfs
   - ip: "<worker-ip-3>"
-    mask: "<worker-mask>"
+    mask: "<worker-cidr-prefix-length>"
     gateway: "<worker-gateway>"
     dns: "<worker-dns>"
     hostname: "<worker-hostname-3>"
@@ -106,16 +106,16 @@ spec:
 | Parameter | Type | Description | Required |
 |-----------|------|-------------|----------|
 | `.spec.pool[].ip` | string | IP address for the worker virtual machine | Yes |
-| `.spec.pool[].mask` | string | Subnet mask for the network | Yes |
+| `.spec.pool[].mask` | string | CIDR prefix length without `/`, for example `24` | Yes |
 | `.spec.pool[].gateway` | string | Gateway IP address | Yes |
-| `.spec.pool[].dns` | string | DNS server IP addresses (comma-separated for multiple) | No |
+| `.spec.pool[].dns` | string | DNS server IP addresses (semicolon-separated for multiple) | No |
 | `.spec.pool[].machineName` | string | Virtual machine name in the DCS platform | No |
 | `.spec.pool[].hostname` | string | Hostname for the virtual machine | No |
 | `.spec.pool[].additionNic[]` | []object | Additional NICs bound to this IP slot. Use this for storage, management, or isolated application networks. | No |
 | `.spec.pool[].additionNic[].ip` | string | Additional NIC IP address for the generated guest network configuration. | Recommended* |
-| `.spec.pool[].additionNic[].mask` | string | Additional NIC subnet mask for the generated guest network configuration. | Recommended* |
+| `.spec.pool[].additionNic[].mask` | string | Additional NIC CIDR prefix length without `/`, for example `24`. | Recommended* |
 | `.spec.pool[].additionNic[].gateway` | string | Gateway for the additional NIC network. Confirm route behavior before setting this value. | No |
-| `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by commas when multiple values are required. | No |
+| `.spec.pool[].additionNic[].dns` | string | DNS server IPs for the additional NIC network, separated by semicolons when multiple values are required. | No |
 | `.spec.pool[].additionNic[].dvSwitchName` | string | DCS distributed virtual switch used to resolve the Port Group for the additional NIC. | Yes* |
 | `.spec.pool[].additionNic[].portGroupName` | string | DCS Port Group used to attach the additional NIC. | Yes* |
 | `.spec.pool[].persistentDisk[]` | []object | Persistent disks bound to this IP slot. Use this for `/var/cpaas` and any disk that must survive node replacement. | No |
@@ -443,7 +443,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
        "pool": [
          {
            "ip": "<existing-ip-1>",
-           "mask": "<worker-mask>",
+           "mask": "<worker-cidr-prefix-length>",
            "gateway": "<worker-gateway>",
            "dns": "<worker-dns>",
            "hostname": "<existing-hostname-1>",
@@ -460,7 +460,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "<existing-ip-2>",
-           "mask": "<worker-mask>",
+           "mask": "<worker-cidr-prefix-length>",
            "gateway": "<worker-gateway>",
            "dns": "<worker-dns>",
            "hostname": "<existing-hostname-2>",
@@ -477,7 +477,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "<new-worker-ip-1>",
-           "mask": "<worker-mask>",
+           "mask": "<worker-cidr-prefix-length>",
            "gateway": "<worker-gateway>",
            "dns": "<worker-dns>",
            "hostname": "<new-worker-hostname-1>",
@@ -494,7 +494,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "<new-worker-ip-2>",
-           "mask": "<worker-mask>",
+           "mask": "<worker-cidr-prefix-length>",
            "gateway": "<worker-gateway>",
            "dns": "<worker-dns>",
            "hostname": "<new-worker-hostname-2>",
@@ -535,7 +535,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
        "pool": [
          {
            "ip": "10.0.1.11",
-           "mask": "255.255.255.0",
+           "mask": "24",
            "gateway": "10.0.1.1",
            "dns": "10.0.0.2",
            "hostname": "worker-node-1",
@@ -552,7 +552,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "10.0.1.12",
-           "mask": "255.255.255.0",
+           "mask": "24",
            "gateway": "10.0.1.1",
            "dns": "10.0.0.2",
            "hostname": "worker-node-2",
@@ -569,7 +569,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "10.0.1.13",
-           "mask": "255.255.255.0",
+           "mask": "24",
            "gateway": "10.0.1.1",
            "dns": "10.0.0.2",
            "hostname": "worker-node-3",
@@ -586,7 +586,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "10.0.1.14",
-           "mask": "255.255.255.0",
+           "mask": "24",
            "gateway": "10.0.1.1",
            "dns": "10.0.0.2",
            "hostname": "worker-node-4",
@@ -603,7 +603,7 @@ Increase the number of worker nodes to handle increased workload or add new capa
          },
          {
            "ip": "10.0.1.15",
-           "mask": "255.255.255.0",
+           "mask": "24",
            "gateway": "10.0.1.1",
            "dns": "10.0.0.2",
            "hostname": "worker-node-5",


### PR DESCRIPTION
## Summary

- Update DCS IP pool DNS documentation to use semicolon-separated values, matching provider behavior.
- Clarify that DCS IP pool `mask` uses CIDR prefix length without `/`, for example `24`.
- Fix worker pool examples that previously used dotted-decimal masks such as `255.255.255.0`.

## Validation

- `git diff --check`
