### PR TITLE
docs(AIT-72246): update VMware deployment guidance

### DIFF
--- a/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
@@ -48,7 +48,8 @@ Before you begin, ensure the following conditions are met:
 5. All required static IP addresses are allocated and not in use.
 6. `ClusterResourceSet=true` is enabled.
 7. The platform already has a valid public registry configuration.
-8. The platform can process the cluster annotations required to install the network plugin.
+8. The bootstrap registry is reachable through `<bootstrap_ip>:11443` from workload nodes and contains the required `kube-ovn`, CoreDNS, etcd, and kube-apiserver tags.
+9. The platform can process the cluster annotations required to install the network plugin.
 
 ## Key Objects
 
@@ -146,12 +147,24 @@ kubectl -n cpaas-system get deploy capi-controller-manager -o jsonpath='{.spec.t
 kubectl -n cpaas-system get secret public-registry-credential -o jsonpath='{.data.content}'
 ```
 
+Run the following commands on the bootstrap host to verify that the required tags exist in the local registry:
+
+```bash
+curl -sk http://127.0.0.1:11443/v2/acp/chart-cpaas-kube-ovn/tags/list
+curl -sk http://127.0.0.1:11443/v2/tkestack/coredns/tags/list
+curl -sk http://127.0.0.1:11443/v2/tkestack/etcd/tags/list
+curl -sk http://127.0.0.1:11443/v2/tkestack/kube-apiserver/tags/list
+```
+
+The commands above query the local registry endpoint from the bootstrap host. In the workload `Cluster` manifest, set the registry annotation to `<bootstrap_ip>:11443`.
+
 Confirm the following results:
 
 - The `global` cluster is reachable.
 - Alauda Container Platform Kubeadm Provider and Alauda Container Platform VMware vSphere Infrastructure Provider are running.
 - The controller arguments include `ClusterResourceSet=true`.
 - The public registry credential `data.content` is not empty.
+- The bootstrap registry contains the required `kube-ovn`, CoreDNS, etcd, and kube-apiserver tags.
 
 Before you continue, also verify the following items:
 
@@ -201,7 +214,7 @@ kubectl apply -f 01-vsphere-credentials-secret.yaml
 
 ### Create the `Cluster` and `VSphereCluster` objects
 
-Create the base cluster manifest with the workload cluster network settings, the control plane endpoint, and the vCenter connection settings.
+Create the base cluster manifest with the workload cluster network settings, the control plane endpoint, and the vCenter connection settings. Set `cpaas.io/registry-address` to the bootstrap node address in the form `<bootstrap_ip>:11443`.
 
 ```yaml title="10-cluster.yaml"
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -221,6 +234,7 @@ metadata:
     cpaas.io/network-type: kube-ovn
     cpaas.io/kube-ovn-version: <kube_ovn_version>
     cpaas.io/kube-ovn-join-cidr: <kube_ovn_join_cidr>
+    cpaas.io/registry-address: <bootstrap_ip>:11443
 spec:
   clusterNetwork:
     pods:
@@ -525,6 +539,10 @@ Each node slot declares its NIC layout under `network.primary` (required) and `n
 `deviceName` is optional. If you do not need to force the guest NIC name, remove the `deviceName` line from every node slot. The provider assigns NIC names such as `eth0`, `eth1` by NIC order.
 </Directive>
 
+<Directive type="warning">
+The `dns` entries in `VSphereMachineConfigPool` are kept in the static network configuration, but they might not update the guest operating system's `/etc/resolv.conf` reliably in affected VMware deployments. The control plane and worker bootstrap manifests below therefore also write `/etc/resolv.conf` explicitly through kubeadm `files`.
+</Directive>
+
 ```yaml title="02-vspheremachineconfigpool-control-plane.yaml"
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineConfigPool
@@ -663,6 +681,14 @@ Create the `VSphereMachineTemplate` and `KubeadmControlPlane` objects. Replace t
 
 `cloneMode` and `diskGiB` both remain present in the template because CAPV accepts both fields. In practice, `diskGiB` only affects the system disk when the actual clone operation is `fullClone`. If `cloneMode` is `linkedClone` and the template has a usable snapshot, CAPV completes a linked clone and the system disk size remains equal to the source template. If no usable snapshot exists, CAPV falls back to `fullClone`, and `diskGiB` applies again.
 
