### PR TITLE
docs(AIT-71982): backport bare-metal doc updates to release-1.0

### DIFF
--- a/.cspell/abbreviations.txt
+++ b/.cspell/abbreviations.txt
@@ -2,3 +2,6 @@ CAPI
 CAPV
 Kubeadm
 kubelet
+blkid
+COS
+VD

--- a/docs/en/create-cluster/bare-metal.mdx
+++ b/docs/en/create-cluster/bare-metal.mdx
@@ -59,11 +59,22 @@ nmcli connection up "Wired connection 1"
 
 ### 4. TPM Decision
 
-Production hosts should keep `MachineRegistration.spec.config.elemental.registration.emulate-tpm: false` (or remove the field). For PoC and virtual-machine smoke tests, set `emulate-tpm: true` and `emulated-tpm-seed: -1` so registration works without a real TPM.
+Set `MachineRegistration.spec.config.elemental.registration.emulate-tpm` from whether the host exposes a **real hardware TPM** (`/dev/tpm0`), not from whether it is physical or virtual:
+
+- `emulate-tpm: false` (or omit the field) — only when the host has a working hardware TPM, so `elemental-register` can use it for `auth: tpm`.
+- `emulate-tpm: true` with `emulated-tpm-seed: -1` — for any host **without** a hardware TPM. This includes both virtual machines and physical servers that ship without a TPM module (for example a Dell R620). On such a host, `auth: tpm` combined with `emulate-tpm: false` makes `elemental-register` fail TPM attestation and never send the registration request, so `elemental-operator` records zero registration POSTs.
 
 ### 5. Public Registry Credential (Only When Installing Platform Components Later)
 
 `public-registry-credential` is **not** required to create a bare-metal cluster. It only becomes necessary when later platform components on the new workload cluster need to pull from a credentialed public registry. If your test scope ends at cluster + node Ready, you can ignore this prerequisite.
+
+### 6. Host Disk and Boot Preparation
+
+Prepare **every** disk and virtual disk (VD) on each host before you boot the `SeedImage` ISO:
+
+- Wipe all disks so that no bootable previous operating system remains. The host must boot the ISO, not an old on-disk OS.
+- Remove residual Elemental partition labels — `COS_STATE`, `COS_PERSISTENT`, `COS_OEM`, `COS_RECOVERY` — from **all** disks, not only the intended install disk. Elemental resolves partitions by label (`blkid -L COS_STATE`); a stale label left on a second disk (for example from a previous install or a leftover multipath member) makes it resolve the wrong device and the reprovision snapshotter fails.
+- Set the boot order so the host boots the virtual CD / ISO first.
 
 ---
 
@@ -151,9 +162,9 @@ spec:
           type: btrfs
           maxSnaps: 4
       registration:
-        # Keep false for production hardware and for VM tests that already
-        # expose stable SMBIOS identity. Set true only for lab hosts without
-        # a usable TPM or stable identity source.
+        # false only when the host has a real hardware TPM (/dev/tpm0). Set true
+        # (with emulated-tpm-seed: -1) on any host without one, including physical
+        # servers that ship without a TPM module.
         emulate-tpm: false
 ---
 apiVersion: elemental.cattle.io/v1beta1

--- a/docs/en/create-cluster/bare-metal.mdx
+++ b/docs/en/create-cluster/bare-metal.mdx
@@ -74,6 +74,7 @@ Prepare **every** disk and virtual disk (VD) on each host before you boot the `S
 
 - Wipe all disks so that no bootable previous operating system remains. The host must boot the ISO, not an old on-disk OS.
 - Remove residual Elemental partition labels — `COS_STATE`, `COS_PERSISTENT`, `COS_OEM`, `COS_RECOVERY` — from **all** disks, not only the intended install disk. Elemental resolves partitions by label (`blkid -L COS_STATE`); a stale label left on a second disk (for example from a previous install or a leftover multipath member) makes it resolve the wrong device and the reprovision snapshotter fails.
+- On hosts where the same disk can appear through more than one path (multipath), make sure none of those paths exposes a disk that still carries a `COS_*` label; a residual label on any path can be resolved ahead of the intended install disk. Clean the disk rather than disabling multipath — the image keeps it enabled for network-attached storage boot.
 - Set the boot order so the host boots the virtual CD / ISO first.
 
 ---

--- a/docs/en/global/disaster_recovery.mdx
+++ b/docs/en/global/disaster_recovery.mdx
@@ -56,7 +56,9 @@ Use different system-agent endpoints for `global` hosts and workload-cluster hos
 | Machines that belong to the active `global` cluster | `https://<current-global-control-plane-vip>/kubernetes/global` |
 | Machines that belong to non-`global` workload clusters | `https://<platform-domain>/kubernetes/global` |
 
