### PR TITLE
docs: document Kubernetes 1.35 kubelet image policy

### DIFF
--- a/docs/en/create-cluster/bare-metal.mdx
+++ b/docs/en/create-cluster/bare-metal.mdx
@@ -513,6 +513,10 @@ After creating a cluster:
 
 The hardened configuration recommended for production bare-metal clusters — admission control, audit policy, kubelet patches, encryption provider, and IPv6 bind addresses. Substitute the placeholders from the table in [Resolving Placeholder Values](#resolving-placeholders).
 
+<Directive type="warning" title="Kubernetes 1.35 kubelet settings">
+  `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating a cluster with Kubernetes 1.34 or earlier.
+</Directive>
+
 ```yaml
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -572,6 +576,7 @@ spec:
           {
             "apiVersion": "kubelet.config.k8s.io/v1beta1",
             "kind": "KubeletConfiguration",
+            "imagePullCredentialsVerificationPolicy": "NeverVerify",
             "protectKernelDefaults": true,
             "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
             "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key",

--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -471,6 +471,10 @@ spec:
 
 The `KubeadmControlPlane` defines the Kubernetes control plane configuration.
 
+<Directive type="warning" title="Kubernetes 1.35 kubelet settings">
+  `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating a cluster with Kubernetes 1.34 or earlier.
+</Directive>
+
 ```yaml
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -517,6 +521,7 @@ spec:
           {
             "apiVersion": "kubelet.config.k8s.io/v1beta1",
             "kind": "KubeletConfiguration",
+            "imagePullCredentialsVerificationPolicy": "NeverVerify",
             "protectKernelDefaults": true,
             "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
             "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key",

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -297,6 +297,10 @@ For `Self-built VIP`, validate that the target DCS port group allows VIP ownersh
 
 The KubeadmControlPlane resource defines the control plane configuration including Kubernetes version, node specifications, and bootstrap settings.
 
+<Directive type="warning" title="Kubernetes 1.35 kubelet settings">
+  `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating a cluster with Kubernetes 1.34 or earlier. If `contentFrom.secret` supplies the patch, verify that the referenced Secret key contains this parameter for Kubernetes 1.35.
+</Directive>
+
 :::tip
 **Full Configuration Reference**
 
@@ -336,6 +340,7 @@ spec:
         {
           "apiVersion": "kubelet.config.k8s.io/v1beta1",
           "kind": "KubeletConfiguration",
+          "imagePullCredentialsVerificationPolicy": "NeverVerify",
           "_comment": "... (Kubelet Configuration Content) ..."
         }
     # ... (other files) ...
@@ -686,6 +691,8 @@ A successfully created cluster should show:
 
 Below is the complete `KubeadmControlPlane` configuration, including all default audit policies, admission controls, and file contents.
 
+The embedded kubelet patch includes `imagePullCredentialsVerificationPolicy: NeverVerify`, which is required only starting with Kubernetes 1.35. Remove this parameter for Kubernetes 1.34 or earlier.
+
 ```yaml
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -738,6 +745,7 @@ spec:
         {
           "apiVersion": "kubelet.config.k8s.io/v1beta1",
           "kind": "KubeletConfiguration",
+          "imagePullCredentialsVerificationPolicy": "NeverVerify",
           "protectKernelDefaults": true,
           "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
           "tlsPrivateKeyFile": "/etc/kubernetes/pki/kubelet.key",

--- a/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
+++ b/docs/en/create-cluster/vmware-vsphere/create-cluster-in-global.mdx
@@ -683,6 +683,10 @@ kubectl apply -f 03-vspheremachineconfigpool-worker.yaml
 
 Create the `VSphereMachineTemplate` and `KubeadmControlPlane` objects. Replace the placeholders in the following full template with the values collected in the checklist document.
 
+<Directive type="warning" title="Kubernetes 1.35 kubelet settings">
+  `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating a cluster with Kubernetes 1.34 or earlier.
+</Directive>
+
 `cloneMode` and `diskGiB` both remain present in the template because CAPV accepts both fields. In practice, `diskGiB` only affects the system disk when the actual clone operation is `fullClone`. If `cloneMode` is `linkedClone` and the template has a usable snapshot, CAPV completes a linked clone and the system disk size remains equal to the source template. If no usable snapshot exists, CAPV falls back to `fullClone`, and `diskGiB` applies again.
 
 <Directive type="warning" title="System disk and persistent disks are separate">
@@ -787,6 +791,7 @@ spec:
         {
           "apiVersion": "kubelet.config.k8s.io/v1beta1",
           "kind": "KubeletConfiguration",
+          "imagePullCredentialsVerificationPolicy": "NeverVerify",
           "protectKernelDefaults": true,
           "streamingConnectionIdleTimeout": "5m",
           "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
@@ -1033,6 +1038,8 @@ kubectl apply -f 20-control-plane.yaml
 
 Create the worker machine template, bootstrap template, and `MachineDeployment`.
 
+The worker kubelet patch follows the same version rule as the control plane: `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35 and must be omitted for Kubernetes 1.34 or earlier.
+
 ```yaml title="30-workers-md-0.yaml"
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: VSphereMachineTemplate
@@ -1083,6 +1090,7 @@ spec:
           {
             "apiVersion": "kubelet.config.k8s.io/v1beta1",
             "kind": "KubeletConfiguration",
+            "imagePullCredentialsVerificationPolicy": "NeverVerify",
             "protectKernelDefaults": true,
             "staticPodPath": null,
             "streamingConnectionIdleTimeout": "5m",

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -44,6 +44,10 @@ Like workload clusters, the `global` cluster on Immutable Infrastructure follows
 
 After installation, the Cluster API controllers that manage the `global` cluster run on the `global` cluster itself. Use the `global` kubeconfig for the `kubectl` commands in this procedure.
 
+<Directive type="warning" title="Required when the target is Kubernetes 1.35">
+  `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. On the hop to Kubernetes 1.35 or later, add it to the kubelet patch used by every replacement node. Update the control-plane file in the same `KubeadmControlPlane` edit as `spec.version`. For workers, create a new `KubeadmConfigTemplate` with the updated patch and switch `MachineDeployment.spec.template.spec.bootstrap.configRef.name` in the same edit as the version. Do not add this parameter for Kubernetes 1.34 or earlier. See [Required kubelet patch for Kubernetes 1.35](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch).
+</Directive>
+
 ### Step 1 — Update the global Cluster Manifest
 
 Update the Cluster API manifests of the `global` cluster to reference the new Alauda OS image and Kubernetes version. The manifest fields to update are provider-specific.
@@ -58,6 +62,7 @@ Update the control plane resources:
 - Create a new `DCSMachineTemplate` for the target image and set `spec.template.spec.vmTemplateName` to the Alauda OS template that matches the target Kubernetes version.
 - Keep preserved node-local data, including `/var/cpaas`, in `DCSIpHostnamePool.spec.pool[].persistentDisk`. Do not move preserved disks back into `DCSMachineTemplate`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.
+- When the target is Kubernetes 1.35 or later, update the control-plane kubelet patch in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the same manifest edit.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `DCSMachineTemplate`.
 - Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the cluster uses pool-managed persistent disks.
 
@@ -65,6 +70,7 @@ Update worker node resources:
 
 - Create a new worker `DCSMachineTemplate` with the target `vmTemplateName`.
 - Set each `MachineDeployment.spec.template.spec.version` to the target Kubernetes version.
+- When the target is Kubernetes 1.35 or later, create a new worker `KubeadmConfigTemplate` with the required kubelet patch and point `MachineDeployment.spec.template.spec.bootstrap.configRef.name` to it.
 - Point each `MachineDeployment.spec.template.spec.infrastructureRef.name` to the new worker `DCSMachineTemplate`.
 - Keep each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` when the worker pool uses pool-managed persistent disks.
 
@@ -112,6 +118,7 @@ Update the control plane resources:
 - Keep preserved node-local data, including `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. Do not move preserved disks back into `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 - Leave runtime identity fields unset in the new template, including `spec.template.spec.providerID` and `spec.template.spec.serverId`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.
+- When the target is Kubernetes 1.35 or later, update the control-plane kubelet patch in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the same manifest edit.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `HCSMachineTemplate`.
 - Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the control plane pool uses pool-managed persistent disks.
 
@@ -119,6 +126,7 @@ Update worker node resources:
 
 - Create a new worker `HCSMachineTemplate` with the target `imageName`.
 - Set each `MachineDeployment.spec.template.spec.version` to the target Kubernetes version.
+- When the target is Kubernetes 1.35 or later, create a new worker `KubeadmConfigTemplate` with the required kubelet patch and point `MachineDeployment.spec.template.spec.bootstrap.configRef.name` to it.
 - Point each `MachineDeployment.spec.template.spec.infrastructureRef.name` to the new worker `HCSMachineTemplate`.
 - Keep each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` when the worker pool uses pool-managed persistent disks.
 

--- a/docs/en/manage-nodes/bare-metal.mdx
+++ b/docs/en/manage-nodes/bare-metal.mdx
@@ -80,6 +80,8 @@ spec:
 
 ### Step 3: Configure the Bootstrap Template \{#step-3-configure-bootstrap-template}
 
+`imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating workers with Kubernetes 1.34 or earlier.
+
 ```yaml
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -103,6 +105,7 @@ spec:
             {
               "apiVersion": "kubelet.config.k8s.io/v1beta1",
               "kind": "KubeletConfiguration",
+              "imagePullCredentialsVerificationPolicy": "NeverVerify",
               "protectKernelDefaults": true,
               "staticPodPath": null,
               "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
@@ -339,7 +342,7 @@ To roll out a bootstrap change:
      > new-worker-bootstrap.yaml
    ```
 
-2. Change `metadata.name`, remove server-generated fields (`resourceVersion`, `uid`, `creationTimestamp`, `managedFields`, `kubectl.kubernetes.io/last-applied-configuration`) and the entire `status`, and edit the desired fields.
+2. Change `metadata.name`, remove server-generated fields (`resourceVersion`, `uid`, `creationTimestamp`, `managedFields`, `kubectl.kubernetes.io/last-applied-configuration`) and the entire `status`, and edit the desired fields. For Kubernetes 1.35 or later, add the [required kubelet patch settings](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch) to `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json`.
 3. Apply the new template:
 
    ```bash

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -252,6 +252,8 @@ spec:
 
 The `KubeadmConfigTemplate` defines the bootstrap configuration for worker nodes.
 
+`imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating workers with Kubernetes 1.34 or earlier.
+
 ```yaml
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
@@ -269,6 +271,7 @@ spec:
             {
               "apiVersion": "kubelet.config.k8s.io/v1beta1",
               "kind": "KubeletConfiguration",
+              "imagePullCredentialsVerificationPolicy": "NeverVerify",
               "protectKernelDefaults": true,
               "staticPodPath": null,
               "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
@@ -484,18 +487,25 @@ Kubernetes version upgrades require coordinated updates to both the `MachineDepl
 
    Create a new `HCSMachineTemplate` with an updated `imageName` that supports the target Kubernetes version.
 
-2. **Update MachineDeployment**
+2. **Create a new bootstrap template for Kubernetes 1.35 or later**
+
+   If the target is Kubernetes 1.35 or later, clone the current `KubeadmConfigTemplate` under a new name and add the [required kubelet patch settings](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch) to `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json`. `KubeadmConfigTemplate` is immutable, so do not edit the referenced template in place. Skip this step for earlier versions unless the release has another bootstrap change.
+
+3. **Update MachineDeployment**
 
    Modify the following fields:
    - `spec.template.spec.version` - Target Kubernetes version
    - `spec.template.spec.infrastructureRef.name` - New machine template name
+   - `spec.template.spec.bootstrap.configRef.name` - New bootstrap template name; required for Kubernetes 1.35 or later
 
      ```bash
      kubectl patch machinedeployment <cluster-name>-md-0 -n cpaas-system \
-       --type='merge' -p='{"spec":{"template":{"spec":{"version":"<kubernetes-version>","infrastructureRef":{"name":"<new-template>"}}}}}'
+       --type='merge' -p='{"spec":{"template":{"spec":{"version":"<kubernetes-version>","infrastructureRef":{"name":"<new-template>"},"bootstrap":{"configRef":{"name":"<new-bootstrap-template>"}}}}}}'
      ```
 
-3. **Monitor Upgrade**
+   The command includes the bootstrap reference required for Kubernetes 1.35 or later. For an earlier target with no bootstrap change, omit the `bootstrap` object.
+
+4. **Monitor Upgrade**
 
    Verify that new nodes join the cluster with the correct Kubernetes version:
 

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -246,6 +246,8 @@ kubectl -n cpaas-system get dcsmachine -l cluster.x-k8s.io/cluster-name=<cluster
 
 The KubeadmConfigTemplate defines the bootstrap configuration for worker nodes, including user accounts, SSH keys, system files, and kubeadm join settings.
 
+`imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. Omit this parameter when creating workers with Kubernetes 1.34 or earlier. If `contentFrom.secret` supplies the patch, verify that the referenced `worker-kubelet-patch.json` contains this parameter for Kubernetes 1.35.
+
 :::info
 **Template Optimization**
 The template includes pre-optimized configurations for security and performance. Modify only the parameters that require customization for your environment.
@@ -275,6 +277,7 @@ spec:
           {
             "apiVersion": "kubelet.config.k8s.io/v1beta1",
             "kind": "KubeletConfiguration",
+            "imagePullCredentialsVerificationPolicy": "NeverVerify",
             "protectKernelDefaults": true,
             "staticPodPath": null,
             "tlsCertFile": "/etc/kubernetes/pki/kubelet.crt",
@@ -871,6 +874,7 @@ Bootstrap templates (KubeadmConfigTemplate) are used by MachineDeployment and Ma
 
 2. **Modify Configuration**
    - Update the desired fields in the exported YAML
+   - For Kubernetes 1.35 or later, add the [required kubelet patch settings](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch) to `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json`
    - Change the `metadata.name` to a new unique name
    - Remove extraneous metadata fields (`resourceVersion`, `uid`, `creationTimestamp`, etc.)
 

--- a/docs/en/manage-nodes/vmware-vsphere.mdx
+++ b/docs/en/manage-nodes/vmware-vsphere.mdx
@@ -141,6 +141,7 @@ Confirm the following results:
    Edit `new-bootstrap-template.yaml`:
    - Set `metadata.name` to a new unique name (for example, `<cluster_name>-worker-bootstrap-v2`)
    - Update the desired bootstrap configuration fields
+   - For Kubernetes 1.35 or later, add the [required kubelet patch settings](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch) to `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json`
    - Remove the same server-generated fields listed in [Roll out updated worker node configuration](#roll-out-updated-worker-node-configuration) step 2
 
 3. **Apply the new template**

--- a/docs/en/upgrade-cluster/bare-metal.mdx
+++ b/docs/en/upgrade-cluster/bare-metal.mdx
@@ -191,6 +191,7 @@ kubectl -n cpaas-system edit kubeadmcontrolplane <cluster-name>-control-plane
 - `spec.version` ← target Kubernetes version (must match an `elemental-image-catalog` key).
 - `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` ← matching CoreDNS image tag for the new release.
 - `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` ← matching etcd image tag for the new release.
+- When the target is Kubernetes 1.35 or later, update `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json` in `spec.kubeadmConfigSpec.files` in this same edit, as described in [Required kubelet patch for Kubernetes 1.35](./index.mdx#kubernetes-1-35-kubelet-patch).
 
 The bare-metal provider does **not** require a new `BaremetalMachineTemplate` for a Kubernetes-only upgrade: the template only carries the pool reference, and the upgrade image is resolved from `Machine.spec.version` through the catalog. A new template is only required when you want to move the control plane to a different pool.
 
@@ -219,10 +220,12 @@ Throughout the rollout, `alive` continues to manage the VIP. As control-plane me
 
 Patch each `MachineDeployment.spec.template.spec.version` to the new Kubernetes version. CAPI replaces workers within the `maxUnavailable` budget — the bare-metal provider re-uses the same worker pool and the same image-catalog resolution logic as the control plane.
 
+For Kubernetes 1.35 or later, first create a new worker `KubeadmConfigTemplate` containing the [required kubelet patch](./index.mdx#kubernetes-1-35-kubelet-patch), then update `spec.template.spec.bootstrap.configRef.name` in the same `MachineDeployment` edit as the version bump. The command below includes that reference. For an earlier target with no bootstrap change, omit the `bootstrap` object. Follow [Updating Bootstrap Templates](../manage-nodes/bare-metal.mdx#updating-bootstrap-templates) to create the immutable template.
+
 ```bash
 kubectl -n cpaas-system patch machinedeployment <cluster-name>-workers \
   --type='merge' \
-  -p='{"spec":{"template":{"spec":{"version":"<new-kubernetes-version>"}}}}'
+  -p='{"spec":{"template":{"spec":{"version":"<new-kubernetes-version>","bootstrap":{"configRef":{"name":"<new-bootstrap-template>"}}}}}}'
 ```
 
 Watch:
@@ -235,7 +238,7 @@ kubectl get nodes -o wide
 
 Worker upgrades carry fewer knobs than the control plane: there is no `clusterConfiguration` block on `MachineDeployment`, so no DNS / etcd tags to update. Kubernetes component versions on worker nodes follow the new base image.
 
-If the new release also requires a bootstrap-template change (different cloud-init, different `kubeletExtraArgs`), follow [Updating Bootstrap Templates](../manage-nodes/bare-metal.mdx#updating-bootstrap-templates) — that is a separate template swap, independent of the version bump.
+For earlier versions, a bootstrap-template change is needed only when the release changes settings such as cloud-init or `kubeletExtraArgs`.
 
 ## Cross-Version Upgrades
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -280,6 +280,7 @@ Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-th
    - `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` ← **coredns** column from the same row
    - `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` ← **etcd** column from the same row
    - `spec.machineTemplate.infrastructureRef.name` ← the new `HCSMachineTemplate` name created in step 1
+   - When the target is Kubernetes 1.35 or later, update `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json` in `spec.kubeadmConfigSpec.files` in this same edit, as described in [Required kubelet patch for Kubernetes 1.35](./index.mdx#kubernetes-1-35-kubelet-patch)
 
      ```bash
      kubectl edit kubeadmcontrolplane <kcp-name> -n cpaas-system

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -257,6 +257,7 @@ Before you start, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-
    - `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` ← **coredns** column from the same row
    - `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` ← **etcd** column from the same row
    - `spec.machineTemplate.infrastructureRef.name` ← the new `DCSMachineTemplate` name created in step 1
+   - When the target is Kubernetes 1.35 or later, update `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json` in `spec.kubeadmConfigSpec.files` in this same edit, as described in [Required kubelet patch for Kubernetes 1.35](./index.mdx#kubernetes-1-35-kubelet-patch)
 
      ```bash
      kubectl edit kubeadmcontrolplane <kcp-name> -n cpaas-system
@@ -290,7 +291,7 @@ Before you start, read the **Alauda OS Image Version** and **Kubernetes Version*
 2. **Update the `MachineDeployment`**
    - Set `spec.template.spec.version` to the **Kubernetes Version** value from the same OS Support Matrix row
    - Set `spec.template.spec.infrastructureRef.name` to the new `DCSMachineTemplate` name created in step 1
-   - Optionally update `spec.template.spec.bootstrap.configRef.name` if bootstrap configuration changes are required for this release
+   - When the target is Kubernetes 1.35 or later, create a new `KubeadmConfigTemplate` containing the required kubelet patch and set `spec.template.spec.bootstrap.configRef.name` to that template in the same edit; for earlier versions, update the bootstrap reference only when other bootstrap changes are required
 
 3. **Monitor the rolling update**
    - Verify that the rolling update completes successfully

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -98,6 +98,26 @@ Provider-specific guides contain the Phase 2 procedures for each platform.
 
 For Huawei DCS, Huawei Cloud Stack, VMware vSphere, and bare-metal clusters, upgrade the Kube-OVN chart for the current upgrade hop **before** changing `KubeadmControlPlane`. Wait until the workload cluster's `cni-kube-ovn` `AppRelease` reports the target installed revision and `phase=Success`, then upgrade the control plane, followed by worker nodes. Repeat this Kube-OVN-first ordering for every intermediate Kubernetes minor in a cross-version upgrade.
 
+### Required kubelet patch for Kubernetes 1.35 \{#kubernetes-1-35-kubelet-patch}
+
+When an upgrade hop targets Kubernetes 1.35 or later, the kubelet patch file at `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json` must include the following setting:
+
+```json
+{
+  "imagePullCredentialsVerificationPolicy": "NeverVerify"
+}
+```
+
+`imagePullCredentialsVerificationPolicy` is required only starting with Kubernetes 1.35. Setting it to `NeverVerify` prevents the kubelet from requiring registry credential verification for images that are already present in the immutable OS image.
+
+Apply this change only on the hop to Kubernetes 1.35 or later:
+
+- For control-plane nodes, update the matching file in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the **same edit** that changes `spec.version` to 1.35. Do not roll out the policy separately while the target version is still 1.34.
+- For worker nodes, create a new immutable `KubeadmConfigTemplate` containing the updated file, then update `MachineDeployment.spec.template.spec.bootstrap.configRef.name` in the same edit as the target version and infrastructure template.
+- If the file uses `contentFrom.secret`, verify that the referenced Secret key contains this parameter. An older version-specific Secret is not automatically suitable for the 1.35 hop.
+
+For Kubernetes 1.34 or earlier, omit `imagePullCredentialsVerificationPolicy`. Add it only on the upgrade hop whose target is Kubernetes 1.35 or later.
+
 See platform-specific guides:
 - [Huawei DCS](./huawei-dcs.mdx)
 - [Huawei Cloud Stack](./huawei-cloud-stack.mdx)
@@ -139,7 +159,7 @@ The control plane and worker rollouts then step through the intermediate OS imag
 
 ### Step 3 — Apply the platform-specific procedure for each intermediate version
 
-Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for Kube-OVN, `KubeadmControlPlane`, and `MachineDeployment` values. For each hop, upgrade Kube-OVN first and wait for `phase=Success`, then upgrade the control plane, followed by workers. Complete the whole hop before starting the next one. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
+Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for Kube-OVN, `KubeadmControlPlane`, and `MachineDeployment` values. For each hop, upgrade Kube-OVN first and wait for `phase=Success`, then upgrade the control plane, followed by workers. On the hop to Kubernetes 1.35, also apply the [required kubelet patch](#kubernetes-1-35-kubelet-patch) to the control-plane and worker bootstrap configurations. Complete the whole hop before starting the next one. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
 
 ---
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -200,6 +200,7 @@ Before you start, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-
    - `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` ← **coredns** column from the same row
    - `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` ← **etcd** column from the same row
    - `spec.machineTemplate.infrastructureRef.name` ← the new `VSphereMachineTemplate` name created above
+   - When the target is Kubernetes 1.35 or later, update `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json` in `spec.kubeadmConfigSpec.files` in this same edit, as described in [Required kubelet patch for Kubernetes 1.35](./index.mdx#kubernetes-1-35-kubelet-patch)
 
      ```bash
      kubectl edit kubeadmcontrolplane <cluster_name> -n <namespace>
@@ -222,9 +223,11 @@ Typical changes include:
 
 - `spec.template.spec.version` — the target Kubernetes version
 - `spec.template.spec.infrastructureRef.name` — the new `VSphereMachineTemplate` name
-- `spec.template.spec.bootstrap.configRef.name` — the new `KubeadmConfigTemplate` name, if bootstrap settings must change (see [Updating Bootstrap Templates](../manage-nodes/vmware-vsphere.mdx#updating-bootstrap-templates))
+- `spec.template.spec.bootstrap.configRef.name` — the new `KubeadmConfigTemplate` name. This is required for Kubernetes 1.35 or later so the worker receives the [required kubelet patch](./index.mdx#kubernetes-1-35-kubelet-patch); for earlier versions, change it only when other bootstrap settings must change. See [Updating Bootstrap Templates](../manage-nodes/vmware-vsphere.mdx#updating-bootstrap-templates).
 
 Apply the changes:
+
+The following command includes the bootstrap reference required for Kubernetes 1.35 or later. For an earlier target with no bootstrap change, omit the `bootstrap` object.
 
 ```bash
 kubectl patch machinedeployment <cluster_name>-md-0 -n <namespace> \
@@ -235,6 +238,11 @@ kubectl patch machinedeployment <cluster_name>-md-0 -n <namespace> \
           "version": "<target_kubernetes_version>",
           "infrastructureRef": {
             "name": "<new-worker-template-name>"
+          },
+          "bootstrap": {
+            "configRef": {
+              "name": "<new-bootstrap-template-name>"
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- add imagePullCredentialsVerificationPolicy: NeverVerify to kubelet patch examples for Huawei DCS, Huawei Cloud Stack, VMware vSphere, and bare metal
- state that the parameter is required only starting with Kubernetes 1.35 and must be omitted for Kubernetes 1.34 and earlier
- update workload and global upgrade procedures for control-plane patches and immutable worker KubeadmConfigTemplate replacement

## Validation

- validated all 9 embedded kubelet patch JSON blocks
- yarn lint
- git diff --check