### PR TITLE
docs: upgrade kube-ovn before control plane [release-1.0]

### DIFF
--- a/docs/en/create-cluster/bare-metal.mdx
+++ b/docs/en/create-cluster/bare-metal.mdx
@@ -116,6 +116,7 @@ The example manifests below use `<placeholder>` syntax for environment-specific 
 | `<control-plane-vip>` / `<control-plane-port>` / `<vrid>` | Operator-supplied. The VIP must be free in the control-plane Layer-2 domain; `<vrid>` must be unique in that domain. | n/a |
 | `<install-device>` | Target disk for `elemental install`, such as `/dev/vda`, `/dev/sda`, or `/dev/nvme0n1`. | Confirm from the host console or inventory hardware data. Do not leave this implicit in virtualized tests. |
 | `<dns-image-tag>` / `<etcd-image-tag>` | Component versions baked into the bare-metal base image for `<kubernetes-version>`. | See [OS Support Matrix](../overview/os-support-matrix.mdx). |
+| `<kube-ovn-version>` | The `acp/chart-cpaas-kube-ovn` chart version matching the selected ACP and Kubernetes release. | Use the **kube-ovn (chart)** value from the [OS Support Matrix](../overview/os-support-matrix.mdx), not the Kube-OVN component version. |
 | `<dns-server>` | Operator-supplied when the first-boot registration path needs an explicit resolver. | Prefer `MachineRegistration.config.cloud-config` or later kubeadm cloud-init. Do not write `/etc/resolv.conf` from `SeedImage.cloud-config`. |
 | `<ssh-authorized-keys>` | Operator-supplied OpenSSH public key — required for any interactive debugging on the node. | n/a |
 | `<inventory-name>` | Allocated by `elemental-operator` after the host boots the ISO and registers. Cannot be predicted before registration. | `kubectl -n cpaas-system get machineinventories.elemental.cattle.io` |
@@ -299,7 +300,7 @@ spec:
     host: <control-plane-vip>
     port: <control-plane-port>
     vrid: <vrid>
-  networkType: kube-ovn      # Phase-1 metadata only.
+  networkType: kube-ovn      # Enables provider-managed Kube-OVN AppRelease reconciliation.
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: BaremetalMachineTemplate
@@ -375,6 +376,7 @@ metadata:
     capi.cpaas.io/resource-group-version: infrastructure.cluster.x-k8s.io/v1beta1
     capi.cpaas.io/resource-kind: BaremetalCluster
     cpaas.io/kube-ovn-join-cidr: <kube-ovn-join-cidr>
+    cpaas.io/kube-ovn-version: <kube-ovn-version>
     cpaas.io/sentry-deploy-type: Baremetal
     cpaas.io/alb-address-type: ClusterAddress
   labels:
@@ -404,6 +406,7 @@ spec:
 | `capi.cpaas.io/resource-group-version` | Yes | Literal `infrastructure.cluster.x-k8s.io/v1beta1` | CAPI infrastructure binding. |
 | `capi.cpaas.io/resource-kind` | Yes | Literal `BaremetalCluster` | CAPI infrastructure binding. |
 | `cpaas.io/kube-ovn-join-cidr` | Yes | Operator-chosen `/16` CIDR that does not overlap with pods/services or any other cluster. | Kube-OVN inter-node tunnel. |
+| `cpaas.io/kube-ovn-version` | Recommended | **kube-ovn (chart)** value from the [OS Support Matrix](../overview/os-support-matrix.mdx). | Pins the chart version used when the provider creates `cni-kube-ovn`. If omitted, the provider falls back to the `kube-ovn` `ModulePlugin` version. |
 | `cpaas.io/sentry-deploy-type` | Yes | Literal `Baremetal`. | Marks the cluster for the bare-metal deploy profile. |
 | `cpaas.io/alb-address-type` | Yes | Literal `ClusterAddress`. | ALB address mode used on bare-metal clusters. |
 