-Both endpoints are platform ingress paths, not direct kube-apiserver `:6443` endpoints. For the bootstrap KIND phase, `global` host registration uses the bootstrap host endpoint, normally `https://<bootstrap-host-ip>:12443`. Handoff changes only the installed `global` hosts to the final VIP endpoint.
+By default both endpoints are platform ingress paths, not direct kube-apiserver `:6443` endpoints. For the bootstrap KIND phase, `global` host registration uses the bootstrap host endpoint, normally `https://<bootstrap-host-ip>:12443`. Handoff changes only the installed `global` hosts to the final VIP endpoint.
+
+For a DR `global` cluster that must keep managing its own hosts without depending on its own ingress, opt in to direct kube-apiserver access by setting `handoffHook.directAPIServer: true` on the Bare Metal provider AppRelease (this requires `handoffHook.controlPlaneVIP`). Handoff then points `global`-cluster machines at `https://<current-global-control-plane-vip>:6443` directly, with no `/kubernetes/global` ingress path, and the agent trusts the apiserver with the in-cluster apiserver CA instead of the platform-ingress certificate. The parameter defaults to `false` (the ingress endpoint above); it applies only to `global`-cluster machines, and workload-cluster machines always keep the ingress path.
 
 <Directive type="warning" title="Do Not Reuse the Bootstrap ISO After Handoff">
   A `SeedImage` generated in the bootstrap KIND environment points at the bootstrap registration endpoint. After the `global` cluster is installed and handed off, create new `MachineRegistration` and `SeedImage` resources on the active `global` cluster for any new `global` hosts. A pre-failover workload ISO can be reused after failover only when its registration URL uses the platform domain and the matching non-`global` `MachineRegistration` was synchronized to standby.
@@ -73,6 +75,8 @@ metadata:
   annotations:
     baremetal.cluster.io/system-agent-server-url: https://<current-global-control-plane-vip>
 ```
+
+When the `global` cluster was handed off with `handoffHook.directAPIServer: true`, keep new `global` registrations on the same direct-apiserver endpoint instead: set `baremetal.cluster.io/system-agent-server-url: https://<current-global-control-plane-vip>:6443` and add `baremetal.cluster.io/system-agent-direct: "true"`. The elemental operator then serves that URL verbatim and does not append `/kubernetes/global`.
 
 ### Shared Token Requirements
 
@@ -199,7 +203,7 @@ Bare Metal requires all of the following to be aligned:
 - Same ServiceAccount signing key files and same issuer/audience values on both sides.
 - Same trusted platform certificate chain, with SANs that cover the platform domain, primary control-plane VIP, and standby control-plane VIP.
 - `dcs-import-extra-resources` created before the installer API call on both sides.
-- Bare Metal provider AppRelease values set with `handoffHook.controlPlaneVIP` for the local side and `elemental.systemAgent.authMode: shared`.
+- Bare Metal provider AppRelease values set with `handoffHook.controlPlaneVIP` for the local side and `elemental.systemAgent.authMode: shared`. Add `handoffHook.directAPIServer: true` only when the `global`-cluster machines must reach the kube-apiserver directly at `https://<control-plane-vip>:6443` instead of the ingress path (see Endpoint Rules); it defaults to `false`.
 
 Do not sync `SeedImage` from primary to standby. Sync non-`global` `MachineRegistration` resources when workload ISOs need to remain valid across failover. Do not sync primary `global` `MachineRegistration` resources to standby; create them locally on the active side and set `baremetal.cluster.io/system-agent-server-url` to that side's control-plane VIP.
 

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -2043,6 +2043,9 @@ handoffHook:
   delivery:
     enabled: true
     mode: always
+  # directAPIServer: true   # DR opt-in only. Points global-cluster machines at
+  #   https://<control-plane-vip>:6443 directly instead of the platform ingress
+  #   path. Defaults to false. See "Bare Metal DR Model" in Disaster Recovery.
 
 elemental:
   systemAgent:

--- a/docs/en/overview/providers/bare-metal.mdx
+++ b/docs/en/overview/providers/bare-metal.mdx
@@ -163,7 +163,7 @@ The bare-metal provider enforces that support decision through `elemental-image-
 - A platform registry reachable from each host (used by both `elemental install` and `elemental upgrade`). Set `global.registry.address` and, when the registry is self-signed, leave `global.registry.tlsVerify=false` (chart default).
 - A control-plane VIP, free port (typically `6443`), and a `vrid` unique within the control-plane Layer-2 broadcast domain.
 - One `MachineInventoryPool` per role (control plane, worker) sized to at least the target replica count plus headroom for upgrades.
-- TPM available on production hosts. Lab and PoC hosts can keep `MachineRegistration.spec.config.elemental.registration.emulate-tpm: true` to bypass real TPM hardware.
+- A host with a real hardware TPM (`/dev/tpm0`) can register with `emulate-tpm: false`. Any host without a hardware TPM — virtual machines and physical servers that ship without a TPM module alike — must set `MachineRegistration.spec.config.elemental.registration.emulate-tpm: true`; the physical-versus-virtual distinction does not apply.
 
 ## Documentation
 


### PR DESCRIPTION
Backport of https://github.com/alauda/immutable-infra-docs/pull/119 to release-1.0.

Cherry-picked:
- 0fd558d docs(AIT-71982): bare-metal DR direct-apiserver opt-in, TPM rule, disk prep
- 6893f80 docs(AIT-71982): cover multipath residual-label case in disk prep (item 2)

Verification:
- yarn lint
- yarn build