### PR TITLE
docs(AIT-62827): document control plane HA

### DIFF
--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -508,7 +508,7 @@ spec:
 
 Do not include `spec.controlPlaneEndpoint` in the create manifest. In the HCS create flow, the controller derives and populates this field from `spec.controlPlaneLoadBalancer` after the `HCSCluster` is created. Do not set `controlPlaneEndpoint` manually, and do not add an empty `controlPlaneEndpoint` object. If `controlPlaneEndpoint` is explicitly present in the manifest, it must include both `host` and `port`.
 
-`controlPlaneHA` is optional. When you include it, both `enabled` and `policy` are required. Use `anti-affinity` for strict host separation. Use `soft-anti-affinity` when you prefer host spread but do not want ECS creation to fail only because HCS cannot satisfy the hard placement rule. For planning guidance, see [Control Plane HA Placement Plan](../infrastructure/huawei-cloud-stack.mdx#control-plane-ha-placement).
+`controlPlaneHA` is optional. When you include it, both `enabled` and `policy` are required. Use `anti-affinity` for strict host separation. Use `soft-anti-affinity` when you prefer host spread but do not want ECS creation to fail only because HCS cannot satisfy the hard placement rule. For planning guidance, including the rolling replacement requirement when enabling the feature on an existing cluster, see [Control Plane HA Placement Plan](../infrastructure/huawei-cloud-stack.mdx#control-plane-ha-placement).
 
 ### Configure Cluster
 

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -427,7 +427,7 @@ The HCS controller also injects files while resolving cloud-init data. It writes
 
 Use the [OS Support Matrix](../overview/os-support-matrix.mdx) only for the component versions it explicitly lists, such as coredns and etcd image tags for supported Alauda OS images. It is not a complete source for all HCS manifest values. Before you apply this YAML, also use the approved release baseline for values such as `imageRepository`, DNS image repository, Kube-OVN version, Kube-OVN join CIDR, Pod CIDR, and Service CIDR.
 
-### Configure HCSCluster
+### Configure HCSCluster \{#configure-hcscluster}
 
 The `HCSCluster` resource defines the HCS infrastructure configuration.
 
@@ -450,6 +450,10 @@ metadata:
   name: <cluster-name>
   namespace: cpaas-system
 spec:
+  # Optional. Include only when you want provider-managed control-plane ECS placement.
+  controlPlaneHA:
+    enabled: true
+    policy: soft-anti-affinity
   controlPlaneLoadBalancer:
     vipAddress: <control-plane-vip-address>
     vipSubnetName: <vip-subnet-name>
@@ -489,6 +493,8 @@ spec:
 | `.spec.network.subnets[].secondaryDNS` | string | Recommended | Secondary DNS kept in the cluster subnet inventory |
 | `.spec.network.securityGroup.name` | string | Yes | Security group name |
 | `.spec.identityRef.name` | string | Yes | Non-empty credential Secret name referenced by `HCSCluster`; this value does not need to match the cluster name |
+| `.spec.controlPlaneHA.enabled` | bool | Required when `controlPlaneHA` is set | Enables a provider-managed server group for control-plane ECS placement |
+| `.spec.controlPlaneHA.policy` | string | Required when `controlPlaneHA` is set | Server group placement policy. Allowed values are `anti-affinity` and `soft-anti-affinity` |
 | `.spec.controlPlaneLoadBalancer` | object | Yes | ELB settings for the provider-created control plane ELB |
 | `.spec.controlPlaneLoadBalancer.vipAddress` | string | Yes | Fixed VIP for the control plane ELB |
 | `.spec.controlPlaneLoadBalancer.vipSubnetName` | string | Yes | Subnet name that contains the ELB VIP. This subnet must also appear in `.spec.network.subnets` |
@@ -501,6 +507,8 @@ spec:
 | `.spec.controlPlaneLoadBalancer.elbVirsubnetL7Ips[].ips[]` | string | Yes | Two fixed L7 virtual subnet IPs |
 
 Do not include `spec.controlPlaneEndpoint` in the create manifest. In the HCS create flow, the controller derives and populates this field from `spec.controlPlaneLoadBalancer` after the `HCSCluster` is created. Do not set `controlPlaneEndpoint` manually, and do not add an empty `controlPlaneEndpoint` object. If `controlPlaneEndpoint` is explicitly present in the manifest, it must include both `host` and `port`.
+
+`controlPlaneHA` is optional. When you include it, both `enabled` and `policy` are required. Use `anti-affinity` for strict host separation. Use `soft-anti-affinity` when you prefer host spread but do not want ECS creation to fail only because HCS cannot satisfy the hard placement rule. For planning guidance, see [Control Plane HA Placement Plan](../infrastructure/huawei-cloud-stack.mdx#control-plane-ha-placement).
 
 ### Configure Cluster
 
@@ -567,6 +575,32 @@ kubectl get machines -n cpaas-system
 # Verify cluster deployment status
 kubectl get clustermodule <cluster-name> -o jsonpath='{.status.base.deployStatus}'
 ```
+
+### Verify Control Plane HA \{#verify-control-plane-ha}
+
+If you enabled `HCSCluster.spec.controlPlaneHA`, inspect the `HCSCluster` condition first:
+
+```bash
+kubectl get hcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{range .status.conditions[?(@.type=="ControlPlaneHAReady")]}{.status}{" "}{.reason}{" "}{.message}{"\n"}{end}'
+```
+
+Interpret the condition as follows:
+
+| Status and reason | Meaning | Next step |
+|-------------------|---------|-----------|
+| `True ControlPlaneHAReady` | The provider-managed server group exists and the current control-plane ECS members are tracked. | No action is required. |
+| `False ControlPlaneHAPending` | The provider is waiting for a recoverable state, such as ECS creation or server group membership convergence. | Read the message and wait for the referenced control-plane machine or ECS operation to finish. |
+| `False ControlPlaneHAFailed` | The provider could not create, validate, update, or clean up the server group, or HCS rejected ECS scheduling for the selected policy. | Read the message, then check HCS capacity, the selected policy, and controller logs if needed. |
+
+Inspect the observed server group and membership snapshot:
+
+```bash
+kubectl get hcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='serverGroup={.status.controlPlaneHA.name}{" id="}{.status.controlPlaneHA.id}{" policy="}{.status.controlPlaneHA.policy}{"\n"}{range .status.controlPlaneHA.members[*]}{.machineName}{" "}{.serverID}{"\n"}{end}'
+```
+
+For `anti-affinity`, HCS treats the server group policy as a hard scheduling constraint. If capacity is insufficient, ECS creation can fail and the condition message should be used as the first diagnostic signal. For `soft-anti-affinity`, HCS tries to spread members but may still place multiple ECS instances on the same host.
 
 ### Expected Results
 

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -415,7 +415,7 @@ spec:
 | `.spec.networkType` | string | Currently only supports "kube-ovn" | Yes |
 | `.spec.site` | string | DCS platform site ID | Yes |
 
-`controlPlaneHA` is optional. When enabled, the provider creates and maintains one DRS `ruleType=2` mutual-exclusion rule for the current control-plane VMs in this workload cluster. DCS performs the actual placement and runtime migration. For infrastructure prerequisites, see [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
+`controlPlaneHA` is optional. When enabled, the provider creates and maintains one DRS `ruleType=2` mutual-exclusion rule for the current control-plane VMs in this workload cluster. DCS performs the actual placement and runtime migration. The provider does not run DRS or apply DRS recommendations. If the rule is maintained but placement has not converged, wait for the DCS scheduling mechanism or trigger/apply DRS from the DCS platform side. For infrastructure prerequisites, see [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
 
 #### Single-Control-Plane (No External LB) Layout \{#single-control-plane-layout}
 

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -376,7 +376,7 @@ spec:
 
 For component versions (e.g., `<dns-image-tag>`, `<etcd-image-tag>`), refer to [OS Support Matrix](../overview/os-support-matrix.mdx).
 
-### Configure DCSCluster
+### Configure DCSCluster \{#configure-dcscluster}
 
 DCSCluster is the infrastructure cluster declaration that references the load balancer and DCS platform credentials.
 
@@ -396,6 +396,9 @@ spec:
   controlPlaneEndpoint:
     host: <load-balancer-ip-or-domain-name>
     port: 6443
+  # Optional. Enable only when the target DCS compute cluster has DRS enabled.
+  controlPlaneHA:
+    enabled: true
   networkType: kube-ovn
   site: <site>
 ```
@@ -408,8 +411,11 @@ spec:
 | `.spec.controlPlaneLoadBalancer.type` | string | Currently only supports "external" | Yes |
 | `.spec.controlPlaneLoadBalancer.host` | string | Load balancer IP or domain name | Yes |
 | `.spec.credentialSecretRef.name` | string | DCS authentication Secret name. The Secret defines whether DCS Provider authenticates as an interface interconnection user (default) or a domain user — see [Credential User Types](../infrastructure/huawei-dcs.mdx#user-types). | Yes |
+| `.spec.controlPlaneHA.enabled` | bool | Enables a provider-managed DCS DRS mutual-exclusion rule for control-plane VMs. Set it to `true` only when the target DCS compute cluster has DRS enabled and has enough hosts and capacity for cross-host placement. | No |
 | `.spec.networkType` | string | Currently only supports "kube-ovn" | Yes |
 | `.spec.site` | string | DCS platform site ID | Yes |
+
+`controlPlaneHA` is optional. When enabled, the provider creates and maintains one DRS `ruleType=2` mutual-exclusion rule for the current control-plane VMs in this workload cluster. DCS performs the actual placement and runtime migration. For infrastructure prerequisites, see [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
 
 #### Single-Control-Plane (No External LB) Layout \{#single-control-plane-layout}
 
@@ -533,6 +539,32 @@ For clusters that use additional NICs, also verify that the provider recorded th
 kubectl -n cpaas-system get dcsmachine -l cluster.x-k8s.io/cluster-name=<cluster-name> \
   -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.networkConfig.ip}{"\t"}{.status.additionalNic}{"\n"}{end}'
 ```
+
+### Verify Control Plane HA \{#verify-control-plane-ha}
+
+If you enabled `DCSCluster.spec.controlPlaneHA.enabled`, inspect the `DCSCluster` condition first:
+
+```bash
+kubectl get dcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{range .status.conditions[?(@.type=="ControlPlaneHAReady")]}{.status}{" "}{.reason}{" "}{.message}{"\n"}{end}'
+```
+
+Interpret the condition as follows:
+
+| Status and reason | Meaning | Next step |
+|-------------------|---------|-----------|
+| `True ControlPlaneHAReady` | The provider-managed DRS rule exists and the provider has observed the current control-plane VMs on different DCS hosts. | No action is required. |
+| `False ControlPlaneHAPending` | The provider is waiting for a recoverable state, such as enough VM URNs, enough members, or DCS-side placement. | Read the message. If it mentions placement, check DCS host capacity, DRS status, and whether runtime migration is blocked. |
+| `False ControlPlaneHAFailed` | The provider could not query, validate, create, update, delete, or check the DRS rule. | Read the message, then check the DCS credential, DRS settings, rule-name conflicts, and controller logs if needed. |
+
+Inspect the observed rule and membership snapshot:
+
+```bash
+kubectl get dcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='rule={.status.controlPlaneHA.ruleName}{" index="}{.status.controlPlaneHA.ruleIndex}{" cluster="}{.status.controlPlaneHA.clusterUrn}{"\n"}{range .status.controlPlaneHA.members[*]}{.machineName}{" "}{.vmUrn}{"\n"}{end}'
+```
+
+The `members[]` list contains the CAPI Machine name and DCS VM URN for each control-plane VM in the rule. The current DCS status snapshot does not include the DCS host name. If you need to confirm the exact host placement, query the VM details from the DCS platform or DCS API and compare the VM `hostName` or `hostUrn` values.
 
 ### Expected Results
 

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -47,6 +47,7 @@ Prepare the following inputs before you create or edit any cluster manifests:
 | `vipAddress` and `vipSubnetName` | `HCSCluster.spec.controlPlaneLoadBalancer` | HCS ELB address plan | Yes | `vipAddress` must belong to `vipSubnetName` |
 | `elbVirsubnetL4Ips` and `elbVirsubnetL7Ips` | `HCSCluster.spec.controlPlaneLoadBalancer` | HCS ELB address plan | Yes | Each L4 or L7 entry must include exactly two IPs |
 | `vipDomainName` | `HCSCluster.spec.controlPlaneLoadBalancer` | HCS Cloud DNS Private Zones | Recommended | Configure the domain so it already resolves to `vipAddress` |
+| Control plane HA placement policy | `HCSCluster.spec.controlPlaneHA` | HCS scheduling policy plan | No | Required only when you enable provider-managed control-plane server groups. Choose `anti-affinity` or `soft-anti-affinity` |
 | `controlPlaneEndpoint` | `Cluster.status` / derived cluster endpoint | Controller-managed | No | Do not prepare or write this field in create manifests; the controller fills it after the ELB is ready |
 
 ## Credential Secret Inputs
@@ -139,6 +140,21 @@ If you set `vipDomainName`, configure HCS Cloud DNS Private Zones so the domain 
 - Do not disable Hybrid Load Balancing on the HCS ELB after the cluster is created.
 - Do not write `spec.controlPlaneEndpoint` in the create manifest. The controller fills that field after the ELB is ready.
 
+## Control Plane HA Placement Plan \{#control-plane-ha-placement}
+
+For a multi-replica control plane, you can configure the HCS provider to create and maintain a provider-owned server group for control-plane ECS placement. Enable this through `HCSCluster.spec.controlPlaneHA` when you write the cluster manifest.
+
+Plan the placement policy before you enable the feature:
+
+| Policy | Behavior | Operational impact |
+|--------|----------|--------------------|
+| `anti-affinity` | Hard anti-affinity. HCS must place control-plane ECS instances on different hosts. | Use this when strict host separation is required. ECS creation can fail if HCS cannot find enough capacity that satisfies the rule. |
+| `soft-anti-affinity` | Best-effort anti-affinity. HCS tries to place control-plane ECS instances on different hosts. | Use this when you prefer spread but do not want the rule to block ECS creation. Final placement may still share a host. |
+
+This feature is cluster-scoped and applies only to control-plane machines. It does not configure worker node pools. The provider creates the server group, attaches control-plane ECS creation requests to that group, records the server group in `HCSCluster.status.controlPlaneHA`, and reports progress through the `ControlPlaneHAReady` condition.
+
+For the manifest example and verification commands, see [Configure HCSCluster](../create-cluster/huawei-cloud-stack.mdx#configure-hcscluster) and [Verify Control Plane HA](../create-cluster/huawei-cloud-stack.mdx#verify-control-plane-ha).
+
 ## Static IP Pool Plan
 
 This page focuses on the planned static IP workflow.
@@ -213,6 +229,7 @@ Use the following mapping after you complete the preparation checklist:
 | Control plane and worker hostnames, static IPs, and pool-managed persistent disks | `HCSMachineConfigPool.spec.configs[]` |
 | VPC name, subnet inventory, security group name | `HCSCluster.spec.network.*` |
 | `vipAddress`, `vipSubnetName`, `vipDomainName`, `elbVirsubnetL4Ips`, `elbVirsubnetL7Ips` | `HCSCluster.spec.controlPlaneLoadBalancer.*` |
+| Control plane HA placement policy | `HCSCluster.spec.controlPlaneHA.*` |
 | Kubernetes version and component baseline | `KubeadmControlPlane.spec.version`, `Cluster.spec.clusterNetwork.*`, cluster annotations, and related bootstrap settings |
 
 ## Next Steps

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -153,6 +153,8 @@ Plan the placement policy before you enable the feature:
 
 This feature is cluster-scoped and applies only to control-plane machines. It does not configure worker node pools. The provider creates the server group, attaches control-plane ECS creation requests to that group, records the server group in `HCSCluster.status.controlPlaneHA`, and reports progress through the `ControlPlaneHAReady` condition.
 
+For an existing cluster, enabling `HCSCluster.spec.controlPlaneHA` creates and records the provider-owned server group, but it does not retroactively add already-running control-plane ECS instances to that group. Server group placement is applied when a control-plane ECS is created with `os:scheduler_hints.group`. To converge an existing cluster, enable `controlPlaneHA`, wait for `HCSCluster.status.controlPlaneHA.id`, then trigger a control-plane rolling replacement so replacement ECS instances are created with the server group. Until the current control-plane ECS members have been replaced and observed in the group, `ControlPlaneHAReady` can remain `False` with reason `ControlPlaneHAPending`.
+
 For the manifest example and verification commands, see [Configure HCSCluster](../create-cluster/huawei-cloud-stack.mdx#configure-hcscluster) and [Verify Control Plane HA](../create-cluster/huawei-cloud-stack.mdx#verify-control-plane-ha).
 
 ## Static IP Pool Plan

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -485,6 +485,8 @@ The DCS Provider does not implement host pinning or Cluster API `FailureDomain` 
 
 The provider creates and updates a DRS `ruleType=2` mutual-exclusion rule after the control-plane VMs exist and their VM URNs are known. The rule lists the current control-plane VMs for one workload cluster and asks the DCS scheduler to keep them on different physical hosts. DCS remains responsible for executing the placement decision and any runtime migration.
 
+The provider does not call the DCS Run DRS API and does not apply DRS recommendations. If `ControlPlaneHAReady` stays `False` with reason `ControlPlaneHAPending` after the rule has been maintained, the DCS scheduler has not converged the placement yet. Wait for DCS-side scheduling, or use the DCS platform operation process to run DRS and apply the generated recommendations.
+
 Before you enable this feature, verify the following DCS-side requirements:
 
 - The target DCS compute cluster has DRS enabled.

--- a/docs/en/infrastructure/huawei-dcs.mdx
+++ b/docs/en/infrastructure/huawei-dcs.mdx
@@ -464,7 +464,7 @@ Host placement on the DCS platform is performed by the DCS scheduler. The DCS Pr
 Two consequences follow from this:
 
 - **Capacity hot spots**: If the DCS cluster has uneven host load (for example, one host is severely CPU-over-committed while another is mostly idle), the DCS scheduler may refuse new placements on the over-committed host. The deploy task can stall until the load is rebalanced on the DCS side or DRS is enabled. Use the snippet below to confirm whether host load is the cause.
-- **No automatic spread for control plane**: Control-plane virtual machines from a single `DCSMachineTemplate` are not automatically distributed across multiple physical hosts. For high-availability deployments, configure VM-VM anti-affinity on the DCS platform side as described in [Cross-Host High Availability for Control Plane](#cross-host-ha) below.
+- **Control plane spread depends on DRS**: Control-plane virtual machines are not pinned to specific hosts through the machine template. For high-availability deployments, enable provider-managed DRS mutual exclusion as described in [Cross-Host High Availability for Control Plane](#cross-host-ha) below.
 
 To check current host load before applying a new template:
 
@@ -481,11 +481,30 @@ A `cpuMuxRatio` (CPU allocation / physical cores) above ~3× on every host in th
 
 ### Cross-Host High Availability for Control Plane \{#cross-host-ha}
 
-The DCS Provider does not currently implement host pinning or Cluster API `FailureDomain` spreading. As a result, the three control-plane virtual machines of a Kubernetes cluster created through this provider can be placed on the same physical DCS Host. If that host fails, the entire Kubernetes control plane is unavailable until the host recovers.
+The DCS Provider does not implement host pinning or Cluster API `FailureDomain` spreading. Instead, it can maintain a provider-owned DCS DRS rule for control-plane virtual machines when you enable `DCSCluster.spec.controlPlaneHA`.
 
-To force control-plane virtual machines onto different physical hosts, configure a VM-VM anti-affinity rule on the DCS platform side. The DCS platform calls this feature 互斥虚拟机 (Mutually Exclusive Virtual Machines). The rule is configured under the DCS Cluster's compute resource scheduling settings, lists the control-plane virtual machines by name, and instructs the DCS scheduler to keep those virtual machines on different hosts.
+The provider creates and updates a DRS `ruleType=2` mutual-exclusion rule after the control-plane VMs exist and their VM URNs are known. The rule lists the current control-plane VMs for one workload cluster and asks the DCS scheduler to keep them on different physical hosts. DCS remains responsible for executing the placement decision and any runtime migration.
 
-A full operational runbook for this configuration is being prepared and will be published as a separate document. Until it is available, follow the DCS / FusionCompute platform documentation, or contact the DCS platform support team. Two prerequisites apply on the DCS side: the target cluster must have enough healthy hosts (typically at least one host per control-plane virtual machine), and the cluster must have DRS enabled if the rule should also be honoured during runtime rebalancing.
+Before you enable this feature, verify the following DCS-side requirements:
+
+- The target DCS compute cluster has DRS enabled.
+- The target DCS compute cluster has enough healthy hosts and capacity. A three-replica control plane normally needs at least three usable hosts.
+- The selected datastores are visible from all hosts that may run the control-plane VMs.
+- Runtime DRS migration is not blocked by DCS-side constraints such as a mounted CD-ROM device.
+
+Enable the feature in `DCSCluster.spec.controlPlaneHA` when you write the cluster manifest. For the manifest example and the status fields to watch, see [Configure DCSCluster](../create-cluster/huawei-dcs.mdx#configure-dcscluster) and [Verify Control Plane HA](../create-cluster/huawei-dcs.mdx#verify-control-plane-ha).
+
+After the cluster is created, inspect the condition and status on `DCSCluster`:
+
+```bash
+kubectl get dcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{range .status.conditions[?(@.type=="ControlPlaneHAReady")]}{.status}{" "}{.reason}{" "}{.message}{"\n"}{end}'
+
+kubectl get dcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{.status.controlPlaneHA}{"\n"}'
+```
+
+`ControlPlaneHAReady=True` means the provider-managed DRS rule exists and the provider has observed the current control-plane VMs on different DCS hosts. `ControlPlaneHAReady=False` with reason `ControlPlaneHAPending` usually means the controller is waiting for VM URNs, waiting for enough members, or waiting for DCS-side placement to converge. `ControlPlaneHAReady=False` with reason `ControlPlaneHAFailed` means the provider could not query, validate, create, update, delete, or check the DRS rule. Read the condition message before checking controller logs.
 
 ### Troubleshooting: VM stuck in `creating` \{#stuck-creating}
 

--- a/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsclusters.yaml
+++ b/docs/shared/crds/providers/huawei-cloud-stack/infrastructure.cluster.x-k8s.io_hcsclusters.yaml
@@ -55,6 +55,25 @@ spec:
                 - host
                 - port
                 type: object
+              controlPlaneHA:
+                description: ControlPlaneHA configures the provider-managed control-plane
+                  server group.
+                properties:
+                  enabled:
+                    description: Enabled controls whether provider creates and uses
+                      a control-plane server group.
+                    type: boolean
+                  policy:
+                    description: Policy is the HCS server group policy used for control-plane
+                      ECS placement.
+                    enum:
+                    - anti-affinity
+                    - soft-anti-affinity
+                    type: string
+                required:
+                - enabled
+                - policy
+                type: object
               controlPlaneLoadBalancer:
                 properties:
                   elbVirsubnetL4Ips:
@@ -357,6 +376,26 @@ spec:
                   - type
                   type: object
                 type: array
+              controlPlaneHA:
+                description: ControlPlaneHA records the provider-managed control-plane
+                  server group observed state.
+                properties:
+                  id:
+                    type: string
+                  members:
+                    items:
+                      properties:
+                        machineName:
+                          type: string
+                        serverID:
+                          type: string
+                      type: object
+                    type: array
+                  name:
+                    type: string
+                  policy:
+                    type: string
+                type: object
               ready:
                 default: false
                 description: Ready indicates whether the cluster is in a ready state.

--- a/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsclusters.yaml
+++ b/docs/shared/crds/providers/huawei-dcs/infrastructure.cluster.x-k8s.io_dcsclusters.yaml
@@ -57,6 +57,17 @@ spec:
                 - host
                 - port
                 type: object
+              controlPlaneHA:
+                description: |-
+                  ControlPlaneHA enables provider-managed DRS mutual-exclusion rules for
+                  control-plane VMs. The controller maintains the rule after VM URNs exist;
+                  DCS is responsible for executing DRS placement.
+                properties:
+                  enabled:
+                    description: Enabled turns on provider-managed DRS mutual exclusion
+                      for control-plane VMs.
+                    type: boolean
+                type: object
               controlPlaneLoadBalancer:
                 properties:
                   host:
@@ -174,6 +185,42 @@ spec:
                   - type
                   type: object
                 type: array
+              controlPlaneHA:
+                description: |-
+                  ControlPlaneHA records the provider-managed DRS rule currently owned by
+                  this cluster. Members are a snapshot from the latest reconcile.
+                properties:
+                  clusterUrn:
+                    description: ClusterUrn is the DCS compute cluster URN where the
+                      rule is maintained.
+                    type: string
+                  members:
+                    description: Members is the latest control-plane VM membership
+                      snapshot.
+                    items:
+                      description: ControlPlaneHAMember records one control-plane
+                        VM included in the DRS rule.
+                      properties:
+                        machineName:
+                          description: MachineName is the owning CAPI Machine name
+                            when known.
+                          type: string
+                        vmUrn:
+                          description: VMUrn is the DCS VM URN used as the DRS rule
+                            member.
+                          type: string
+                      type: object
+                    type: array
+                  ruleIndex:
+                    description: |-
+                      RuleIndex is the DCS rule index returned by cluster detail. It must be
+                      used together with RuleName validation.
+                    type: integer
+                  ruleName:
+                    description: RuleName is the deterministic provider-generated
+                      DRS rule name.
+                    type: string
+                type: object
               failureDomains:
                 additionalProperties:
                   description: |-


### PR DESCRIPTION
## Summary

- 将 release-1.0 PR #106 的 control plane HA 文档改动同步到 master。
- 补充 DCS control plane HA 文档：说明通过 `DCSCluster.spec.controlPlaneHA.enabled=true` 启用 provider 维护的 DRS mutual-exclusion rule，并补充 DRS 前置条件、CD-ROM 调度限制、condition/status 查看方式。
- 补充 HCS control plane HA 文档：说明通过 `HCSCluster.spec.controlPlaneHA` 配置 `enabled` 和 `policy`，覆盖 `anti-affinity` / `soft-anti-affinity` 行为、适用范围和 condition/status 查看方式。
- 更新 DCS/HCS create-cluster 示例和 CRD reference，让 `controlPlaneHA` 字段在用户文档和 CRD 文档中保持一致。

## Related PRs / MRs

- release-1.0 docs PR: https://github.com/alauda/immutable-infra-docs/pull/106
- DCS implementation MR: https://gitlab-ce.alauda.cn/ait/cluster-api-provider-dcs/-/merge_requests/40
- HCS implementation MR: https://gitlab-ce.alauda.cn/ait/cluster-api-provider-hcs/-/merge_requests/16

## Validation

- `git diff --check origin/master...HEAD`
- conflict marker scan for docs paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Control-plane high availability configuration now available for Huawei-managed clusters with selectable placement policies.

* **Documentation**
  * Added comprehensive guides for configuring and verifying control-plane HA on Huawei Cloud Stack and DCS clusters.
  * Included status condition interpretation and troubleshooting procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->