@@ -416,7 +419,7 @@ spec:
 | `.spec.controlPlaneLoadBalancer.port` | int (1–65535) | Control-plane port. Typically `6443`. | Yes |
 | `.spec.controlPlaneLoadBalancer.vrid` | int (0–255) | `keepalived` `virtual_router_id`. Must be unique in the control-plane Layer-2 domain. Only consumed when `type=Internal`. | When `type=Internal` |
 | `.spec.controlPlaneEndpoint` | object | API server endpoint exposed to CAPI. Once set, must not change. Leave empty to let the reconciler backfill it from `controlPlaneLoadBalancer`. | No |
-| `.spec.networkType` | string | CNI hint. `kube-ovn` today (Phase-1 metadata only). | No |
+| `.spec.networkType` | string | CNI implementation managed by the provider. Set it to `kube-ovn`; any other value causes the provider to skip Kube-OVN `AppRelease` reconciliation and node-removal integration. | Yes for Kube-OVN clusters |
 
 Apply and watch:
 

--- a/docs/en/upgrade-cluster/bare-metal.mdx
+++ b/docs/en/upgrade-cluster/bare-metal.mdx
@@ -50,8 +50,9 @@ Upgrade bare-metal clusters in the following order:
 1. **(Prerequisite)** Upgrade the ACP platform on the `global` cluster. This brings the bare-metal provider, `elemental-operator`, and the related CAPI components to versions that understand the new schema. Trigger workload-cluster upgrades only after the management-side controllers have rolled out and become Ready.
 2. Upgrade the Distribution Version (Aligned Extensions) on the workload cluster. See [Upgrading Distribution Version](index.mdx).
 3. Ensure the target Kubernetes version is present in `elemental-image-catalog` (and the matching `-iso` repository is available for any future host re-registration).
-4. Upgrade the control plane Kubernetes version (replaces all control-plane nodes one at a time).
-5. Upgrade worker nodes to the target Kubernetes version (replaces all worker nodes within the `maxUnavailable` budget).
+4. Upgrade Kube-OVN to the chart version required by the target ACP release and wait for the `AppRelease` to reach `Success`.
+5. Upgrade the control plane Kubernetes version (replaces all control-plane nodes one at a time).
+6. Upgrade worker nodes to the target Kubernetes version (replaces all worker nodes within the `maxUnavailable` budget).
 
 Cluster API orchestrates the rolling replacement.
 
