### PR TITLE
docs: clarify global immutable-OS install (kubeadm config source, boot SSH key, bootstrap teardown)

### DIFF
--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -904,7 +904,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DCSMachineTemplate
-      name: global-master-template
+      name: global-cp-template
   kubeadmConfigSpec:
     format: ignition
     clusterConfiguration:
@@ -1005,7 +1005,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: VSphereMachineTemplate
-      name: global-master-machine-template
+      name: global-cp-machine-template
   kubeadmConfigSpec:
     format: cloud-init
     clusterConfiguration:
@@ -1102,7 +1102,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: HCSMachineTemplate
-      name: global-master-machine-template
+      name: global-cp-machine-template
   kubeadmConfigSpec:
     format: cloud-init
     clusterConfiguration:
@@ -2205,21 +2205,21 @@ stringData:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DCSIpHostnamePool
 metadata:
-  name: global-master-pool
+  name: global-cp-pool
   namespace: cpaas-system
   labels:
     cpaas.io/cluster-name: "global"
 spec:
   pool:
-  - {ip: "192.0.2.11", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-master-1", machineName: "global-master-1"}
-  - {ip: "192.0.2.12", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-master-2", machineName: "global-master-2"}
-  - {ip: "192.0.2.13", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-master-3", machineName: "global-master-3"}
+  - {ip: "192.0.2.11", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-cp-1", machineName: "global-cp-1"}
+  - {ip: "192.0.2.12", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-cp-2", machineName: "global-cp-2"}
+  - {ip: "192.0.2.13", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-cp-3", machineName: "global-cp-3"}
 ---
 # 3. Control-plane VM spec.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: DCSMachineTemplate
 metadata:
-  name: global-master-template
+  name: global-cp-template
   namespace: cpaas-system
   labels:
     cpaas.io/cluster-name: "global"
@@ -2246,7 +2246,7 @@ spec:
         # so it survives node replacement (see Infrastructure Resources).
         - {quantity: 100, datastoreName: <datastore-name>, path: /var/cpaas,          format: xfs}
       ipHostPoolRef:
-        name: global-master-pool
+        name: global-cp-pool
 ---
 # 4. Control plane.
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
@@ -2270,7 +2270,7 @@ spec:
     infrastructureRef:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: DCSMachineTemplate
-      name: global-master-template
+      name: global-cp-template
   kubeadmConfigSpec:
     format: ignition
     users:
@@ -2326,7 +2326,7 @@ spec:
       patches: {directory: /etc/kubernetes/patches}
       nodeRegistration:
         kubeletExtraArgs:
-          node-labels: "kube-ovn/role=master"
+          node-labels: "kube-ovn/role=master"   # kube-ovn-recognized role value; do not rename
           provider-id: PROVIDER_ID
           volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
           protect-kernel-defaults: "true"
@@ -2334,7 +2334,7 @@ spec:
       patches: {directory: /etc/kubernetes/patches}
       nodeRegistration:
         kubeletExtraArgs:
-          node-labels: "kube-ovn/role=master"
+          node-labels: "kube-ovn/role=master"   # kube-ovn-recognized role value; do not rename
           provider-id: PROVIDER_ID
           volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
           protect-kernel-defaults: "true"

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -849,7 +849,7 @@ Use the DCS resource fields from [Creating Clusters on Huawei DCS](../create-clu
 - Use concrete `datastoreName` values for DCS local storage unless you have verified that the selected datastore cluster can place volumes on hosts that can run the target VM.
 
 <Directive type="warning" title="Fragment Scope">
-  The following YAML is a differential fragment, not a complete manifest that you can apply directly. Merge these `global`-specific changes into the manifest that you prepare from the DCS create-cluster references, then apply the complete manifest file.
+  The following YAML is a differential fragment, not a complete manifest that you can apply directly. Merge these `global`-specific changes into the manifest that you prepare from the DCS create-cluster references, then apply the complete manifest file. If you would rather start from a complete file, adapt the [Worked Example: Complete `global` Manifest for Huawei DCS](#dcs-worked-example) at the end of this page instead of assembling it from fragments.
 </Directive>
 
 The following fragment shows the `global`-specific Cluster API wiring. Fill the provider resource fields by using the DCS create-cluster references above.
@@ -2177,3 +2177,227 @@ After the installer reports success, the `global` cluster runs its own Cluster A
 - Configure infrastructure resources for workload clusters: see [Infrastructure Resources](../infrastructure/index.mdx).
 - Create your first workload cluster: see [Creating Clusters](../create-cluster/index.mdx).
 - Plan disaster recovery: see [Global Cluster Disaster Recovery](./disaster_recovery.mdx).
+
+## Worked Example: Complete `global` Manifest for Huawei DCS \{#dcs-worked-example}
+
+This is a complete, single-file manifest for a three-replica control-plane `global` cluster on Huawei DCS. It is the same set of resources described in [Step 4](#step-4--configure-the-provider-specific-global-manifest), already assembled so you do not have to merge fragments across pages. It uses documentation-only example values: replace every `<placeholder>`, and reuse the `${...}` variables you exported in [Step 1](#step-1--prepare-common-variables). Apply it in [Step 5](#step-5--apply-the-global-manifest).
+
+This example targets a non-DR cluster. The three large kubeadm files (the PodSecurity admission config, the kubelet patch, and the audit policy) are identical to a workload cluster, so they are pulled from the `dcs-kubernetes-<major.minor>-files` Secret shipped by the DCS provider plugin. If that Secret is not present on the bootstrap cluster, inline the file contents from the [Complete KubeadmControlPlane Configuration](../create-cluster/huawei-dcs.mdx#complete-kubeadmcontrolplane-configuration) appendix instead.
+
+```yaml
+---
+# 1. DCS API credential. See Infrastructure Resources for the field sources.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: global-secret
+  namespace: cpaas-system
+  labels:
+    cpaas.io/cluster-name: "global"
+type: Opaque
+stringData:
+  authUser: "<dcs-api-user>"
+  authKey: "<dcs-api-password>"
+  endpoint: "https://<dcs-api-host>:7443"
+  # userType: "interconnect"   # optional; "interconnect" (default) or "domain"
+---
+# 2. Control-plane IP / hostname pool (one entry per control-plane replica).
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DCSIpHostnamePool
+metadata:
+  name: global-master-pool
+  namespace: cpaas-system
+  labels:
+    cpaas.io/cluster-name: "global"
+spec:
+  pool:
+  - {ip: "192.0.2.11", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-master-1", machineName: "global-master-1"}
+  - {ip: "192.0.2.12", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-master-2", machineName: "global-master-2"}
+  - {ip: "192.0.2.13", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-master-3", machineName: "global-master-3"}
+---
+# 3. Control-plane VM spec.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DCSMachineTemplate
+metadata:
+  name: global-master-template
+  namespace: cpaas-system
+  labels:
+    cpaas.io/cluster-name: "global"
+spec:
+  template:
+    spec:
+      vmTemplateName: <vm-template-name>
+      # Places the cloned VMs in a DCS compute cluster.
+      resource:
+        type: cluster
+        name: <dcs-cluster-name>
+      vmConfig:
+        dvSwitchName: <dvswitch-name>
+        portGroupName: <port-group-name>
+        dcsMachineCpuSpec: {quantity: 16}
+        dcsMachineMemorySpec: {quantity: 32768}   # MB
+        dcsMachineDiskSpec:
+        - {quantity: 0,   datastoreName: <datastore-name>, systemVolume: true}
+        - {quantity: 10,  datastoreName: <datastore-name>, path: /var/lib/etcd,       format: xfs}
+        - {quantity: 100, datastoreName: <datastore-name>, path: /var/lib/kubelet,    format: xfs}
+        - {quantity: 100, datastoreName: <datastore-name>, path: /var/lib/containerd, format: xfs}
+        # This example keeps /var/cpaas as a template disk for simplicity. For
+        # production, declare it in DCSIpHostnamePool.spec.pool[].persistentDisk
+        # so it survives node replacement (see Infrastructure Resources).
+        - {quantity: 100, datastoreName: <datastore-name>, path: /var/cpaas,          format: xfs}
+      ipHostPoolRef:
+        name: global-master-pool
+---
+# 4. Control plane.
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  name: global-kcp
+  namespace: cpaas-system
+  labels:
+    cpaas.io/cluster-name: "global"
+  annotations:
+    controlplane.cluster.x-k8s.io/skip-kube-proxy: ""
+spec:
+  replicas: 3
+  version: ${K8S_VERSION}
+  rolloutStrategy:
+    type: RollingUpdate
+    rollingUpdate: {maxSurge: 0}
+  machineTemplate:
+    nodeDrainTimeout: 1m
+    nodeDeletionTimeout: 5m
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: DCSMachineTemplate
+      name: global-master-template
+  kubeadmConfigSpec:
+    format: ignition
+    users:
+    - name: boot
+      sshAuthorizedKeys:
+      - "ssh-ed25519 AAAA...replace-with-your-public-key... global-boot"
+    files:
+    - contentFrom: {secret: {name: dcs-kubernetes-<major.minor>-files, key: psa-config.yaml}}
+      path: /etc/kubernetes/admission/psa-config.yaml
+      owner: "root:root"
+      permissions: "0644"
+    - contentFrom: {secret: {name: dcs-kubernetes-<major.minor>-files, key: control-plane-kubelet-patch.json}}
+      path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
+      owner: "root:root"
+      permissions: "0644"
+    - contentFrom: {secret: {name: dcs-kubernetes-<major.minor>-files, key: audit-policy.yaml}}
+      path: /etc/kubernetes/audit/policy.yaml
+      owner: "root:root"
+      permissions: "0644"
+    preKubeadmCommands:
+    - while ! ip route | grep -q "default via"; do sleep 1; done; echo "NetworkManager started"
+    - mkdir -p /run/cluster-api && restorecon -Rv /run/cluster-api
+    - if [ -f /etc/disk-setup.sh ]; then bash /etc/disk-setup.sh; fi
+    postKubeadmCommands:
+    - chmod 600 /var/lib/kubelet/config.yaml
+    clusterConfiguration:
+      imageRepository: cloud.alauda.io/alauda
+      dns: {imageTag: <dns-image-tag>}
+      etcd:
+        local:
+          imageTag: <etcd-image-tag>
+          serverCertSANs: ["${CONTROL_PLANE_VIP}", "etcd.kube-system"]
+      apiServer:
+        extraArgs:
+          audit-log-format: json
+          audit-log-maxage: "30"
+          audit-log-maxbackup: "10"
+          audit-log-maxsize: "200"
+          audit-log-mode: batch
+          audit-log-path: /etc/kubernetes/audit/audit.log
+          audit-policy-file: /etc/kubernetes/audit/policy.yaml
+          admission-control-config-file: /etc/kubernetes/admission/psa-config.yaml
+          profiling: "false"
+          tls-min-version: VersionTLS12
+          kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
+        extraVolumes:
+        - {name: vol-dir-0, hostPath: /etc/kubernetes, mountPath: /etc/kubernetes, pathType: Directory}
+      controllerManager:
+        extraArgs: {bind-address: "::", profiling: "false", tls-min-version: VersionTLS12, flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"}
+      scheduler:
+        extraArgs: {bind-address: "::", tls-min-version: VersionTLS12, profiling: "false"}
+    initConfiguration:
+      patches: {directory: /etc/kubernetes/patches}
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-labels: "kube-ovn/role=master"
+          provider-id: PROVIDER_ID
+          volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+          protect-kernel-defaults: "true"
+    joinConfiguration:
+      patches: {directory: /etc/kubernetes/patches}
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-labels: "kube-ovn/role=master"
+          provider-id: PROVIDER_ID
+          volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+          protect-kernel-defaults: "true"
+---
+# 5. DCS infrastructure cluster.
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: DCSCluster
+metadata:
+  name: "global"
+  namespace: cpaas-system
+  labels:
+    cpaas.io/cluster-name: "global"
+  annotations:
+    cpaas.io/registry-address: "${NODE_REGISTRY_ADDRESS}"
+spec:
+  controlPlaneLoadBalancer: {host: "${CONTROL_PLANE_VIP}", port: 6443, type: external}
+  controlPlaneEndpoint: {host: "${CONTROL_PLANE_VIP}", port: 6443}
+  credentialSecretRef: {name: global-secret}
+  networkType: kube-ovn
+  site: <dcs-site-id>
+---
+# 6. Top-level CAPI Cluster: global wiring, labels, and annotations.
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: global
+  namespace: cpaas-system
+  labels:
+    cpaas.io/cluster-name: "global"
+    cluster-type: DCS
+    is-global: "true"
+  annotations:
+    capi.cpaas.io/resource-group-version: infrastructure.cluster.x-k8s.io/v1beta1
+    capi.cpaas.io/resource-kind: DCSCluster
+    cpaas.io/registry-address: "${NODE_REGISTRY_ADDRESS}"
+    cpaas.io/kube-ovn-join-cidr: 100.5.0.0/16
+    cpaas.io/kube-ovn-version: <kube-ovn-chart-version>
+    cpaas.io/os-family: <os-family>   # OS family of the Alauda OS image, for example slemicro
+spec:
+  clusterNetwork:
+    pods:     {cidrBlocks: ["${CLUSTER_CIDR}"]}
+    services: {cidrBlocks: ["${SERVICE_CIDR}"]}
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: global-kcp
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: DCSCluster
+    name: global
+```
+
+### Values to Replace \{#dcs-worked-example-values}
+
+| Placeholder / variable | Where it comes from |
+|---|---|
+| `${K8S_VERSION}`, `${CONTROL_PLANE_VIP}`, `${NODE_REGISTRY_ADDRESS}`, `${CLUSTER_CIDR}`, `${SERVICE_CIDR}` | Exported in [Step 1](#step-1--prepare-common-variables). |
+| `<dcs-api-user>` / `<dcs-api-password>` / `<dcs-api-host>` / `<dcs-site-id>` | DCS platform credentials and site. See [Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials). |
+| `<vm-template-name>`, `<dns-image-tag>`, `<etcd-image-tag>` | The `cpaas.io/dcs-vm-template` ConfigMap. See [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders). |
+| `<dcs-cluster-name>`, `<dvswitch-name>`, `<port-group-name>`, `<datastore-name>` | DCS platform objects. Confirm with the DCS administrator. |
+| `192.0.2.x`, `<os-family>`, `<kube-ovn-chart-version>` | Node IPs/gateway/DNS for your network; the OS family of the image; and the kube-ovn chart version from the [OS Support Matrix](../overview/os-support-matrix.mdx). |
+| `ssh-ed25519 AAAA...` | A real OpenSSH public key. The `ignition` format rejects an empty list; supply any valid key even if you do not plan to SSH in. |
+
+<Directive type="info" title="Secret encryption and disaster recovery">
+  This example does not enable etcd secret encryption-at-rest. To enable it, or to deploy a DR pair, add the `/etc/kubernetes/encryption-provider.conf` file and the `apiServer.extraArgs.encryption-provider-config` argument as described in [Optional Disaster Recovery Deployment](#optional-disaster-recovery-deployment).
+</Directive>

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -1811,7 +1811,6 @@ kubectl --kubeconfig <global-kubeconfig> get clustermodule global
 |---|---|---|
 | Machines stay in `Pending` or do not appear | `kubectl describe machine -n cpaas-system <machine>` | The provider-specific failure reason on the machine `Bootstrap` and `Infrastructure` conditions. IaaS quota, network, and credential issues surface here. |
 | `KubeadmControlPlane` does not reach `Ready` | `kubectl get nodes` with the new cluster kubeconfig and `kubectl describe kubeadmcontrolplane -n cpaas-system` | etcd health on the first control plane node and join progress for the remaining nodes. |
-| `KubeadmControlPlane` stays not `Ready` (often `EtcdClusterHealthy=Unknown`) and the installer hangs, even though the control-plane VMs are up, and the bootstrap (KIND) Pods cannot reach the control-plane subnet | NAT rules on the bootstrap (KIND) host | Stopping the host firewall after KIND started can flush the KIND bridge's SNAT masquerade, so the CAPI controller Pods running in KIND cannot route to the new control-plane subnet. Re-add it: `iptables -t nat -A POSTROUTING -s 172.18.0.0/16 ! -d 172.18.0.0/16 -j MASQUERADE` (`172.18.0.0/16` is the default KIND subnet). |
 | Pods in `kube-system` stay `Pending` or fail to pull images | `kubectl --kubeconfig <global-kubeconfig> describe pod -n kube-system <pod>` | Image pull errors usually mean the node-facing registry address is not reachable from the new cluster's subnet. |
 | Installer progress API shows a stalled stage | `/var/cpaas/data/installer.log` | The most recent phase line and the most recent error message. Retried errors repeat on a short interval; persistent errors do not advance. |
 | `ClusterModule/global` does not reach a healthy phase | `kubectl --kubeconfig <global-kubeconfig> describe clustermodule global` | The `Status.conditions` describe which module is blocking the cluster from completing. |
@@ -2216,9 +2215,33 @@ metadata:
     cpaas.io/cluster-name: "global"
 spec:
   pool:
-  - {ip: "192.0.2.11", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-cp-1", machineName: "global-cp-1"}
-  - {ip: "192.0.2.12", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-cp-2", machineName: "global-cp-2"}
-  - {ip: "192.0.2.13", mask: "24", gateway: "192.0.2.1", dns: "192.0.2.2", hostname: "global-cp-3", machineName: "global-cp-3"}
+  # /var/cpaas holds platform state and must survive node replacement, so it is
+  # declared here as a persistentDisk bound to the IP slot (not as a
+  # DCSMachineTemplate disk). Requires a DCS VM template 4.2.1+ and maxSurge: 0.
+  - ip: "192.0.2.11"
+    mask: "24"
+    gateway: "192.0.2.1"
+    dns: "192.0.2.2"
+    hostname: "global-cp-1"
+    machineName: "global-cp-1"
+    persistentDisk:
+    - {slot: 0, quantityGB: 100, datastoreName: <datastore-name>, path: /var/cpaas, format: xfs, mountOptions: [defaults]}
+  - ip: "192.0.2.12"
+    mask: "24"
+    gateway: "192.0.2.1"
+    dns: "192.0.2.2"
+    hostname: "global-cp-2"
+    machineName: "global-cp-2"
+    persistentDisk:
+    - {slot: 0, quantityGB: 100, datastoreName: <datastore-name>, path: /var/cpaas, format: xfs, mountOptions: [defaults]}
+  - ip: "192.0.2.13"
+    mask: "24"
+    gateway: "192.0.2.1"
+    dns: "192.0.2.2"
+    hostname: "global-cp-3"
+    machineName: "global-cp-3"
+    persistentDisk:
+    - {slot: 0, quantityGB: 100, datastoreName: <datastore-name>, path: /var/cpaas, format: xfs, mountOptions: [defaults]}
 ---
 # 3. Control-plane VM spec.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -2246,10 +2269,8 @@ spec:
         - {quantity: 10,  datastoreName: <datastore-name>, path: /var/lib/etcd,       format: xfs}
         - {quantity: 100, datastoreName: <datastore-name>, path: /var/lib/kubelet,    format: xfs}
         - {quantity: 100, datastoreName: <datastore-name>, path: /var/lib/containerd, format: xfs}
-        # This example keeps /var/cpaas as a template disk for simplicity. For
-        # production, declare it in DCSIpHostnamePool.spec.pool[].persistentDisk
-        # so it survives node replacement (see Infrastructure Resources).
-        - {quantity: 100, datastoreName: <datastore-name>, path: /var/cpaas,          format: xfs}
+        # /var/cpaas is intentionally NOT a template disk — it is declared as a
+        # persistentDisk on the IP pool above so it survives node replacement.
       ipHostPoolRef:
         name: global-cp-pool
 ---
@@ -2375,7 +2396,7 @@ metadata:
     capi.cpaas.io/resource-group-version: infrastructure.cluster.x-k8s.io/v1beta1
     capi.cpaas.io/resource-kind: DCSCluster
     cpaas.io/registry-address: "${NODE_REGISTRY_ADDRESS}"
-    cpaas.io/kube-ovn-join-cidr: 100.5.0.0/16
+    cpaas.io/kube-ovn-join-cidr: <kube-ovn-join-cidr>   # a /16 you choose; must not overlap the pod / service CIDRs or another cluster's join CIDR
     cpaas.io/kube-ovn-version: <kube-ovn-chart-version>
     cpaas.io/os-family: <os-family>   # OS family of the Alauda OS image, for example slemicro
 spec:
@@ -2400,7 +2421,7 @@ spec:
 | `<dcs-api-user>` / `<dcs-api-password>` / `<dcs-api-host>` / `<dcs-site-id>` | DCS platform credentials and site. See [Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials). |
 | `<vm-template-name>`, `<dns-image-tag>`, `<etcd-image-tag>` | The `cpaas.io/dcs-vm-template` ConfigMap. See [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders). |
 | `<dcs-cluster-name>`, `<dvswitch-name>`, `<port-group-name>`, `<datastore-name>` | DCS platform objects. Confirm with the DCS administrator. |
-| `192.0.2.x`, `<os-family>`, `<kube-ovn-chart-version>` | Node IPs/gateway/DNS for your network; the OS family of the image; and the kube-ovn chart version from the [OS Support Matrix](../overview/os-support-matrix.mdx). |
+| `192.0.2.x`, `<kube-ovn-join-cidr>`, `<os-family>`, `<kube-ovn-chart-version>` | Node IPs/gateway/DNS for your network; a `/16` Kube-OVN join CIDR that does not overlap the pod / service CIDRs or another cluster's join CIDR; the OS family of the image; and the kube-ovn chart version from the [OS Support Matrix](../overview/os-support-matrix.mdx). |
 | `ssh-ed25519 AAAA...` | A real OpenSSH public key. The `ignition` format rejects an empty list; supply any valid key even if you do not plan to SSH in. |
 
 <Directive type="info" title="Secret encryption and disaster recovery">

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -535,12 +535,12 @@ Upload the packages.
 Create and apply the AppRelease resources for the Kubeadm provider and the Bare Metal provider.
 
 <Directive type="warning" title="Bare Metal Bootstrap Endpoint">
-  During bootstrap, the `global` cluster has not handed control to the final VIP yet. Keep the bare-metal registration path on the bootstrap KIND host: `global.platformUrl` points to the bootstrap host, and `elemental.server.url` points to `https://<kind-host-ip>:12443`. Do not set `baremetal.cluster.io/system-agent-server-url` on the `MachineRegistration` used for the `global` machines during this phase. The handoff job changes the `global` machines to `https://<CONTROL_PLANE_VIP>/kubernetes/global` after the platform installation completes.
+  During bootstrap, the `global` cluster has not handed control to the final VIP yet. Keep the bare-metal registration path on the bootstrap host: `global.platformUrl` points to the bootstrap host, and `elemental.server.url` points to `https://<bootstrap-host-ip>:12443`. Do not set `baremetal.cluster.io/system-agent-server-url` on the `MachineRegistration` used for the `global` machines during this phase. The handoff job changes the `global` machines to `https://<CONTROL_PLANE_VIP>/kubernetes/global` after the platform installation completes.
 </Directive>
 
 Prepare the bootstrap HTTPS certificate used by `global-alb2` before you install the Bare Metal provider. The `elemental-operator` mounts the CA from `cpaas-system/dex.tls`, and `elemental-system-agent` uses that CA when `elemental.tls.agentTLSMode` is `strict`. The Secret must contain `tls.crt`, `tls.key`, and the CA bundle key that you configure in the AppRelease, shown below as `ca.crt`. The serving certificate must include `${HOST_IP}` as an IP SAN because the bootstrap endpoint is `https://${HOST_IP}:12443`.
 
-If cert-manager is available in the bootstrap KIND cluster, create or refresh `dex.tls` with a bootstrap-local CA:
+If cert-manager is available in the bootstrap cluster, create or refresh `dex.tls` with a bootstrap-local CA:
 
 ```shell
 kubectl get crd certificates.cert-manager.io issuers.cert-manager.io
@@ -1151,7 +1151,7 @@ Use [Creating Clusters on Bare Metal](../create-cluster/bare-metal.mdx), [Managi
 - Do not set `baremetal.cluster.io/system-agent-server-url` on the `MachineRegistration` used for the bootstrap `global` hosts. The bootstrap ISO must register through the bootstrap host; the handoff job later moves the `global` machines to the VIP.
 - If a `global` VM or physical host does not have DHCP during the live-ISO boot, configure the NIC manually from the host console before waiting for `MachineInventory` registration. Use the same NetworkManager procedure described in [Creating Clusters on Bare Metal](../create-cluster/bare-metal.mdx#network-connectivity), replacing the example address, gateway, DNS, and connection name with the values for that host.
 - Do not depend on OS hostname side effects. The bare-metal provider normalizes kubeadm node names and provider IDs from the CAPI and inventory objects.
-- The `SeedImage` created in the bootstrap KIND environment is a bootstrap artifact. After handoff, create any new `MachineRegistration` or `SeedImage` on the active `global` cluster.
+- The `SeedImage` created in the bootstrap cluster is a bootstrap artifact. After handoff, create any new `MachineRegistration` or `SeedImage` on the active `global` cluster.
 - When adding new machines to an already installed `global` cluster, explicitly set the `baremetal.cluster.io/system-agent-server-url` annotation on that `MachineRegistration` to the current active `global` control-plane VIP. New `global` machines do not pass through the bootstrap handoff job, so this annotation is what makes their system-agent watch plan Secrets through `https://<CONTROL_PLANE_VIP>/kubernetes/global`. Non-`global` workload-cluster machines should continue to use the platform domain path.
 
   ```yaml
@@ -1444,7 +1444,7 @@ kubectl apply -f /root/yamls/dcs-import-extra-resources.yaml
   </Tab>
   <Tab label="Bare Metal">
 
-Create and apply the Bare Metal import ConfigMap before you trigger the installer. This ConfigMap is required because the installer must import the bare-metal and elemental resources that were created in the bootstrap KIND cluster before the `global` cluster exists.
+Create and apply the Bare Metal import ConfigMap before you trigger the installer. This ConfigMap is required because the installer must import the bare-metal and elemental resources that were created in the bootstrap cluster before the `global` cluster exists.
 
 <Directive type="warning" title="Import Before DCS API">
   Create `dcs-import-extra-resources` before calling `POST /cpaas-installer/api/config/dcs`. If it is missing, the handoff job can run with an empty target list because the new `global` cluster does not contain the `BaremetalMachine`, `MachineInventory`, `MachineRegistration`, or plan Secret objects that describe the bootstrap `global` machines.
@@ -2047,7 +2047,7 @@ spec:
 
 The bare-metal provider reads this Secret and injects `/etc/kubernetes/encryption-provider.conf` into the generated control-plane bootstrap data. Do not also add the file manually to `KubeadmControlPlane.spec.kubeadmConfigSpec.files` for Bare Metal DR; the `BaremetalCluster` reference is the source of truth.
 
-This Secret must also be included in the Bare Metal `dcs-import-extra-resources` ConfigMap from Step 7. It cannot remain only in the bootstrap KIND cluster because the handed-off `global` cluster keeps the imported `BaremetalCluster` object and must also have the referenced Secret for later provider reconciliation.
+This Secret must also be included in the Bare Metal `dcs-import-extra-resources` ConfigMap from Step 7. It cannot remain only in the bootstrap cluster because the handed-off `global` cluster keeps the imported `BaremetalCluster` object and must also have the referenced Secret for later provider reconciliation.
 
 Keep the same DR `serverCertSANs` list on both the primary and standby installation environments.
 
@@ -2083,7 +2083,7 @@ The generated `Role/cpaas-system/baremetal-system-agent` must restrict `secrets`
 
 Run Steps 1 through 9 for both the primary and standby `global` clusters.
 
-For Bare Metal DR, use two independent bootstrap KIND hosts: one for the primary installation and one for the standby installation. Do not reuse the same bootstrap KIND cluster for both sides. The bootstrap environment contains installer state, AppRelease objects, registry Secrets, `MachineRegistration`, `SeedImage`, and handoff state; sharing it can pollute the two `global` installations and can make handoff or cleanup affect the wrong side.
+For Bare Metal DR, use two independent bootstrap hosts: one for the primary installation and one for the standby installation. Do not reuse the same bootstrap cluster for both sides. The bootstrap environment contains installer state, AppRelease objects, registry Secrets, `MachineRegistration`, `SeedImage`, and handoff state; sharing it can pollute the two `global` installations and can make handoff or cleanup affect the wrong side.
 
 Use the provider-specific installer configuration differences for both sides:
 

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -2167,8 +2167,8 @@ The installation is successful when all of the following conditions are true:
 
 After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once verification passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
 
-<Directive type="info" title="Migrate the DCS credential Secret to the global cluster first">
-  The installer migrates the DCS credential Secret to the `global` cluster automatically only when it is named `ait-credential-secret` (the name used in the [worked example](#dcs-worked-example)). If your `DCSCluster.spec.credentialSecretRef` points to a Secret with a different name, it is not carried over — copy that Secret into the `global` cluster's `cpaas-system` namespace before you remove the bootstrap host. Without it, the `global` cluster's DCS provider has no DCS API credentials and cannot reconcile; for example, scaling the cluster out later fails. Verify with `kubectl --kubeconfig <global-kubeconfig> get secret <name> -n cpaas-system`.
+<Directive type="info" title="Verify the DCS credential Secret reached the global cluster">
+  The installer copies the DCS credential Secret to the `global` cluster during installation. It is copied automatically when the Secret is named `ait-credential-secret` (as in this example — no extra ConfigMap needed), or — for any other name — when you list that Secret in the `dcs-import-extra-resources` ConfigMap (`resource: secrets`, `names: [<your-secret>]`, `method: kubectl`), the same name-matched import that VMware vSphere and Huawei Cloud Stack use. Before you remove the bootstrap host, verify it is present: `kubectl --kubeconfig <global-kubeconfig> get secret <name> -n cpaas-system`. If it is missing, copy it over first — without it the `global` cluster's DCS provider has no DCS API credentials and cannot reconcile (for example, scale-out later fails).
 </Directive>
 
 <Directive type="warning" title="Do not delete the Cluster API objects to clean up">
@@ -2206,7 +2206,7 @@ With those prepared, apply the manifest below.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ait-credential-secret   # this exact name lets the installer migrate the credential to the global cluster (see Decommission)
+  name: ait-credential-secret   # built-in import copies this name to the global cluster automatically; any other name works too if listed in the import ConfigMap (see Decommission)
   namespace: cpaas-system
   labels:
     cpaas.io/cluster-name: "global"

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -842,7 +842,8 @@ Use the DCS resource fields from [Creating Clusters on Huawei DCS](../create-clu
 - Add `Cluster.metadata.labels.is-global: "true"` and `Cluster.metadata.labels.cluster-type: DCS`.
 - Add `Cluster.metadata.annotations["cpaas.io/registry-address"]` with `${NODE_REGISTRY_ADDRESS}`.
 - Set `KubeadmControlPlane.spec.kubeadmConfigSpec.format: ignition` for Alauda OS.
-- Keep the release manifest's non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries.
+- Keep the `KubeadmControlPlane.spec.kubeadmConfigSpec.users` entry with a non-empty `sshAuthorizedKeys` list (the `boot` user). The DCS `ignition` format rejects an empty SSH key list, so this field is required even for a `global` cluster you do not plan to access over SSH. See [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders) for what to supply when no interactive key is needed.
+- Keep the non-encryption kubeadm files, kubelet patches, audit policy, and installer RBAC entries. The file contents (the PodSecurity admission config, the kubelet patch, and the audit policy), together with the full `clusterConfiguration`, `preKubeadmCommands`, `postKubeadmCommands`, and the init and join node-registration patches, are identical to a workload cluster. Copy them from the [Complete KubeadmControlPlane Configuration](../create-cluster/huawei-dcs.mdx#complete-kubeadmcontrolplane-configuration) appendix, or reference the `dcs-kubernetes-<major.minor>-files` Secret documented there. The wiring fragment below shows only the `global`-specific fields layered on top of that base.
 - For a normal non-DR deployment, do not set `DCSCluster.spec.encryptionProviderConfigRef` and do not add `/etc/kubernetes/encryption-provider.conf` to `KubeadmControlPlane.spec.kubeadmConfigSpec.files`.
 - Keep `/var/cpaas` as platform state. If you need the disk to survive rolling replacement, declare it in `DCSIpHostnamePool.spec.pool[].persistentDisk`; do not rely on `DCSMachineTemplate` template disks as preserved state.
 - Use concrete `datastoreName` values for DCS local storage unless you have verified that the selected datastore cluster can place volumes on hosts that can run the target VM.
@@ -2161,6 +2162,14 @@ The installation is successful when all of the following conditions are true:
 - All `global` cluster nodes are `Ready`.
 - Critical Pods in `cpaas-system` are `Running` or `Completed`.
 - `ClusterModule/global` reports the base module as healthy.
+
+## Decommission the Bootstrap Host \{#decommission-bootstrap-host}
+
+After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once [Verification](#verification) passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
+
+<Directive type="warning" title="Do not delete the Cluster API objects to clean up">
+  Do not run `kubectl delete cluster global`, and do not delete the `Cluster`, `KubeadmControlPlane`, or provider infrastructure objects as a cleanup step. After installation these objects own the live `global` control plane machines, so deleting them cascades into deleting the control plane VMs and destroys the cluster you just installed. Decommissioning is limited to removing the local KIND cluster on the bootstrap host; leave the Cluster API objects in place.
+</Directive>
 
 ## Next Steps
 

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -1811,6 +1811,7 @@ kubectl --kubeconfig <global-kubeconfig> get clustermodule global
 |---|---|---|
 | Machines stay in `Pending` or do not appear | `kubectl describe machine -n cpaas-system <machine>` | The provider-specific failure reason on the machine `Bootstrap` and `Infrastructure` conditions. IaaS quota, network, and credential issues surface here. |
 | `KubeadmControlPlane` does not reach `Ready` | `kubectl get nodes` with the new cluster kubeconfig and `kubectl describe kubeadmcontrolplane -n cpaas-system` | etcd health on the first control plane node and join progress for the remaining nodes. |
+| `KubeadmControlPlane` stays not `Ready` (often `EtcdClusterHealthy=Unknown`) and the installer hangs, even though the control-plane VMs are up, and the bootstrap (KIND) Pods cannot reach the control-plane subnet | NAT rules on the bootstrap (KIND) host | Stopping the host firewall after KIND started can flush the KIND bridge's SNAT masquerade, so the CAPI controller Pods running in KIND cannot route to the new control-plane subnet. Re-add it: `iptables -t nat -A POSTROUTING -s 172.18.0.0/16 ! -d 172.18.0.0/16 -j MASQUERADE` (`172.18.0.0/16` is the default KIND subnet). |
 | Pods in `kube-system` stay `Pending` or fail to pull images | `kubectl --kubeconfig <global-kubeconfig> describe pod -n kube-system <pod>` | Image pull errors usually mean the node-facing registry address is not reachable from the new cluster's subnet. |
 | Installer progress API shows a stalled stage | `/var/cpaas/data/installer.log` | The most recent phase line and the most recent error message. Retried errors repeat on a short interval; persistent errors do not advance. |
 | `ClusterModule/global` does not reach a healthy phase | `kubectl --kubeconfig <global-kubeconfig> describe clustermodule global` | The `Status.conditions` describe which module is blocking the cluster from completing. |
@@ -2167,6 +2168,10 @@ The installation is successful when all of the following conditions are true:
 
 After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once verification passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
 
+<Directive type="info" title="Migrate the DCS credential Secret to the global cluster first">
+  The installer migrates the DCS credential Secret to the `global` cluster automatically only when it is named `ait-credential-secret` (the name used in the [worked example](#dcs-worked-example)). If your `DCSCluster.spec.credentialSecretRef` points to a Secret with a different name, it is not carried over — copy that Secret into the `global` cluster's `cpaas-system` namespace before you remove the bootstrap host. Without it, the `global` cluster's DCS provider has no DCS API credentials and cannot reconcile; for example, scaling the cluster out later fails. Verify with `kubectl --kubeconfig <global-kubeconfig> get secret <name> -n cpaas-system`.
+</Directive>
+
 <Directive type="warning" title="Do not delete the Cluster API objects to clean up">
   Do not run `kubectl delete cluster global`, and do not delete the `Cluster`, `KubeadmControlPlane`, or provider infrastructure objects as a cleanup step. After installation these objects own the live `global` control plane machines, so deleting them cascades into deleting the control plane VMs and destroys the cluster you just installed. Decommissioning is limited to removing the local KIND cluster on the bootstrap host; leave the Cluster API objects in place.
 </Directive>
@@ -2190,7 +2195,7 @@ This example targets a non-DR cluster. The three large kubeadm files (the PodSec
 apiVersion: v1
 kind: Secret
 metadata:
-  name: global-secret
+  name: ait-credential-secret   # this exact name lets the installer migrate the credential to the global cluster (see Decommission)
   namespace: cpaas-system
   labels:
     cpaas.io/cluster-name: "global"
@@ -2352,7 +2357,7 @@ metadata:
 spec:
   controlPlaneLoadBalancer: {host: "${CONTROL_PLANE_VIP}", port: 6443, type: external}
   controlPlaneEndpoint: {host: "${CONTROL_PLANE_VIP}", port: 6443}
-  credentialSecretRef: {name: global-secret}
+  credentialSecretRef: {name: ait-credential-secret}
   networkType: kube-ovn
   site: <dcs-site-id>
 ---

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -2188,6 +2188,18 @@ This is a complete, single-file manifest for a three-replica control-plane `glob
 
 This example targets a non-DR cluster. To avoid maintaining two copies of it, the `KubeadmControlPlane` `kubeadmConfigSpec` body is not repeated here — it is identical to a workload cluster and is taken from the [Complete KubeadmControlPlane Configuration](../create-cluster/huawei-dcs.mdx#complete-kubeadmcontrolplane-configuration) appendix, with the two `global` / non-DR deltas noted inline in resource 4 below.
 
+### Before You Apply: Prepare These on DCS \{#dcs-worked-example-prereqs}
+
+The manifest references these but does not create them. Prepare them first, in order:
+
+1. **DCS API access** — the endpoint (`https://<host>:7443`), an `administrator` user and password, and the site ID. These fill the `Secret` and `DCSCluster.spec.site`. See [Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials).
+2. **A VM template** — upload the Alauda OS image and create a VM template from it; record its name for `vmTemplateName`. Use a `4.2.1+` template so the `/var/cpaas` persistent disk can be detached and reattached during node replacement. See [Machine Templates](../infrastructure/huawei-dcs.mdx#machine-templates).
+3. **DCS placement objects** — the target compute cluster, a distributed virtual switch, a port group, and a datastore with enough free capacity. These fill `resource`, `dvSwitchName`, `portGroupName`, and `datastoreName`. See [DCS Platform Capacity and Placement](../infrastructure/huawei-dcs.mdx#capacity-and-placement).
+4. **IPs and the API load balancer** — three free node IPs (with gateway and DNS) for the control plane, and a control-plane VIP / load balancer that balances at least port `6443` across the three nodes (the DCS provider does not create it). These fill the `DCSIpHostnamePool` and `DCSCluster.spec.controlPlaneLoadBalancer` / `controlPlaneEndpoint`. See [Creating Clusters on Huawei DCS](../create-cluster/huawei-dcs.mdx).
+5. **Versions and IDs to read** — `${K8S_VERSION}` plus the CoreDNS and etcd image tags from the `cpaas.io/dcs-vm-template` ConfigMap (see [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders)); the kube-ovn chart version from the [OS Support Matrix](../overview/os-support-matrix.mdx); and the registry address, VIP, and CIDR values you exported in Step 1.
+
+With those prepared, apply the manifest below.
+
 ```yaml
 ---
 # 1. DCS API credential. See Infrastructure Resources for the field sources.

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -81,7 +81,7 @@ export HCS_SECRET_NAME="global-secret"
 # Use v-prefixed semver that matches the target Alauda OS image.
 ```
 
-Use `LOCAL_REGISTRY_ADDRESS` when pushing packages from the bootstrap host. Use `BOOTSTRAP_REGISTRY_ADDRESS` in AppRelease chart repository values because provider Pods read the chart repository from inside the bootstrap cluster's network. Use `NODE_REGISTRY_ADDRESS` in Cluster API registry annotations because provisioned `global` nodes must pull images through an address reachable from their subnet.
+Use `LOCAL_REGISTRY_ADDRESS` when pushing packages from the bootstrap host. Use `BOOTSTRAP_REGISTRY_ADDRESS` in AppRelease chart repository values because provider Pods read the chart repository from inside the bootstrap cluster's network. Use `NODE_REGISTRY_ADDRESS` (the bootstrap host's registry, `<bootstrap-host-ip>:11443`) in the Cluster API registry annotations, because provisioned `global` nodes must pull images through an address reachable from their subnet during provisioning. This is a temporary value: after the `global` cluster's own registry comes up, the installer automatically rewrites the `cpaas.io/registry-address` annotation on the `Cluster` and `DCSCluster` to the permanent platform registry, so later reconciles pull from the `global` cluster instead of the bootstrap host.
 
 ### Step 2 — Create the Bootstrap Cluster
 

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -2165,7 +2165,7 @@ The installation is successful when all of the following conditions are true:
 
 ## Decommission the Bootstrap Host \{#decommission-bootstrap-host}
 
-After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once [Verification](#verification) passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
+After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once verification passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
 
 <Directive type="warning" title="Do not delete the Cluster API objects to clean up">
   Do not run `kubectl delete cluster global`, and do not delete the `Cluster`, `KubeadmControlPlane`, or provider infrastructure objects as a cleanup step. After installation these objects own the live `global` control plane machines, so deleting them cascades into deleting the control plane VMs and destroys the cluster you just installed. Decommissioning is limited to removing the local KIND cluster on the bootstrap host; leave the Cluster API objects in place.
@@ -2180,7 +2180,7 @@ After the installer reports success, the `global` cluster runs its own Cluster A
 
 ## Worked Example: Complete `global` Manifest for Huawei DCS \{#dcs-worked-example}
 
-This is a complete, single-file manifest for a three-replica control-plane `global` cluster on Huawei DCS. It is the same set of resources described in [Step 4](#step-4--configure-the-provider-specific-global-manifest), already assembled so you do not have to merge fragments across pages. It uses documentation-only example values: replace every `<placeholder>`, and reuse the `${...}` variables you exported in [Step 1](#step-1--prepare-common-variables). Apply it in [Step 5](#step-5--apply-the-global-manifest).
+This is a complete, single-file manifest for a three-replica control-plane `global` cluster on Huawei DCS. It is the same set of resources described in Step 4, already assembled so you do not have to merge fragments across pages. It uses documentation-only example values: replace every `<placeholder>`, and reuse the `${...}` variables you exported in Step 1. Apply it in Step 5.
 
 This example targets a non-DR cluster. The three large kubeadm files (the PodSecurity admission config, the kubelet patch, and the audit policy) are identical to a workload cluster, so they are pulled from the `dcs-kubernetes-<major.minor>-files` Secret shipped by the DCS provider plugin. If that Secret is not present on the bootstrap cluster, inline the file contents from the [Complete KubeadmControlPlane Configuration](../create-cluster/huawei-dcs.mdx#complete-kubeadmcontrolplane-configuration) appendix instead.
 
@@ -2391,7 +2391,7 @@ spec:
 
 | Placeholder / variable | Where it comes from |
 |---|---|
-| `${K8S_VERSION}`, `${CONTROL_PLANE_VIP}`, `${NODE_REGISTRY_ADDRESS}`, `${CLUSTER_CIDR}`, `${SERVICE_CIDR}` | Exported in [Step 1](#step-1--prepare-common-variables). |
+| `${K8S_VERSION}`, `${CONTROL_PLANE_VIP}`, `${NODE_REGISTRY_ADDRESS}`, `${CLUSTER_CIDR}`, `${SERVICE_CIDR}` | Exported in Step 1. |
 | `<dcs-api-user>` / `<dcs-api-password>` / `<dcs-api-host>` / `<dcs-site-id>` | DCS platform credentials and site. See [Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials). |
 | `<vm-template-name>`, `<dns-image-tag>`, `<etcd-image-tag>` | The `cpaas.io/dcs-vm-template` ConfigMap. See [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders). |
 | `<dcs-cluster-name>`, `<dvswitch-name>`, `<port-group-name>`, `<datastore-name>` | DCS platform objects. Confirm with the DCS administrator. |

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -20,7 +20,7 @@ Choose this installation path when all of the following conditions apply:
 
 - You want the `global` cluster to run on an immutable operating system. Alauda OS is the supported image today.
 - Your infrastructure is one of the documented providers: Huawei DCS, VMware vSphere, Huawei Cloud Stack, or Bare Metal.
-- You can run a temporary KIND host that has network access to the target IaaS platform.
+- You can run a temporary bootstrap host that has network access to the target IaaS platform.
 
 For traditional operating systems such as Ubuntu or RHEL, use <ExternalSiteLink name="acp" href="/install/index.html" children="the standard installation path" /> instead.
 
@@ -28,11 +28,11 @@ For traditional operating systems such as Ubuntu or RHEL, use <ExternalSiteLink 
 
 The following prerequisites apply to every provider:
 
-- A KIND host that meets the minimum hardware and network requirements. See the [Overview](../overview/index.mdx) for sizing guidance.
+- A bootstrap host that meets the minimum hardware and network requirements. See the [Overview](../overview/index.mdx) for sizing guidance.
 - The Core Package from the Customer Portal.
 - The Alauda Container Platform Kubeadm Provider package.
 - The infrastructure provider package for your target platform.
-- Network reachability between the KIND host and the target IaaS platform API endpoint.
+- Network reachability between the bootstrap host and the target IaaS platform API endpoint.
 - IP and hostname planning for the `global` control plane and worker nodes. See [Infrastructure Resources](../infrastructure/index.mdx) for the resource model used by each provider.
 - A stable Kubernetes API endpoint for the `global` cluster, such as a VIP or load balancer address.
 - A platform access address, registry address, and Pod and Service CIDR ranges.
@@ -62,10 +62,10 @@ Before installation, record the supported version set for the delivery package:
 
 ### Step 1 — Prepare Common Variables
 
-Set the common variables on the KIND host.
+Set the common variables on the bootstrap host.
 
 ```shell
-export HOST_IP="<kind-host-ip>"
+export HOST_IP="<bootstrap-host-ip>"
 export LOCAL_REGISTRY_ADDRESS="127.0.0.1:11443"
 export BOOTSTRAP_REGISTRY_ADDRESS="172.18.0.1:11443"
 export NODE_REGISTRY_ADDRESS="${HOST_IP}:11443"
@@ -81,11 +81,11 @@ export HCS_SECRET_NAME="global-secret"
 # Use v-prefixed semver that matches the target Alauda OS image.
 ```
 
-Use `LOCAL_REGISTRY_ADDRESS` when pushing packages from the KIND host. Use `BOOTSTRAP_REGISTRY_ADDRESS` in AppRelease chart repository values because provider Pods read the chart repository from inside the bootstrap KIND network. Use `NODE_REGISTRY_ADDRESS` in Cluster API registry annotations because provisioned `global` nodes must pull images through an address reachable from their subnet.
+Use `LOCAL_REGISTRY_ADDRESS` when pushing packages from the bootstrap host. Use `BOOTSTRAP_REGISTRY_ADDRESS` in AppRelease chart repository values because provider Pods read the chart repository from inside the bootstrap cluster's network. Use `NODE_REGISTRY_ADDRESS` in Cluster API registry annotations because provisioned `global` nodes must pull images through an address reachable from their subnet.
 
-### Step 2 — Bootstrap the KIND Host
+### Step 2 — Create the Bootstrap Cluster
 
-Run the bootstrap script provided by the Core Package. This brings up a temporary management cluster, `minialauda`, on the KIND host.
+Run the bootstrap script provided by the Core Package. This brings up a temporary KIND-based bootstrap cluster named `minialauda` on the bootstrap host — the temporary Cluster API management cluster used only to provision the `global` cluster.
 
 ```shell
 mkdir -p /root/cpaas-install
@@ -1281,7 +1281,7 @@ spec:
 
 ### Step 5 — Apply the global Manifest
 
-Apply the provider-specific manifest to `minialauda`.
+Apply the provider-specific manifest to the bootstrap cluster.
 
 <Tabs>
   <Tab label="Huawei DCS">
@@ -1357,7 +1357,7 @@ data:
   resources.yaml: |
     resources:
     - resource: "secrets"
-      names: ["global-dcs-credentials"]
+      names: ["<auth-secret-name>"]
       method: kubectl
 EOF
 
@@ -1555,10 +1555,10 @@ export INSTALLER_IP=$(kubectl get pods -n cpaas-system -l service_name=cpaas-ins
 ```
 
 <Directive type="info" title="Network Scope">
-  `INSTALLER_IP` is the Pod IP of the embedded installer in `minialauda`. The endpoint is used only during installation.
+  `INSTALLER_IP` is the Pod IP of the embedded installer in the bootstrap cluster. The endpoint is used only during installation.
 </Directive>
 
-Create the provider-specific installer configuration JSON file on the current KIND host, then submit it to the installer endpoint. All providers in this install path use the same endpoint path, but their request bodies are different.
+Create the provider-specific installer configuration JSON file on the current bootstrap host, then submit it to the installer endpoint. All providers in this install path use the same endpoint path, but their request bodies are different.
 
 | Field | Huawei DCS | VMware vSphere | Huawei Cloud Stack | Bare Metal |
 |-------|------------|----------------|--------------------|------------|
@@ -1567,7 +1567,7 @@ Create the provider-specific installer configuration JSON file on the current KI
 | `console.globalHost` | Platform access address | Platform access address | Platform access address | Platform access address |
 | `cluster.clusterCIDR` and `cluster.serviceCIDR` | Required | Not set; cluster CIDRs are declared in the VMware vSphere `Cluster` manifest | Not set | Required |
 | `cluster.features.ha` | Required, points to the local HA VIP with `isThirdParty: true` | Not set; the control plane endpoint is declared in `VSphereCluster.spec.controlPlaneEndpoint.host` | Not set; HCS ELB is declared in `HCSCluster` | Required, points to the bare-metal control-plane VIP with `isThirdParty: true` |
-| `hostIP` | Current KIND host IP | Current KIND host IP | Current KIND host IP | Current KIND host IP |
+| `hostIP` | Current bootstrap host IP | Current bootstrap host IP | Current bootstrap host IP | Current bootstrap host IP |
 
 <Tabs>
   <Tab label="Huawei DCS">
@@ -1786,13 +1786,13 @@ Set `console.host` and `cluster.features.ha.vip` to the local Bare Metal `global
 
 ### Step 9 — Monitor the Installation
 
-After the installer accepts the request, the install runs through several phases that are observable from the KIND host. A typical immutable-OS `global` cluster takes 30–60 minutes; total time depends on IaaS provisioning speed, image pull time, and the number of plugins selected.
+After the installer accepts the request, the install runs through several phases that are observable from the bootstrap host. A typical immutable-OS `global` cluster takes 30–60 minutes; total time depends on IaaS provisioning speed, image pull time, and the number of plugins selected.
 
 #### Phases You Will Observe
 
 | Phase | What is happening | First place to watch |
 |---|---|---|
-| Bootstrap | The bootstrap KIND, embedded registry, and Cluster API providers are running on the KIND host. Completed in Step 2 and Step 3. | KIND host terminal; `kubectl get pods -n cpaas-system` |
+| Bootstrap | The bootstrap cluster, embedded registry, and Cluster API providers are running on the bootstrap host. Completed in Step 2 and Step 3. | bootstrap host terminal; `kubectl get pods -n cpaas-system` |
 | Infrastructure provisioning | The Cluster API provider creates VMs from the Alauda OS template on the target IaaS platform. | `kubectl get machines -n cpaas-system` |
 | Control plane bootstrap | `KubeadmControlPlane` bootstraps the first control plane node, etcd starts, and additional control plane nodes join. | `kubectl get kubeadmcontrolplane -n cpaas-system` |
 | Network and core add-ons | The CAPI provider reconciles Kube-OVN, CoreDNS, and kube-proxy on the new cluster. | `kubectl --kubeconfig <global-kubeconfig> get pods -n kube-system` |
@@ -1801,14 +1801,14 @@ After the installer accepts the request, the install runs through several phases
 
 #### Signals During Installation
 
-Watch the installer progress API and the installer log together. If one appears stalled, check the underlying Cluster API resources directly on the bootstrap KIND host.
+Watch the installer progress API and the installer log together. If one appears stalled, check the underlying Cluster API resources directly on the bootstrap host.
 
 ```shell
 # Installer progress and live log
 curl "http://${INSTALLER_IP}:8080/cpaas-installer/api/progress"
 tail -f /var/cpaas/data/installer.log
 
-# Cluster API resources on the bootstrap KIND host
+# Cluster API resources on the bootstrap host
 kubectl get clusters.cluster.x-k8s.io -A
 kubectl get kubeadmcontrolplane -A
 kubectl get machines -A
@@ -1948,7 +1948,7 @@ serverCertSANs:
 <Tabs>
   <Tab label="Huawei DCS">
 
-Create the encryption provider Secret in `minialauda`.
+Create the encryption provider Secret in the bootstrap cluster.
 
 ```shell
 kubectl create secret generic encryption-provider-config \
@@ -2094,9 +2094,9 @@ Use the provider-specific installer configuration differences for both sides:
 | Huawei Cloud Stack | Keep `console.host: []`; the primary VIP is managed by the HCS ELB. Create the HCS `dcs-import-extra-resources` ConfigMap from Step 7 and keep `HCS_SECRET_NAME` aligned with `HCSCluster.spec.identityRef.name`. | Keep `console.host: []`; the standby VIP is managed by the HCS ELB. Create the HCS `dcs-import-extra-resources` ConfigMap from Step 7 and keep `HCS_SECRET_NAME` aligned with `HCSCluster.spec.identityRef.name`. |
 | Bare Metal | Set `console.host`, `cluster.features.ha.vip`, `BaremetalCluster.spec.controlPlaneLoadBalancer.host`, and `handoffHook.controlPlaneVIP` to the primary control-plane VIP. Create the Bare Metal `dcs-import-extra-resources` ConfigMap from Step 7. | Set `console.host`, `cluster.features.ha.vip`, `BaremetalCluster.spec.controlPlaneLoadBalancer.host`, and `handoffHook.controlPlaneVIP` to the standby control-plane VIP. Create the Bare Metal `dcs-import-extra-resources` ConfigMap from Step 7. |
 
-For the primary cluster, make sure the platform domain resolves to the primary HA VIP. In Step 8, set `hostIP` to the primary KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. For VMware vSphere, set the control plane endpoint in the primary manifest to the primary HA VIP. For HCS, keep `console.host: []` because the VIP is owned by the HCS ELB. For Bare Metal, set both the manifest VIP and the installer VIP fields to the primary control-plane VIP.
+For the primary cluster, make sure the platform domain resolves to the primary HA VIP. In Step 8, set `hostIP` to the primary bootstrap host IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the primary HA VIP. For VMware vSphere, set the control plane endpoint in the primary manifest to the primary HA VIP. For HCS, keep `console.host: []` because the VIP is owned by the HCS ELB. For Bare Metal, set both the manifest VIP and the installer VIP fields to the primary control-plane VIP.
 
-After the primary cluster installation succeeds, switch the platform domain to the standby HA VIP as required by the DR procedure. Then install the standby cluster. This DNS switch before the standby installation is required because several platform resources are rendered with the platform domain and must resolve to the standby entrance while the standby installer runs. In Step 8 on the standby KIND host, set `hostIP` to the standby KIND node IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the standby HA VIP. For VMware vSphere, set the control plane endpoint in the standby manifest to the standby HA VIP. For HCS, keep `console.host: []`. For Bare Metal, set both the manifest VIP and the installer VIP fields to the standby control-plane VIP, and keep `REGISTRY_DOMAIN` as `${PLATFORM_HOST}:11443` on both sides. Get `INSTALLER_IP` from the `cpaas-installer` Pod on the standby KIND host; do not reuse the primary KIND host value.
+After the primary cluster installation succeeds, switch the platform domain to the standby HA VIP as required by the DR procedure. Then install the standby cluster. This DNS switch before the standby installation is required because several platform resources are rendered with the platform domain and must resolve to the standby entrance while the standby installer runs. In Step 8 on the standby bootstrap host, set `hostIP` to the standby bootstrap host IP. For DCS, set `console.host` and `cluster.features.ha.vip` to the standby HA VIP. For VMware vSphere, set the control plane endpoint in the standby manifest to the standby HA VIP. For HCS, keep `console.host: []`. For Bare Metal, set both the manifest VIP and the installer VIP fields to the standby control-plane VIP, and keep `REGISTRY_DOMAIN` as `${PLATFORM_HOST}:11443` on both sides. Get `INSTALLER_IP` from the `cpaas-installer` Pod on the standby bootstrap host; do not reuse the primary bootstrap host value.
 
 After both clusters are installed, get the primary `k8sadmin` token on a primary control plane node. `etcd-sync` is installed only on the standby cluster, and its `active_cluster_*` values point to the primary cluster. Keep this value in its original base64 Secret form for `active_cluster_token`.
 
@@ -2182,16 +2182,16 @@ The installation is successful when all of the following conditions are true:
 - Critical Pods in `cpaas-system` are `Running` or `Completed`.
 - `ClusterModule/global` reports the base module as healthy.
 
-## Decommission the Bootstrap Host \{#decommission-bootstrap-host}
+## Decommission the Bootstrap Cluster \{#decommission-bootstrap-cluster}
 
-After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once verification passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
+After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary bootstrap cluster (`minialauda`). Once verification passes, remove it from the bootstrap host — delete only the local bootstrap cluster (`minialauda`) and its KIND container network.
 
 <Directive type="info" title="Verify the DCS credential Secret reached the global cluster">
   The DCS API credential `Secret` is copied to the `global` cluster during installation by the `dcs-import-extra-resources` ConfigMap you create in Step 7 — it imports the Secret named in your `DCSCluster.spec.credentialSecretRef`. Before you remove the bootstrap host, verify it is present: `kubectl --kubeconfig <global-kubeconfig> get secret <name> -n cpaas-system`. If it is missing, copy it over first — without it the `global` cluster's DCS provider has no DCS API credentials and cannot reconcile (for example, scale-out later fails).
 </Directive>
 
 <Directive type="warning" title="Do not delete the Cluster API objects to clean up">
-  Do not run `kubectl delete cluster global`, and do not delete the `Cluster`, `KubeadmControlPlane`, or provider infrastructure objects as a cleanup step. After installation these objects own the live `global` control plane machines, so deleting them cascades into deleting the control plane VMs and destroys the cluster you just installed. Decommissioning is limited to removing the local KIND cluster on the bootstrap host; leave the Cluster API objects in place.
+  Do not run `kubectl delete cluster global`, and do not delete the `Cluster`, `KubeadmControlPlane`, or provider infrastructure objects as a cleanup step. After installation these objects own the live `global` control plane machines, so deleting them cascades into deleting the control plane VMs and destroys the cluster you just installed. Decommissioning is limited to removing the local bootstrap cluster (its KIND container) on the bootstrap host; leave the Cluster API objects in place.
 </Directive>
 
 ## Next Steps
@@ -2213,7 +2213,7 @@ The manifest references these but does not create them. Prepare them first, in o
 
 1. **DCS API access** — the endpoint (`https://<host>:7443`), an `administrator` user and password, and the site ID. These fill the `Secret` and `DCSCluster.spec.site`. See [Cloud Credentials](../infrastructure/huawei-dcs.mdx#cloud-credentials).
 2. **A VM template** — upload the Alauda OS image and create a VM template from it; record its name for `vmTemplateName`. Use a `4.2.1+` template so the `/var/cpaas` persistent disk can be detached and reattached during node replacement. See [Machine Templates](../infrastructure/huawei-dcs.mdx#machine-templates).
-3. **DCS placement objects** — the target compute cluster, a distributed virtual switch, a port group, and a datastore with enough free capacity. These fill `resource`, `dvSwitchName`, `portGroupName`, and `datastoreName`. See [DCS Platform Capacity and Placement](../infrastructure/huawei-dcs.mdx#capacity-and-placement).
+3. **Compute cluster, distributed virtual switch, port group, and datastore** — pick the target DCS compute cluster, a distributed virtual switch, a port group, and a datastore with enough free capacity. They fill `resource`, `dvSwitchName`, `portGroupName`, and `datastoreName`. See [DCS Platform Capacity and Placement](../infrastructure/huawei-dcs.mdx#capacity-and-placement).
 4. **IPs and the API load balancer** — three free node IPs (with gateway and DNS) for the control plane, and a control-plane VIP / load balancer that balances at least port `6443` across the three nodes (the DCS provider does not create it). These fill the `DCSIpHostnamePool` and `DCSCluster.spec.controlPlaneLoadBalancer` / `controlPlaneEndpoint`. See [Creating Clusters on Huawei DCS](../create-cluster/huawei-dcs.mdx).
 5. **Versions and IDs to read** — `${K8S_VERSION}` plus the CoreDNS and etcd image tags from the `cpaas.io/dcs-vm-template` ConfigMap (see [Resolving Placeholder Values](../create-cluster/huawei-dcs.mdx#resolving-placeholders)); the kube-ovn chart version from the [OS Support Matrix](../overview/os-support-matrix.mdx); and the registry address, VIP, and CIDR values you exported in Step 1.
 
@@ -2225,7 +2225,7 @@ With those prepared, apply the manifest below.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: global-dcs-credentials   # imported to the global cluster via the dcs-import-extra-resources ConfigMap in Step 7
+  name: <auth-secret-name>   # imported to the global cluster via the dcs-import-extra-resources ConfigMap in Step 7
   namespace: cpaas-system
   labels:
     cpaas.io/cluster-name: "global"
@@ -2362,7 +2362,7 @@ metadata:
 spec:
   controlPlaneLoadBalancer: {host: "${CONTROL_PLANE_VIP}", port: 6443, type: external}
   controlPlaneEndpoint: {host: "${CONTROL_PLANE_VIP}", port: 6443}
-  credentialSecretRef: {name: global-dcs-credentials}
+  credentialSecretRef: {name: <auth-secret-name>}
   networkType: kube-ovn
   site: <dcs-site-id>
 ---

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -2338,6 +2338,7 @@ spec:
           audit-log-mode: batch
           audit-log-path: /etc/kubernetes/audit/audit.log
           audit-policy-file: /etc/kubernetes/audit/policy.yaml
+          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
           admission-control-config-file: /etc/kubernetes/admission/psa-config.yaml
           profiling: "false"
           tls-min-version: VersionTLS12
@@ -2395,7 +2396,9 @@ metadata:
   annotations:
     capi.cpaas.io/resource-group-version: infrastructure.cluster.x-k8s.io/v1beta1
     capi.cpaas.io/resource-kind: DCSCluster
+    capi.cpaas.io/kubernetes: ${K8S_VERSION}   # same value as KubeadmControlPlane.spec.version
     cpaas.io/registry-address: "${NODE_REGISTRY_ADDRESS}"
+    cpaas.io/nodes-mode: self-managed   # node lifecycle managed by CAPI + the DCS provider
     cpaas.io/kube-ovn-join-cidr: <kube-ovn-join-cidr>   # a /16 you choose; must not overlap the pod / service CIDRs or another cluster's join CIDR
     cpaas.io/kube-ovn-version: <kube-ovn-chart-version>
     cpaas.io/os-family: <os-family>   # OS family of the Alauda OS image, for example slemicro

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -1338,12 +1338,31 @@ The control plane is ready when the `KubeadmControlPlane` reports `Ready: True` 
 
 Before triggering the installer, create the `dcs-import-extra-resources` ConfigMap in the `cpaas-system` namespace for providers that require extra resource import. The ConfigMap name keeps the `dcs` prefix for historical installer compatibility, even when the provider is not Huawei DCS.
 
-VMware vSphere, Huawei Cloud Stack, and Bare Metal require this ConfigMap for both normal and disaster recovery `global` installations. Huawei DCS does not require it for the default installation because DCS provider resources are migrated by the built-in flow; create it for DCS only when you need to import additional resources beyond the built-in provider resource migration.
+Every provider uses this ConfigMap to import the IaaS credential `Secret` into the new `global` cluster. For VMware vSphere, Huawei Cloud Stack, and Bare Metal it also imports the provider's Cluster API resources; for Huawei DCS those resources are migrated by the built-in flow, so the DCS ConfigMap only needs the credential `Secret` entry. VMware vSphere, Huawei Cloud Stack, and Bare Metal require it for both normal and disaster recovery `global` installations.
 
 <Tabs>
   <Tab label="Huawei DCS">
 
-Do not create the DCS `dcs-import-extra-resources` ConfigMap for the default DCS installation path. DCS provider resources are migrated by the built-in flow.
+The DCS provider's Cluster API resources are migrated by the built-in flow, so the ConfigMap only needs to import the credential `Secret` referenced by `DCSCluster.spec.credentialSecretRef`. Use the same Secret name you set in the `global` manifest.
+
+```shell
+mkdir -p /root/yamls
+cat > /root/yamls/dcs-import-extra-resources.yaml <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dcs-import-extra-resources
+  namespace: cpaas-system
+data:
+  resources.yaml: |
+    resources:
+    - resource: "secrets"
+      names: ["global-dcs-credentials"]
+      method: kubectl
+EOF
+
+kubectl apply -f /root/yamls/dcs-import-extra-resources.yaml
+```
 
   </Tab>
   <Tab label="VMware vSphere">
@@ -2168,7 +2187,7 @@ The installation is successful when all of the following conditions are true:
 After the installer reports success, the `global` cluster runs its own Cluster API providers and no longer depends on the temporary `minialauda` KIND cluster on the bootstrap host. Once verification passes, decommission the bootstrap host by removing only the local `minialauda` KIND cluster and its container network on that host.
 
 <Directive type="info" title="Verify the DCS credential Secret reached the global cluster">
-  The installer copies the DCS credential Secret to the `global` cluster during installation. It is copied automatically when the Secret is named `ait-credential-secret` (as in this example — no extra ConfigMap needed), or — for any other name — when you list that Secret in the `dcs-import-extra-resources` ConfigMap (`resource: secrets`, `names: [<your-secret>]`, `method: kubectl`), the same name-matched import that VMware vSphere and Huawei Cloud Stack use. Before you remove the bootstrap host, verify it is present: `kubectl --kubeconfig <global-kubeconfig> get secret <name> -n cpaas-system`. If it is missing, copy it over first — without it the `global` cluster's DCS provider has no DCS API credentials and cannot reconcile (for example, scale-out later fails).
+  The DCS API credential `Secret` is copied to the `global` cluster during installation by the `dcs-import-extra-resources` ConfigMap you create in Step 7 — it imports the Secret named in your `DCSCluster.spec.credentialSecretRef`. Before you remove the bootstrap host, verify it is present: `kubectl --kubeconfig <global-kubeconfig> get secret <name> -n cpaas-system`. If it is missing, copy it over first — without it the `global` cluster's DCS provider has no DCS API credentials and cannot reconcile (for example, scale-out later fails).
 </Directive>
 
 <Directive type="warning" title="Do not delete the Cluster API objects to clean up">
@@ -2206,7 +2225,7 @@ With those prepared, apply the manifest below.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ait-credential-secret   # built-in import copies this name to the global cluster automatically; any other name works too if listed in the import ConfigMap (see Decommission)
+  name: global-dcs-credentials   # imported to the global cluster via the dcs-import-extra-resources ConfigMap in Step 7
   namespace: cpaas-system
   labels:
     cpaas.io/cluster-name: "global"
@@ -2343,7 +2362,7 @@ metadata:
 spec:
   controlPlaneLoadBalancer: {host: "${CONTROL_PLANE_VIP}", port: 6443, type: external}
   controlPlaneEndpoint: {host: "${CONTROL_PLANE_VIP}", port: 6443}
-  credentialSecretRef: {name: ait-credential-secret}
+  credentialSecretRef: {name: global-dcs-credentials}
   networkType: kube-ovn
   site: <dcs-site-id>
 ---

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -2186,7 +2186,7 @@ After the installer reports success, the `global` cluster runs its own Cluster A
 
 This is a complete, single-file manifest for a three-replica control-plane `global` cluster on Huawei DCS. It is the same set of resources described in Step 4, already assembled so you do not have to merge fragments across pages. It uses documentation-only example values: replace every `<placeholder>`, and reuse the `${...}` variables you exported in Step 1. Apply it in Step 5.
 
-This example targets a non-DR cluster. The three large kubeadm files (the PodSecurity admission config, the kubelet patch, and the audit policy) are identical to a workload cluster, so they are pulled from the `dcs-kubernetes-<major.minor>-files` Secret shipped by the DCS provider plugin. If that Secret is not present on the bootstrap cluster, inline the file contents from the [Complete KubeadmControlPlane Configuration](../create-cluster/huawei-dcs.mdx#complete-kubeadmcontrolplane-configuration) appendix instead.
+This example targets a non-DR cluster. To avoid maintaining two copies of it, the `KubeadmControlPlane` `kubeadmConfigSpec` body is not repeated here — it is identical to a workload cluster and is taken from the [Complete KubeadmControlPlane Configuration](../create-cluster/huawei-dcs.mdx#complete-kubeadmcontrolplane-configuration) appendix, with the two `global` / non-DR deltas noted inline in resource 4 below.
 
 ```yaml
 ---
@@ -2303,68 +2303,20 @@ spec:
     - name: boot
       sshAuthorizedKeys:
       - "ssh-ed25519 AAAA...replace-with-your-public-key... global-boot"
-    files:
-    - contentFrom: {secret: {name: dcs-kubernetes-<major.minor>-files, key: psa-config.yaml}}
-      path: /etc/kubernetes/admission/psa-config.yaml
-      owner: "root:root"
-      permissions: "0644"
-    - contentFrom: {secret: {name: dcs-kubernetes-<major.minor>-files, key: control-plane-kubelet-patch.json}}
-      path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
-      owner: "root:root"
-      permissions: "0644"
-    - contentFrom: {secret: {name: dcs-kubernetes-<major.minor>-files, key: audit-policy.yaml}}
-      path: /etc/kubernetes/audit/policy.yaml
-      owner: "root:root"
-      permissions: "0644"
-    preKubeadmCommands:
-    - while ! ip route | grep -q "default via"; do sleep 1; done; echo "NetworkManager started"
-    - mkdir -p /run/cluster-api && restorecon -Rv /run/cluster-api
-    - if [ -f /etc/disk-setup.sh ]; then bash /etc/disk-setup.sh; fi
-    postKubeadmCommands:
-    - chmod 600 /var/lib/kubelet/config.yaml
-    clusterConfiguration:
-      imageRepository: cloud.alauda.io/alauda
-      dns: {imageTag: <dns-image-tag>}
-      etcd:
-        local:
-          imageTag: <etcd-image-tag>
-          serverCertSANs: ["${CONTROL_PLANE_VIP}", "etcd.kube-system"]
-      apiServer:
-        extraArgs:
-          audit-log-format: json
-          audit-log-maxage: "30"
-          audit-log-maxbackup: "10"
-          audit-log-maxsize: "200"
-          audit-log-mode: batch
-          audit-log-path: /etc/kubernetes/audit/audit.log
-          audit-policy-file: /etc/kubernetes/audit/policy.yaml
-          tls-cipher-suites: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
-          admission-control-config-file: /etc/kubernetes/admission/psa-config.yaml
-          profiling: "false"
-          tls-min-version: VersionTLS12
-          kubelet-certificate-authority: /etc/kubernetes/pki/ca.crt
-        extraVolumes:
-        - {name: vol-dir-0, hostPath: /etc/kubernetes, mountPath: /etc/kubernetes, pathType: Directory}
-      controllerManager:
-        extraArgs: {bind-address: "::", profiling: "false", tls-min-version: VersionTLS12, flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"}
-      scheduler:
-        extraArgs: {bind-address: "::", tls-min-version: VersionTLS12, profiling: "false"}
-    initConfiguration:
-      patches: {directory: /etc/kubernetes/patches}
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "kube-ovn/role=master"   # kube-ovn-recognized role value; do not rename
-          provider-id: PROVIDER_ID
-          volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
-          protect-kernel-defaults: "true"
-    joinConfiguration:
-      patches: {directory: /etc/kubernetes/patches}
-      nodeRegistration:
-        kubeletExtraArgs:
-          node-labels: "kube-ovn/role=master"   # kube-ovn-recognized role value; do not rename
-          provider-id: PROVIDER_ID
-          volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
-          protect-kernel-defaults: "true"
+    # The rest of kubeadmConfigSpec — files, clusterConfiguration,
+    # preKubeadmCommands, postKubeadmCommands, initConfiguration,
+    # joinConfiguration — is identical to a workload cluster, so it is not
+    # duplicated here. Take it verbatim from the Complete KubeadmControlPlane
+    # Configuration appendix in the DCS create-cluster guide
+    # (#complete-kubeadmcontrolplane-configuration). The three large files
+    # (psa-config.yaml, control-plane-kubelet-patch.json, audit-policy.yaml) may
+    # use contentFrom the dcs-kubernetes-<major.minor>-files Secret. Apply these
+    # global / non-DR deltas to that body:
+    #   1. Add clusterConfiguration.etcd.local.serverCertSANs:
+    #        ["${CONTROL_PLANE_VIP}", "etcd.kube-system"]
+    #   2. Non-DR: omit the /etc/kubernetes/encryption-provider.conf file AND the
+    #        apiServer.extraArgs.encryption-provider-config argument (keep both for
+    #        DR / at-rest encryption — see the note after this example).
 ---
 # 5. DCS infrastructure cluster.
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
## Why

Make `docs/en/global/install.mdx` sufficient for another person to reproduce a **fully no-UI `global` install on Huawei DCS** (CLI/API only). Gaps were found by actually doing that install and diffing against the docs.

## Changes (`docs/en/global/install.mdx`)

**Clarity / correctness**
1. Define the source of the kubeadm config in Step 4 (the create-cluster Complete KubeadmControlPlane appendix + `dcs-kubernetes-<ver>-files` Secret), instead of the undefined "release manifest".
2. Restate the ignition-required `boot` user / SSH key in the global DCS requirements.
3. Decommission section: bootstrap teardown + warning that `kubectl delete cluster global` cascades into deleting the live control-plane VMs.

**Complete worked example**
4. New "Worked Example: Complete `global` Manifest for Huawei DCS" — one copy-pasteable file (Secret, `DCSIpHostnamePool`, `DCSMachineTemplate`, `KubeadmControlPlane`, `DCSCluster`, `Cluster`) with the global-specific annotations that were missing (`is-global`, `cluster-type`, `os-family`, `kube-ovn-version`, `kube-ovn-join-cidr`, `registry-address`) and a "Values to Replace" table. Sanitized to RFC 5737 IPs / placeholders.

**Operational gaps recovered from a deploy runbook**
5. **DCS credential Secret migration** — confirmed against cpaas-installer code (`installer_dcs.go` `dcsImportDCSCredentialSecret`): the installer auto-migrates the credential Secret to the `global` cluster **only when it is named `ait-credential-secret`** (Secrets are excluded from the etcdctl resource migration). The worked example now uses that name; a Decommission note tells anyone using a different name to copy it manually, else the `global` DCS provider has no credentials and can't reconcile (scale-out fails).
6. **Bootstrap NAT stall** — Common Stalls row: stopping the host firewall after KIND starts can flush the KIND bridge SNAT masquerade → CAPI controllers in KIND can't reach the new control-plane subnet → KCP stuck `EtcdClusterHealthy=Unknown`, installer hangs. Fix: re-add the `172.18.0.0/16` masquerade rule.

**Inclusive terminology**
7. `master` → `cp` in example identifiers across the page; kept the functional `kube-ovn/role=master` label (commented `do not rename`).

## Still deliberately out of scope

- **OS-template ↔ provider version pairing** and the version-gated `os-family` semantics (KubeOS must set `kubeos` or the node won't boot) — owned separately by the docs owner; the worked example carries the `os-family` field but not the version-gated rule.
- Full DCS REST API operational recipes, qcow2 template upload, env-specific values — agent-runbook material, not customer docs.

`mask` format was already standardized on `master` by #110.

## Validation

Each push validated with `yarn install` + `yarn lint` (0 errors) + `yarn build` in a scratch clone (the in-repo `/workspaces` volume is too small for `node_modules`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Updated Huawei DCS “global” installation guidance to require a non-empty `boot` user `sshAuthorizedKeys` list and clarified ignition behavior when the SSH key list is empty.
- Strengthened requirements that non-encryption kubeadm/kubelet/audit/installer configuration fragments match the workload-cluster appendix (or sourced from the appropriate files Secret), with guidance on layering only `global`-specific fields.
- Refreshed the worked global manifest and provider wiring/template references.
- Added a “Decommission the Bootstrap Host” section, including warnings not to delete Cluster API/provider objects and steps to migrate non-default credential secret names to the global cluster first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->