+<Directive type="warning" title="System disk and persistent disks are separate">
+`VSphereMachineTemplate.spec.template.spec.diskGiB` sets only the VM system disk size. It is not the total capacity of all disks on the node.
+
+Data disks are declared separately under `VSphereMachineConfigPool.spec.configs[].persistentDisks[]`. Do not add the persistent disk sizes to `diskGiB`; otherwise the VM can receive a larger system disk plus the separate data disks, which doubles the intended capacity.
+
+For `fullClone`, `diskGiB` must be greater than or equal to the system disk size in the OS image template. For `linkedClone`, the system disk remains at the template size and `diskGiB` is ignored.
+</Directive>
+
 ```yaml title="20-control-plane.yaml"
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
@@ -720,6 +746,12 @@ spec:
       sshAuthorizedKeys:
       - "<ssh_public_key>"
     files:
+    - path: /etc/resolv.conf
+      owner: "root:root"
+      append: false
+      permissions: "0644"
+      content: |
+        nameserver <nic1_dns_1>
     - path: /etc/kubernetes/admission/psa-config.yaml
       owner: "root:root"
       permissions: "0644"
@@ -1032,6 +1064,12 @@ spec:
   template:
     spec:
       files:
+      - path: /etc/resolv.conf
+        owner: "root:root"
+        append: false
+        permissions: "0644"
+        content: |
+          nameserver <nic1_dns_1>
       - path: /etc/kubernetes/patches/kubeletconfiguration0+strategic.json
         owner: "root:root"
         permissions: "0644"
@@ -1210,7 +1248,7 @@ Prioritize the following checks:
 - If the CPI resources are not delivered, verify `ClusterResourceSet=true`, `ClusterResourceSet`, and `ClusterResourceSetBinding`.
 - If `ClusterResourceSet` exists but no `ClusterResourceSetBinding` is created, check whether the controller has the required delete permission on the referenced `ConfigMap` and `Secret` resources.
 - If the network plugin is not installed, verify that the required cluster annotations are present and that the platform controllers processed them.
-- If the `cpaas.io/registry-address` annotation is missing, verify the public registry credential and the platform controller that injects the annotation.
+- If the `cpaas.io/registry-address` annotation is missing or incorrect, verify that it is set to `<bootstrap_ip>:11443`. Also verify the public registry credential and the platform controller that injects the annotation.
 - If a machine is stuck in `Provisioning`, check `VSphereMachine` conditions for `MachineConfigPoolReady` — it shows whether slot allocation failed due to pool binding or datacenter mismatch.
 - If a VM is waiting for IP allocation, verify VMware Tools, the static IP settings, and `VSphereVM.status.addresses`.
 - If workload `Node` objects remain without `spec.providerID`, first verify the CPI delivery resources and then check for duplicate vCenter guest hostnames. When an old VM in the same datacenter still reports the same guest hostname as a new node, `cloud-provider-vsphere` can fall back to node-name lookup, cache the old VM, and reject the new node because the VM IP does not match the kubelet node IP. Check the leader `vsphere-cloud-controller-manager` logs, the node `SystemUUID`, the real VM UUID, and vCenter guest hostname/IP values. After you fix or remove the duplicate hostname or old VM conflict, restart the workload cluster's `vsphere-cloud-controller-manager` Pods to clear the bad in-memory cache:

--- a/docs/en/create-cluster/vmware-vsphere/extension-scenarios.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/extension-scenarios.mdx
@@ -91,6 +91,8 @@ network:
   - networkName: "<nic2_network_name>"
 ```
 