@@ -67,6 +68,8 @@ Before you start, ensure all of the following prerequisites are met:
 - The control plane is reachable through the existing `<control-plane-vip>:<control-plane-port>`.
 - All current nodes are healthy and `Ready`.
 - The target Kubernetes version is a key in `elemental-image-catalog`. If it is not, add it before starting (see [Update the Image Catalog](#update-the-image-catalog)).
+- The target **kube-ovn (chart)** version has been read from the matching ACP row in the [OS Support Matrix](../overview/os-support-matrix.mdx).
+- `BaremetalCluster.spec.networkType` is `kube-ovn`; the provider skips Kube-OVN reconciliation for any other value.
 - The platform registry is reachable from every host in the cluster.
 - Both `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0` are set — bare-metal does not over-provision physical hosts.
 - The relevant pools have enough capacity to replace one node at a time without falling below the desired replica count.
@@ -113,7 +116,71 @@ The key must include the leading `v` (for example `v1.34.5`). If the key is miss
 
 When the new version corresponds to a new Alauda OS / base-image release, the ISO variant for that release should also be available before the upgrade. The bare-metal provider does not rebuild SeedImages automatically, but you may want to refresh `MachineRegistration` / `SeedImage` for **future** host onboarding so the new hosts come up on the new release. The ISO repository is the same as the base-image repository with `-iso` appended.
 
+## Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
+
+Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`. This ordering ensures that the target network components are already running before bare-metal control-plane nodes begin delete-reprovision replacement.
+
+The bare-metal provider's reconciliation behavior makes two operations necessary:
+
+- It reconciles Kube-OVN only when `BaremetalCluster.spec.networkType` is exactly `kube-ovn`.
+- It reads `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` before falling back to the `kube-ovn` `ModulePlugin` version. However, after `cni-kube-ovn` already exists, the provider updates only `AppRelease.spec.values` and preserves `spec.source`, including the existing chart `targetRevision`. Therefore, changing the annotation alone records the intended version but does not upgrade the existing chart.
+
+1. **Verify that provider-managed Kube-OVN reconciliation is enabled**
+
+   Run this command against the management (`global`) cluster:
+
+   ```bash
+   kubectl -n cpaas-system get baremetalcluster <cluster-name> \
+     -o jsonpath='{.spec.networkType}{"\n"}'
+   # Expected output: kube-ovn
+   ```
+
+   If the output is empty or different, correct `BaremetalCluster.spec.networkType` before continuing. Otherwise, the provider skips Kube-OVN reconciliation, including the control-plane node list updates needed during replacement.
+
+2. **Record the target chart version on the CAPI `Cluster`**
+
+   Use the **kube-ovn (chart)** value from the target ACP row in the [OS Support Matrix](../overview/os-support-matrix.mdx):
+
+   ```bash
+   kubectl annotate cluster <cluster-name> -n cpaas-system \
+     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+   ```
+
+   Run this command against the management (`global`) cluster where the CAPI `Cluster` exists. The annotation takes precedence over the provider's `ModulePlugin` fallback and keeps the cluster's recorded target deterministic.
+
+3. **Patch the existing `AppRelease` chart revision**
+
+   Run this command against the workload cluster's API server, not the management cluster:
+
+   ```bash
+   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+   ```
+
+   Use the same chart version that you set in the annotation. Do not change the provider-managed chart name (`acp/chart-cpaas-kube-ovn`) or release name (`cpaas-kube-ovn`).
+
+4. **Wait for reconciliation to complete before upgrading the control plane**
+
+   ```bash
+   # Overall AppRelease state — Sync and Health must reach a Success-equivalent reason
+   kubectl get apprelease cni-kube-ovn -n cpaas-system
+
+   # Installed revision and chart phase
+   kubectl get apprelease cni-kube-ovn -n cpaas-system \
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
+   ```
+
+   The normal sequence is `Upgrading → HealthChecking → Success`. Do not start the KCP rollout based on `installedRevision` alone: it changes during `HealthChecking`, before Kube-OVN pods have been verified Ready. Continue only when `phase` is `Success` **and** `installedRevision` matches the target chart version.
+
+   If the `AppRelease` reaches `DownloadFailed`, `DeployFailed`, or `NotReady`, stop before changing `KubeadmControlPlane` and inspect the condition messages:
+
+   ```bash
+   kubectl describe apprelease cni-kube-ovn -n cpaas-system
+   ```
+
 ## Upgrade the Control Plane \{#upgrade-control-plane}
+
+Before continuing, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that `cni-kube-ovn` is at the target installed revision with `phase=Success`.
 
 Patch `KubeadmControlPlane.spec.version` to the new Kubernetes version. Where component image tags are pinned (DNS, etcd), update them in the same edit:
 
@@ -172,13 +239,16 @@ If the new release also requires a bootstrap-template change (different cloud-in
 
 ## Cross-Version Upgrades
 
-Kubernetes only supports single-minor upgrades for the control plane (skew policy). To move from v1.32 → v1.34:
+Kubernetes control planes must move through supported minor-version hops. Use [Preparing for Cross-Version Upgrades](./index.mdx#cross-version-preparation) to identify and pre-stage every intermediate ACP row.
 
-1. Add the v1.33 entry to `elemental-image-catalog` and upgrade the control plane to v1.33; wait for the rollout to complete.
-2. Add the v1.34 entry; upgrade the control plane to v1.34.
-3. Upgrade the worker `MachineDeployment` to v1.34.
+For each intermediate row, and finally for the target row:
 
-The bare-metal rollout strategy already serializes node replacement, so cross-version upgrades do not require additional pool capacity beyond what was already needed for a same-minor upgrade.
+1. Ensure that row's Kubernetes version exists in `elemental-image-catalog`.
+2. Upgrade Kube-OVN to that row's **kube-ovn (chart)** version and wait for `phase=Success`.
+3. Upgrade the control plane to that row's Kubernetes version and wait for every control-plane node to become `Ready`.
+4. Upgrade every worker `MachineDeployment` to the same Kubernetes version and wait for the rollout to complete before starting the next hop.
+
+The version values always come from the OS Support Matrix; they are not fixed examples in this guide. The bare-metal rollout strategy already serializes node replacement, so cross-version upgrades do not require additional pool capacity beyond what is needed for a same-minor upgrade.
 
 ## Verification
 
@@ -187,10 +257,11 @@ After the rollout completes:
 ```bash
 kubectl -n cpaas-system get baremetalmachines.infrastructure.cluster.x-k8s.io
 kubectl -n cpaas-system get machines.cluster.x-k8s.io
+kubectl -n cpaas-system get apprelease cni-kube-ovn
 kubectl get nodes -o wide
 ```
 
-All `BaremetalMachine` objects should be `Running`. Every CAPI `Machine` should report the new `spec.version`. Every workload `Node` should be `Ready` with the new `kubelet` version, and every `MachineInventory` plan secret should carry `baremetal.alauda.io/plan.type=reprovision` (the most recent plan applied).
+The `cni-kube-ovn` `AppRelease` should report the target installed revision with `phase=Success`. All `BaremetalMachine` objects should be `Running`. Every CAPI `Machine` should report the new `spec.version`. Every workload `Node` should be `Ready` with the new `kubelet` version, and every `MachineInventory` plan secret should carry `baremetal.alauda.io/plan.type=reprovision` (the most recent plan applied).
 
 `MachineInventoryPool.status` should satisfy `available + allocated + preparing + reprovisioning + unavailable = total` with `preparing = reprovisioning = 0`.
 
@@ -198,6 +269,7 @@ All `BaremetalMachine` objects should be `Running`. Every CAPI `Machine` should 
 
 | Issue | What to check |
 |---|---|
+| The Kube-OVN annotation changed but the installed chart revision did not | This is expected for an existing `AppRelease`: the bare-metal provider preserves `spec.source` and updates only `spec.values`. Patch `spec.source.charts[0].targetRevision` directly as described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane). |
 | Rollout stuck on the first new node | `BaremetalMachine.status.conditions[ImageResolved]` — confirm the new key is in `elemental-image-catalog` and that the `Cluster` carries `cpaas.io/registry-address`. |
 | Host reboots into a state that never joins the cluster | `MachineInventory.status.plan.state` (`Failed` is terminal); inspect the host's serial console for `elemental upgrade` errors. Verify the platform registry is reachable from the host. |
 | New control-plane node fails `kubeadm join` | Confirm the VIP is still reachable; `alive` may have lost the lock. Check `kubectl -n kube-system get lease`, `ipvsadm -Ln`, `keepalived` logs from the static pod. |

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -53,8 +53,9 @@ Upgrade HCS clusters in the following order:
 
 1. **(Prerequisite)** Upgrade the ACP platform on the management cluster first. This brings the `cluster-api-provider-hcs` controller and the related CAPI components to versions that understand the new schema. Trigger workload-cluster upgrades only after the management-side controllers have rolled out and become Ready.
 2. Upgrade the Distribution Version on the workload cluster. See [Upgrading Clusters](index.mdx).
-3. Upgrade the control plane Kubernetes version.
-4. Upgrade worker nodes to the target Kubernetes version.
+3. Upgrade Kube-OVN to the chart version required by the target ACP release and wait for the `AppRelease` to reach `Success`.
+4. Upgrade the control plane Kubernetes version.
+5. Upgrade worker nodes to the target Kubernetes version.
 
 Cluster API orchestrates rolling updates with built-in safety mechanisms to reduce service disruption.
 
@@ -186,11 +187,72 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately (see step 3 below). This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the HCS provider watches it independently of the Kubernetes control plane rollout.
 
-#### Procedure
+#### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
+
+Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`, its component image tags, or its machine template reference. This ordering ensures that the target network components are already running before control-plane nodes begin rolling replacement.
+
+Kube-OVN is a Core lifecycle component, but on immutable OS the HCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
+
+:::warning
+**Why two steps are required on HCS**
+
+The HCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
+:::
+
+1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
+
+   ```bash
+   kubectl annotate cluster <cluster-name> -n cpaas-system \
+     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+   ```
+
+   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
+
+2. **Patch the `AppRelease` chart revision on the workload cluster**
+
+   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
+
+   ```bash
+   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+   ```
+
+   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
+
+3. **Wait for reconciliation to complete before upgrading the control plane**
+
+   Watch the chart phase and the installed revision:
+
+   ```bash
+   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
+   kubectl get apprelease cni-kube-ovn -n cpaas-system
+
+   # Installed revision and chart phase
+   kubectl get apprelease cni-kube-ovn -n cpaas-system \
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
+   ```
+
+   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
+
+   | Phase | Meaning | `installedRevision` |
+   |---|---|---|
+   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
+   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
+   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
+
+   :::warning
+   Do not start the KCP upgrade based on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. Start the control-plane rollout only when `phase` is `Success` **and** `installedRevision` matches the target.
+   :::
+
+   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
+
+#### Upgrade the Control Plane Kubernetes Version
+
+Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success` before continuing.
 
 1. **Create a new `HCSMachineTemplate` for the target Kubernetes version**
 
@@ -227,64 +289,7 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 
    Keep `spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the referenced control plane pool uses persistent disks. The replacement machine must reuse the same fixed hostname and disk slot after the old machine is removed.
 
-3. **Upgrade the Kube-OVN chart on the workload cluster**
-
-   Kube-OVN is a Core lifecycle component, but on immutable OS the HCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
-
-   :::warning
-   **Why two steps are required on HCS**
-
-   The HCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
-   :::
-
-   3.1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
-
-   ```bash
-   kubectl annotate cluster <cluster-name> -n cpaas-system \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
-
-   3.2. **Patch the `AppRelease` chart revision on the workload cluster**
-
-   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
-
-   ```bash
-   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
-   ```
-
-   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
-
-   3.3. **Wait for reconciliation to complete**
-
-   Watch the chart phase and the installed revision:
-
-   ```bash
-   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
-
-   | Phase | Meaning | `installedRevision` |
-   |---|---|---|
-   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
-   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
-   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
-
-   :::warning
-   Do not declare the upgrade complete on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. The chart is only considered upgraded when `phase` is `Success` **and** `installedRevision` matches the target.
-   :::
-
-   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
-
-4. **Verify Upgrade Progress**
+3. **Verify Upgrade Progress**
 
    Monitor the rolling upgrade process:
 
@@ -321,7 +326,7 @@ Procedure:
 
 - **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
 - **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check used in step 3.
+- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane).
 
   ```bash
   kubectl annotate cluster <cluster-name> -n cpaas-system \

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -44,8 +44,9 @@ Upgrade DCS clusters in the following order:
 
 1. **(Prerequisite)** Upgrade the ACP platform on the management cluster first. This brings the cluster-api-provider-dcs controller and the related CAPI components (core, KubeadmControlPlane provider, bootstrap provider) to versions that understand the new schema. Trigger workload-cluster upgrades only after the management-side controllers have rolled out and become Ready.
 2. Upgrade the Distribution Version (Aligned Extensions) on the workload cluster. See [Upgrading Distribution Version](index.mdx).
-3. Upgrade the control plane Kubernetes version.
-4. Upgrade worker nodes to the target Kubernetes version.
+3. Upgrade Kube-OVN to the chart version required by the target ACP release and wait for the `AppRelease` to reach `Success`.
+4. Upgrade the control plane Kubernetes version.
+5. Upgrade worker nodes to the target Kubernetes version.
 
 Cluster API orchestrates rolling updates with built-in safety mechanisms to reduce service disruption.
 
@@ -117,11 +118,70 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately (see step 3 below). This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the DCS provider watches it independently of the Kubernetes control plane rollout.
 
 Confirm with the cluster's platform owner that the target Alauda OS image has already been uploaded to the DCS platform under the same name as the **Alauda OS Image Version** value in the matrix row. The upgrade fails if that VM template is not present on DCS when the `DCSMachineTemplate` is applied.
+
+### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
+
+Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`, its component image tags, or its machine template reference. This ordering ensures that the target network components are already running before control-plane nodes begin rolling replacement.
+
+Kube-OVN is a Core lifecycle component, but on immutable OS the DCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
+
+:::warning
+**Why two steps are required on DCS**
+
+The DCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
+:::
+
+1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
+
+   ```bash
+   kubectl annotate cluster <cluster-name> -n cpaas-system \
+     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+   ```
+
+   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
+
+2. **Patch the `AppRelease` chart revision on the workload cluster**
+
+   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
+
+   ```bash
+   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+   ```
+
+   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
+
+3. **Wait for reconciliation to complete before upgrading the control plane**
+
+   Watch the chart phase and the installed revision:
+
+   ```bash
+   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
+   kubectl get apprelease cni-kube-ovn -n cpaas-system
+
+   # Installed revision and chart phase
+   kubectl get apprelease cni-kube-ovn -n cpaas-system \
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
+   ```
+
+   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
+
+   | Phase | Meaning | `installedRevision` |
+   |---|---|---|
+   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
+   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
+   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
+
+   :::warning
+   Do not start the KCP upgrade based on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. Start the control-plane rollout only when `phase` is `Success` **and** `installedRevision` matches the target.
+   :::
+
+   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
 
 ### Upgrade Control Plane Infrastructure
 
@@ -175,7 +235,7 @@ Upgrading the control plane machine template lets you roll out updated VM specif
 
 Upgrading the control plane Kubernetes version on immutable OS is a delete-recreate workflow. The control plane VMs are replaced one by one from a new `DCSMachineTemplate` that points at the target Alauda OS VM template, and the `KubeadmControlPlane` resource is patched to carry the matching Kubernetes version, CoreDNS image tag, and etcd image tag.
 
-Before you start, collect every required value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
+Before you start, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success`. Then collect every required control-plane value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
 
 #### Procedure
 
@@ -204,64 +264,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
    Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same Alauda OS release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
 
-3. **Upgrade the Kube-OVN chart on the workload cluster**
-
-   Kube-OVN is a Core lifecycle component, but on immutable OS the DCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
-
-   :::warning
-   **Why two steps are required on DCS**
-
-   The DCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
-   :::
-
-   3.1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
-
-   ```bash
-   kubectl annotate cluster <cluster-name> -n cpaas-system \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
-
-   3.2. **Patch the `AppRelease` chart revision on the workload cluster**
-
-   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
-
-   ```bash
-   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
-   ```
-
-   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
-
-   3.3. **Wait for reconciliation to complete**
-
-   Watch the chart phase and the installed revision:
-
-   ```bash
-   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
-
-   | Phase | Meaning | `installedRevision` |
-   |---|---|---|
-   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
-   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
-   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
-
-   :::warning
-   Do not declare the upgrade complete on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. The chart is only considered upgraded when `phase` is `Success` **and** `installedRevision` matches the target.
-   :::
-
-   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
-
-4. **Monitor the rolling update**
+3. **Monitor the rolling update**
 
    ```bash
    kubectl get kubeadmcontrolplane <kcp-name> -n cpaas-system -w
@@ -309,7 +312,7 @@ Procedure:
 
 - **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
 - **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check used in step 3.
+- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane).
 
   ```bash
   kubectl annotate cluster <cluster-name> -n cpaas-system \
@@ -345,6 +348,7 @@ Use this workflow to upgrade Kubernetes from the web UI after Phase 1 is complet
 ### Prerequisites
 
 - The Distribution Version upgrade is complete. See [Upgrading Distribution Version](index.mdx)
+- Kube-OVN has been upgraded to the target chart version and the `cni-kube-ovn` `AppRelease` has reached `phase=Success`. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) with YAML before using the UI to upgrade a node pool.
 - The Control Plane Node Pool is in Running state
 - The IP Pool has sufficient capacity for rolling updates
 - If the upgrade relies on pool-managed persistent disks, ensure the required `DCSIpHostnamePool.spec.pool[].persistentDisk` entries have already been created or updated through YAML
@@ -353,9 +357,10 @@ Use this workflow to upgrade Kubernetes from the web UI after Phase 1 is complet
 
 Kubernetes upgrades follow this sequence after the Distribution Version upgrade:
 
-1. Upgrade the Control Plane Node Pool.
-2. Wait for the Control Plane Node Pool upgrade to complete.
-3. Upgrade Worker Node Pools in any order.
+1. Upgrade Kube-OVN with the YAML procedure and wait for the `AppRelease` to reach `phase=Success`.
+2. Upgrade the Control Plane Node Pool.
+3. Wait for the Control Plane Node Pool upgrade to complete.
+4. Upgrade Worker Node Pools in any order.
 
 ### Checking Available Upgrades
 

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -96,6 +96,8 @@ After the Distribution Version upgrade completes:
 After upgrading Distribution Version, upgrade Kubernetes on each Node Pool.
 Provider-specific guides contain the Phase 2 procedures for each platform.
 
+For Huawei DCS, Huawei Cloud Stack, VMware vSphere, and bare-metal clusters, upgrade the Kube-OVN chart for the current upgrade hop **before** changing `KubeadmControlPlane`. Wait until the workload cluster's `cni-kube-ovn` `AppRelease` reports the target installed revision and `phase=Success`, then upgrade the control plane, followed by worker nodes. Repeat this Kube-OVN-first ordering for every intermediate Kubernetes minor in a cross-version upgrade.
+
 See platform-specific guides:
 - [Huawei DCS](./huawei-dcs.mdx)
 - [Huawei Cloud Stack](./huawei-cloud-stack.mdx)
@@ -137,7 +139,7 @@ The control plane and worker rollouts then step through the intermediate OS imag
 
 ### Step 3 — Apply the platform-specific procedure for each intermediate version
 
-Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for `KubeadmControlPlane` and `MachineDeployment` values. For each hop, complete the provider's standard procedure — control plane first, then workers, per the Kubernetes version skew policy — before starting the next. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
+Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for Kube-OVN, `KubeadmControlPlane`, and `MachineDeployment` values. For each hop, upgrade Kube-OVN first and wait for `phase=Success`, then upgrade the control plane, followed by workers. Complete the whole hop before starting the next one. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
 
 ---
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -33,8 +33,9 @@ Upgrade VMware vSphere clusters in the following order:
 1. **(Prerequisite)** Upgrade the ACP platform on the management cluster first. This brings the `cluster-api-provider-vsphere` controller and the related CAPI components to versions that understand the new schema. Trigger workload-cluster upgrades only after the management-side controllers have rolled out and become Ready.
 2. Complete the distribution-version upgrade described in [Upgrading Clusters](./index.mdx).
 3. Verify that the control plane is healthy and the current cluster is stable.
-4. Upgrade the control plane Kubernetes version.
-5. Upgrade worker nodes to the target Kubernetes version.
+4. Upgrade Kube-OVN to the chart version required by the target ACP release and wait for the `AppRelease` to reach `Success`.
+5. Upgrade the control plane Kubernetes version.
+6. Upgrade worker nodes to the target Kubernetes version.
 
 ## Prerequisites
 
@@ -88,13 +89,67 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the vSphere provider reconciles the Kube-OVN AppRelease from this annotation. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the vSphere provider reconciles the Kube-OVN AppRelease from this annotation. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the vSphere provider watches it independently of the Kubernetes control plane rollout.
 
 ## Steps
 
 <Steps>
+### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
+
+Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`, its component image tags, or its machine template reference. This ordering ensures that the target network components are already running before control-plane nodes begin rolling replacement.
+
+1. **Verify the Kube-OVN reconcile gating annotation**
+
+   On vSphere, the provider reconciles the Kube-OVN `AppRelease` only when the `Cluster` resource carries the annotation `cpaas.io/network-type: kube-ovn`. This annotation is normally set at cluster creation. If it is missing, updating the version annotation will not reconcile the Kube-OVN `AppRelease`.
+
+   ```bash
+   kubectl get cluster <cluster_name> -n <namespace> \
+     -o jsonpath='{.metadata.annotations.cpaas\.io/network-type}{"\n"}'
+   # Expected output: kube-ovn
+   ```
+
+   This precondition is vSphere-specific. The DCS and Huawei Cloud Stack providers use the `DCSCluster` / `HCSCluster` `spec.networkType` field instead and do not require this annotation.
+
+2. **Update the Kube-OVN version annotation on the `Cluster` resource**
+
+   If the target ACP row in the OS Support Matrix shows a different **kube-ovn (chart)** value than the current cluster, patch the annotation on the `Cluster` resource so the vSphere provider reconciles the new Kube-OVN AppRelease:
+
+   ```bash
+   kubectl annotate cluster <cluster_name> -n <namespace> \
+     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+   ```
+
+   Kube-OVN is a Core lifecycle component, but on immutable OS the vSphere provider drives its delivery from this annotation; the annotation does not update automatically when `spec.version` changes.
+
+3. **Wait for reconciliation to complete before upgrading the control plane**
+
+   The vSphere provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster):
+
+   ```bash
+   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
+   kubectl get apprelease cni-kube-ovn -n cpaas-system
+
+   # Installed revision and chart phase
+   kubectl get apprelease cni-kube-ovn -n cpaas-system \
+     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
+   ```
+
+   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
+
+   | Phase | Meaning | `installedRevision` |
+   |---|---|---|
+   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
+   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
+   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
+
+   :::warning
+   Do not start the KCP upgrade based on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. Start the control-plane rollout only when `phase` is `Success` **and** `installedRevision` matches the target.
+   :::
+
+   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
+
 ### Create the target machine templates
 
 Before you start the rolling upgrade, create new `VSphereMachineTemplate` resources for the control plane and workers.