+If the DNS server used by the node changes when you add the second NIC, update the `/etc/resolv.conf` file entries in both `20-control-plane.yaml` and `30-workers-md-0.yaml`. The `dns` values in the machine config pool network blocks do not replace the explicit `/etc/resolv.conf` bootstrap file entries.
+
 If failure domains are enabled, update the network list in `VSphereFailureDomain.spec.topology.networks`:
 
 ```yaml
@@ -312,6 +314,8 @@ The baseline deployment includes the following required data disks:
 
 - **Control plane nodes**: `var-cpaas`, `var-lib-containerd`, and `var-lib-etcd` (3 disks per node). Do not remove any of these disks. The `var-lib-etcd` disk must set `wipeFilesystem: true` to allow `kubeadm join` during rolling updates.
 - **Worker nodes**: `var-cpaas` and `var-lib-containerd` (2 disks per node). Do not remove any of these disks.
+
+`VSphereMachineTemplate.spec.template.spec.diskGiB` is the system disk size, not the total disk capacity of the VM. Keep additional persistent or data disks under `VSphereMachineConfigPool.spec.configs[].persistentDisks[]`. Increase `diskGiB` by the sum of the persistent disks only when you intentionally want a larger system disk.
 
 If a node needs additional data disks beyond the required set, append more entries to the same `persistentDisks` list in the corresponding `VSphereMachineConfigPool` node slot. The following optional fields are especially relevant here:
 

--- a/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/parameter-checklist.mdx
@@ -67,6 +67,8 @@ Each slot declares its NIC layout under `network.primary` and `network.additiona
 - `network.primary` is required. Its `networkName` must be set and is used as the node-ip source for the kubelet.
 - `network.additional` is an optional list of extra NICs merged after the primary NIC in the order listed.
 
+The `dns` values in `VSphereMachineConfigPool.spec.configs[].network` describe the static network metadata for each slot. In affected VMware deployments, these values might not update the guest operating system's `/etc/resolv.conf` reliably. The deployment manifests therefore also write `/etc/resolv.conf` through both `KubeadmControlPlane.spec.kubeadmConfigSpec.files` and `KubeadmConfigTemplate.spec.template.spec.files`.
+
 ### `deviceName`
 
 `deviceName` is an optional field in the `VSphereMachineConfigPool` network configuration. It is used to control the NIC name seen inside the guest operating system, such as `eth0` or `eth1`.
@@ -176,11 +178,32 @@ The control plane VIP is served by an external load balancer that you provision 
 | Pod CIDR | `<pod_cidr>` | Yes | Must not overlap with existing networks. | `10.244.0.0/16` | - |
 | Service CIDR | `<service_cidr>` | Yes | Must not overlap with existing networks. | `10.96.0.0/12` | - |
 | Image registry | `<image_registry>` | Yes | Private registry address. kubeadm `imageRepository` is set to `<image_registry>/tkestack`. | `registry.example.local` | - |
+| Bootstrap registry address | `<bootstrap_ip>:11443` | Yes | Used by the `cpaas.io/registry-address` annotation on the workload `Cluster` resource. Use the bootstrap node IP address because workload nodes must reach this address from outside the bootstrap node. | `10.10.10.5:11443` | - |
 | `kube-ovn` version | `<kube_ovn_version>` | Yes | Must match the platform network plugin requirements. | `v4.2.26` | - |
 | `kube-ovn-join-cidr` | `<kube_ovn_join_cidr>` | Yes | Must not overlap with other networks. | `100.64.0.0/16` | - |
 | CoreDNS image tag | `<dns_image_tag>` | Yes | Use the tag approved for the Kubernetes version. | `1.12.4` | - |
 | etcd image tag | `<etcd_image_tag>` | Yes | Use the tag approved for the Kubernetes version. | `v3.5.0` | - |
 | Encryption provider secret | `<encryption_provider_secret>` | Yes | Base64-encoded AES key for secret encryption at rest. Generate with `head -c 32 /dev/urandom \| base64`. Do not reuse example values. | *(generated)* | - |
+
+### Bootstrap registry tag validation
+
+Run the following commands on the bootstrap host. In this context, `127.0.0.1:11443` is the local registry endpoint on that host.
+
+```bash
+curl -sk http://127.0.0.1:11443/v2/acp/chart-cpaas-kube-ovn/tags/list
+curl -sk http://127.0.0.1:11443/v2/tkestack/coredns/tags/list
+curl -sk http://127.0.0.1:11443/v2/tkestack/etcd/tags/list
+curl -sk http://127.0.0.1:11443/v2/tkestack/kube-apiserver/tags/list
+```
+
+Confirm that the responses include the values you plan to use for:
+
+- `<kube_ovn_version>`
+- `<dns_image_tag>`
+- `<etcd_image_tag>`
+- `<k8s_version>` or the matching kube-apiserver image tag required by the release
+
+Set `cpaas.io/registry-address` in the workload `Cluster` annotation to `<bootstrap_ip>:11443`.
 
 ## Minimum Single-Datacenter Parameters
 
@@ -241,6 +264,17 @@ The control plane VIP is served by an external load balancer that you provision 
 | Worker memory MiB | `<worker_memory_mib>` | Yes | Memory per worker node. | `4096` | - |
 | Worker system datastore | `<worker_system_datastore>` | Yes | Datastore for the worker system disk. | `datastore-worker` | - |
 | Worker system disk size GiB | `<worker_system_disk_gib>` | Yes | Baseline example value is `300`. Ignored when `<clone_mode>` is `linkedClone`; the system disk then stays at the template's size. | `300` | - |
+
+### Disk sizing model
+
+`VSphereMachineTemplate.spec.template.spec.diskGiB` and `VSphereMachineConfigPool.spec.configs[].persistentDisks[]` define different disks.
+
+| Field | Disk type | Meaning |
+|-------|-----------|---------|
+| `VSphereMachineTemplate.spec.template.spec.diskGiB` | System disk | Sets the VM root or system disk size when the VM is created by `fullClone`. The value must be greater than or equal to the system disk size in the OS image template. It is not the sum of all disks. |
+| `VSphereMachineConfigPool.spec.configs[].persistentDisks[]` | Persistent/data disks | Defines extra VMDKs attached to the node slot, such as `/var/cpaas`, `/var/lib/containerd`, and `/var/lib/etcd`. These disks are separate from the system disk. |
+
+Do not add the persistent disk sizes to `diskGiB`. For example, if the OS image has a 100 GiB system disk and the node also needs three 100 GiB persistent disks, use a system disk value that is at least 100 GiB, and define the three 100 GiB data disks under `persistentDisks`. Setting `diskGiB` to 400 GiB would create a 400 GiB system disk in addition to the three data disks.
 
 ### Standard data disks
 
@@ -342,9 +376,12 @@ Before you start the deployment, confirm all of the following items:
 6. The Pod CIDR, Service CIDR, and `kube-ovn-join-cidr` do not overlap with existing networks.
 7. The VM template is available in every required datacenter.
 8. The required datastores and vCenter resource pool paths are confirmed.
-9. The machine config pool values for the minimum single-datacenter topology are complete.
-10. The baseline system disk and data disk sizing is confirmed.
-11. Every required parameter has a real value.
+9. The bootstrap registry tag validation commands include the required `kube-ovn`, CoreDNS, etcd, and kube-apiserver tags.
+10. The `cpaas.io/registry-address` value is planned as `<bootstrap_ip>:11443`.
+11. The control plane and worker bootstrap manifests both write `/etc/resolv.conf` through kubeadm `files`.
+12. The machine config pool values for the minimum single-datacenter topology are complete.
+13. The baseline system disk and data disk sizing is confirmed, and persistent disk sizes are not added into `diskGiB`.
+14. Every required parameter has a real value.
 
 ## Next Steps
 


### PR DESCRIPTION
Clarify VMware vSphere deployment requirements found during cluster setup:

- add bootstrap registry tag validation commands
- document cpaas.io/registry-address with the bootstrap host address
- add explicit /etc/resolv.conf bootstrap file entries for control plane and worker nodes
- clarify that diskGiB is the system disk size, separate from persistentDisks
- align extension scenarios with DNS and data disk guidance

Verified with yarn lint.