@@ -135,7 +190,7 @@ Before you start the rolling upgrade, create new `VSphereMachineTemplate` resour
 
 ### Upgrade the control plane
 
-Before you start, collect every required value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
+Before you start, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success`. Then collect every required control-plane value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
 
 1. **Patch the `KubeadmControlPlane` with the target Kubernetes values**
 
@@ -152,57 +207,7 @@ Before you start, collect every required value from the target ACP row in the OS
 
    Updating only `spec.version` is not sufficient. The CoreDNS and etcd image tags must move together with the Kubernetes version because they are built from the same release; leaving them at the previous values can result in CoreDNS and etcd pods that do not match the new Kubernetes minor version.
 
-2. **Update the Kube-OVN version annotation on the `Cluster` resource**
-
-   If the target ACP row in the OS Support Matrix shows a different **kube-ovn (chart)** value than the current cluster, patch the annotation on the `Cluster` resource so the vSphere provider reconciles the new Kube-OVN AppRelease.
-
-   :::info
-   **Prerequisite — Kube-OVN reconcile gating annotation (vSphere only)**
-
-   On vSphere, the provider reconciles the Kube-OVN `AppRelease` only when the `Cluster` resource carries the annotation `cpaas.io/network-type: kube-ovn`. This annotation is normally set at cluster creation. If it is missing, the steps below will succeed at writing the version annotation but the Kube-OVN `AppRelease` will not be reconciled. Verify before proceeding:
-
-   ```bash
-   kubectl get cluster <cluster_name> -n <namespace> \
-     -o jsonpath='{.metadata.annotations.cpaas\.io/network-type}{"\n"}'
-   # Expected output: kube-ovn
-   ```
-
-   This precondition is vSphere-specific. The DCS and Huawei Cloud Stack providers use the `DCSCluster` / `HCSCluster` `spec.networkType` field instead and do not require this annotation.
-   :::
-
-   ```bash
-   kubectl annotate cluster <cluster_name> -n <namespace> \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   Kube-OVN is a Core lifecycle component, but on immutable OS the vSphere provider drives its delivery from this annotation; the annotation does not update automatically when `spec.version` changes.
-
-   The vSphere provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster) to follow the reconciliation:
-
-   ```bash
-   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
-
-   | Phase | Meaning | `installedRevision` |
-   |---|---|---|
-   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
-   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
-   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
-
-   :::warning
-   Do not declare the upgrade complete on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. The chart is only considered upgraded when `phase` is `Success` **and** `installedRevision` matches the target.
-   :::
-
-   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
-
-3. **Monitor the control plane rollout**
+2. **Monitor the control plane rollout**
 
    ```bash
    kubectl -n <namespace> get kubeadmcontrolplane <cluster_name> -w
@@ -261,7 +266,7 @@ Procedure:
 
 - **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
 - **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the kube-ovn annotation was changed, restore the previous value on the `Cluster` resource:
+- **Kube-OVN**: if the kube-ovn annotation was changed, restore the previous value on the `Cluster` resource and verify reconciliation with the same target-revision and `phase=Success` checks described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane):
 
   ```bash
   kubectl annotate cluster <cluster_name> -n <namespace> \


### PR DESCRIPTION
## Summary

- document kube-ovn upgrades before KubeadmControlPlane rollouts
- add bare-metal annotation and AppRelease behavior based on provider code
- align cross-version upgrade sequencing across providers

Backport of #137 to release-1.0.

## Validation

- yarn lint
- yarn build