### PR TITLE
docs: refresh infrastructure provider release notes

### DIFF
--- a/docs/en/create-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/create-cluster/huawei-cloud-stack.mdx
@@ -7,6 +7,7 @@ queries:
   - create hcs cluster
   - huawei cloud stack kubernetes
   - hcs cluster creation
+  - hcs availability zone cluster node pool
   - workload cluster naming cluster-name not global
 ---
 
@@ -185,12 +186,12 @@ The control plane node pool is fixed at 3 replicas for high availability.
 |-------|------|----------|-------------|
 | Control Plane Node Pool Name | text | Yes | Pool name, automatically prefixed with `<cluster-name>-`. |
 | Flavor | dropdown | Yes | HCS flavor; the list shows vCPU and memory for each option. |
-| Availability Zone | dropdown | No | Target availability zone. Zones without capacity are disabled. |
+| Availability Zone | dropdown | No | Target availability zone for every control plane node. Zones reported as unavailable are disabled. See [Availability Zone Placement](../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement). |
 | Machine Configs | list | Yes | One entry per control plane node. At least 3 entries are required. See [Machine Config entry](#web-ui-machine-config) below. |
 | System Disk | number | Yes | Root disk size in GB; the type is fixed to SSD. |
 | Data Volumes | list | No | Fixed data disks mounted on every node in the pool; only the size is adjustable. The etcd data volume is included for the control plane. |
 | Replicas | readonly | - | Fixed at 3. |
-| Control Plane High Availability | toggle | No | On by default. Spreads control plane nodes across different physical hosts using a provider-managed HCS server group. |
+| Control Plane High Availability | toggle | No | On by default. Spreads control plane nodes across different physical hosts within the selected availability zone by using a provider-managed HCS server group. |
 | Placement Policy | radio | Conditional | Shown when High Availability is on. **Preferred (soft anti-affinity)** (default) spreads nodes on a best-effort basis. **Required (strict anti-affinity)** forces each node onto a different host and fails creation if there are not enough hosts. |
 | SSH Authorized Keys | list | No | Public keys for node access. |
 
@@ -210,7 +211,7 @@ Click **Add Worker Node Pool** to open the pool dialog. You can add multiple poo
 |-------|------|----------|-------------|
 | Worker Node Pool Name | text | Yes | Pool name, automatically prefixed with `<cluster-name>-`. Must be unique within the cluster. |
 | Flavor | dropdown | Yes | HCS flavor; the list shows vCPU and memory for each option. |
-| Availability Zone | dropdown | No | Target availability zone. |
+| Availability Zone | dropdown | No | Target availability zone for every node in this worker pool. Different worker pools can select different zones; zones reported as unavailable are disabled. See [Availability Zone Placement](../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement). |
 | Machine Configs | list | Yes | One entry per worker node. Uses the same [Machine Config entry](#web-ui-machine-config) layout as the control plane. |
 | System Disk | number | Yes | Root disk size in GB; the type is fixed to SSD. |
 | Data Volumes | list | No | Fixed data disks mounted on every node in the pool. |
@@ -449,7 +450,7 @@ spec:
 |-----------|------|----------|-------------|
 | `.spec.template.spec.imageName` | string | Yes | HCS image name. Use the image identifier published in the current release's OS support matrix; placeholder shown as `<alaudaos-version>` in the manifest above. The exact name moves with each Alauda OS release, so do not hardcode the example value across versions. |
 | `.spec.template.spec.flavorName` | string | Yes | Provider-recognized HCS API value matched against `Flavor.Name`. Do not use the tenant UI display name |
-| `.spec.template.spec.availabilityZone` | string | No | Provider-recognized HCS API value matched against `ZoneName`. Do not use the tenant UI display name |
+| `.spec.template.spec.availabilityZone` | string | No | Provider-recognized HCS API value matched against `ZoneName`. Every machine created from this template uses the selected zone. If omitted, the Provider selects a zone reported as available by HCS. See [Availability Zone Placement](../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement) |
 | `.spec.template.spec.rootVolume.type` | string | Yes | Volume type (`SSD` or `SATA`) |
 | `.spec.template.spec.rootVolume.size` | int | Yes | System disk size in GB |
 | `.spec.template.spec.configPoolRef.name` | string | Yes | Referenced HCSMachineConfigPool name |
@@ -465,7 +466,7 @@ spec:
 
 **Note:** Do not set runtime identity fields such as `providerID` or `serverId` in `HCSMachineTemplate` manifests. The provider assigns these values when it creates HCS instances.
 
-**Note:** Tenant administrators cannot retrieve the provider-recognized `flavorName` and `availabilityZone` values from the HCS UI. Get the exact values from the HCS administrator before you apply the manifest.
+**Note:** The ACP web UI loads flavors and availability zones through the selected HCS credential. When you write YAML, get the exact provider-recognized `Flavor.Name` and `ZoneName` values from the HCS administrator because the native HCS tenant console might not expose them.
 
 #### Configure KubeadmControlPlane
 

--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -15,6 +15,8 @@ queries:
 
 This document provides instructions for creating Kubernetes clusters on the Huawei DCS platform. YAML-based cluster creation is available through manifests. If Fleet Essentials is installed and Alauda Container Platform DCS Infrastructure Provider is `1.0.13` or later, you can also create clusters through the web UI. If the workflow relies on pool-managed persistent disks, use DCS provider `v1.0.16` or later. In `v1.0.16`, the `persistentDisk` declaration on `DCSIpHostnamePool` is available through YAML only and is not exposed in the web UI. In ACP v4.4 or later, YAML-based cluster creation can use `Self-built VIP` for the control plane endpoint.
 
+Before choosing a VM template and provider package, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+
 :::info
 The web UI provides a guided workflow with validation, while YAML offers more automation flexibility.
 :::

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -14,6 +14,8 @@ queries:
 
 This document describes how to install the `global` cluster onto Immutable Infrastructure. The `global` cluster is the platform control plane and is provisioned through Cluster API. Use this path when the platform control plane must run on an immutable operating system such as Alauda OS.
 
+For a `global` cluster on Huawei DCS, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility) before selecting the DCS Provider package and VM template.
+
 ## When to Use This Path
 
 Choose this installation path when all of the following conditions apply:

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -12,6 +12,8 @@ queries:
 
 This document describes how to upgrade a `global` cluster that runs on Immutable Infrastructure. Upgrades replace nodes with new Alauda OS images managed by the Cluster API provider; in-place node upgrades are not used.
 
+For a Huawei DCS `global` cluster, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility) before selecting the target DCS Provider package and Alauda OS image.
+
 ## When to Use This Path
 
 Choose this upgrade path when:

--- a/docs/en/infrastructure/huawei-cloud-stack.mdx
+++ b/docs/en/infrastructure/huawei-cloud-stack.mdx
@@ -8,6 +8,7 @@ queries:
   - hcs secret subnet and elb planning
   - huawei cloud stack yaml prerequisites
   - hcs pool managed persistent disks
+  - hcs availability zone planning
 ---
 
 # Infrastructure Resources for Huawei Cloud Stack
@@ -39,7 +40,7 @@ Prepare the following inputs before you create or edit any cluster manifests:
 | `region` | HCS credential `Secret` | HCS administrator | Yes | Tenant administrators cannot retrieve this value from the HCS UI |
 | `imageName` | `HCSMachineTemplate` | HCS image inventory | Yes | Use the validated HCS image name for the selected Alauda OS image |
 | `flavorName` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `Flavor.Name`, not the tenant UI display name |
-| `availabilityZone` | `HCSMachineTemplate` | HCS administrator | Yes | Use the provider-recognized HCS API value matched against `ZoneName`, not the tenant UI display name |
+| `availabilityZone` | `HCSMachineTemplate` | HCS administrator or the ACP web UI | Recommended | Select an explicit provider-recognized HCS API value for predictable placement. If omitted, the Provider selects an availability zone reported as available by HCS |
 | Root, temporary data volume, and persistent disk layout | `HCSMachineTemplate`, `HCSMachineConfigPool` | Cluster storage plan | Yes | Plan disk sizes and mount points before you write the template and pool. Put disks that can be recreated with the VM in `HCSMachineTemplate.spec.template.spec.dataVolumes[]`. Put disks that must survive VM replacement, such as `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` |
 | VPC name and security group name | `HCSCluster` | HCS network inventory | Yes | Confirm that the referenced VPC and security group already exist and are usable |
 | Cluster subnet inventory | `HCSCluster`, `HCSMachineConfigPool`, control plane ELB | HCS network inventory | Yes | Prepare the subnet name, subnet ID, ELB-related subnet metadata, CIDR, gateway, DNS values, and planned free IP range for every subnet that the cluster will use |
@@ -79,7 +80,27 @@ Prepare the VM image, flavor, availability zone, temporary data volume layout, a
 | Root and temporary data volumes | Plan system and temporary data disks in advance. Control plane templates typically use temporary data volumes for `/var/lib/etcd`, `/var/lib/kubelet`, and `/var/lib/containerd`. Worker templates typically use temporary data volumes for `/var/lib/kubelet` and `/var/lib/containerd`. |
 | Pool-managed persistent disks | Plan disks that must survive VM replacement in advance. Use this model for `/var/cpaas` and other node-local state that must be retained during rolling replacement. |
 
-**Note:** Tenant administrators cannot retrieve the provider-recognized `flavorName` and `availabilityZone` values from the HCS UI. Get the exact API values from the HCS administrator before you write the manifest.
+**Note:** The ACP web UI loads flavors and availability zones through the selected HCS credential. When you write YAML, get the exact provider-recognized `Flavor.Name` and `ZoneName` values from the HCS administrator because the native HCS tenant console might not expose them.
+
+### Availability Zone Placement \{#availability-zone-placement}
+
+An `HCSMachineTemplate` selects one availability zone for every machine created from that template. The ACP web UI creates one template for the control plane node pool and one template for each worker node pool. As a result:
+
+- All control plane nodes use one availability zone.
+- All replicas in one worker node pool use one availability zone.
+- Different worker node pools can select different availability zones.
+- A single node pool does not automatically spread replicas across multiple availability zones.
+
+For predictable placement, select an availability zone explicitly. If `HCSMachineTemplate.spec.template.spec.availabilityZone` is omitted, the Provider queries HCS and selects the first availability zone that HCS reports as available. The ordering of that list is controlled by HCS.
+
+When you use the ACP web UI, the Availability Zone dropdown is loaded through the selected HCS credential, uses the HCS API `ZoneName`, and disables zones that HCS reports as unavailable. When you write YAML, use the provider-recognized `ZoneName`, not a display name from the native HCS tenant console. The Provider rejects a name that is not returned by HCS. For a named zone that exists but is currently unavailable, ECS provisioning can still reach HCS and fail there, so verify that the zone is available before you apply the manifest.
+
+:::warning
+Pool-managed persistent disks and control plane high availability add placement constraints:
+
+- An existing pool-managed persistent disk locks its replacement ECS instance to the disk's availability zone. If the template explicitly selects a different zone, the replacement fails with an availability zone conflict.
+- Control Plane High Availability spreads control plane ECS instances across physical hosts by using an HCS server group. It does not spread the control plane across availability zones; all control plane nodes remain in the zone selected by the control plane `HCSMachineTemplate`.
+:::
 
 ## Version and Component Baseline
 

--- a/docs/en/install/huawei-dcs.mdx
+++ b/docs/en/install/huawei-dcs.mdx
@@ -13,6 +13,8 @@ Before installing the provider, ensure you have:
 - Access to the <Term name="product" textCase="capitalize" /> `global` cluster
 - Access to Customer Portal for downloading plugins
 
+Before selecting the provider package and Alauda OS image, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+
 ## Downloading
 
 :::info

--- a/docs/en/manage-nodes/huawei-cloud-stack.mdx
+++ b/docs/en/manage-nodes/huawei-cloud-stack.mdx
@@ -9,6 +9,7 @@ queries:
   - hcs machine deployment
   - hcs worker persistent disks
   - hcs node pools web ui manage ips
+  - hcs worker node pool availability zone
 ---
 
 # Managing Nodes on Huawei Cloud Stack
@@ -65,6 +66,8 @@ The Node Pools tab shows the Control Plane Node Pool and each Worker Node Pool a
 ### Adding a Worker Node Pool
 
 Click **Add Worker Node Pool** and complete the dialog. The fields match Step 5 of the [creation wizard](../create-cluster/huawei-cloud-stack.mdx#using-the-web-ui): pool name (prefixed with `<cluster-name>-`), Flavor, Availability Zone, Machine Configs (hostname, networks, persistent disks), System Disk, Data Volumes, Replicas, Rollout Strategy, and SSH Authorized Keys. New nodes appear in the Nodes tab after the pool is created.
+
+The selected Availability Zone applies to every node in the new worker pool. To place worker nodes in another zone, create a separate worker pool and select that zone; one pool does not automatically spread its replicas across zones. The dropdown disables zones that HCS reports as unavailable. See [Availability Zone Placement](../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement) for automatic selection, persistent disk, and control plane placement constraints.
 
 ### Managing Node IP Addresses \{#manage-ips}
 
@@ -230,7 +233,7 @@ spec:
 |-----------|------|----------|-------------|
 | `.spec.template.spec.imageName` | string | Yes | VM image name |
 | `.spec.template.spec.flavorName` | string | Yes | Provider-recognized HCS API value matched against `Flavor.Name` |
-| `.spec.template.spec.availabilityZone` | string | No | Provider-recognized HCS API value matched against `ZoneName` |
+| `.spec.template.spec.availabilityZone` | string | No | Provider-recognized HCS API value matched against `ZoneName`. Every worker created from this template uses the selected zone. If omitted, the Provider selects a zone reported as available by HCS. See [Availability Zone Placement](../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement) |
 | `.spec.template.spec.rootVolume.type` | string | Yes | Volume type |
 | `.spec.template.spec.rootVolume.size` | int | Yes | System disk size in GB |
 | `.spec.template.spec.configPoolRef.name` | string | Yes | Referenced HCSMachineConfigPool name |
@@ -246,7 +249,7 @@ spec:
 
 **Note:** Do not set runtime identity fields such as `providerID` or `serverId` in `HCSMachineTemplate` manifests. The provider assigns these values when it creates HCS instances.
 
-**Note:** Tenant administrators cannot retrieve the provider-recognized `flavorName` and `availabilityZone` values from the HCS UI. Get the exact values from the HCS administrator before you apply the manifest.
+**Note:** The ACP web UI loads flavors and availability zones through the selected HCS credential. When you write YAML, get the exact provider-recognized `Flavor.Name` and `ZoneName` values from the HCS administrator because the native HCS tenant console might not expose them.
 
 #### Step 3: Configure Bootstrap Template
 

--- a/docs/en/overview/os-support-matrix.mdx
+++ b/docs/en/overview/os-support-matrix.mdx
@@ -37,6 +37,12 @@ This requirement applies when you create or upgrade cluster nodes with ACP-provi
 | v4.3.2 | **alaudaos-43.m55.202606251459-0.x86_64**<br />**alaudaos-43.k.202606260612-0.aarch64** | v1.34.5-3 | 2.2.1-5 | 1.14.2-v4.3.11 | v3.5.28-260625 | 3.10 | v4.3.11 |
 
 :::info
+**Huawei DCS provider pairing**
+
+For Huawei DCS clusters that use the Alauda OS image from ACP `v4.3.2` or a later row, including ACP `v4.4.0` and later, use DCS Provider `v1.0.21` or later. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image from a release earlier than ACP `v4.3.2`. For the complete requirement, see [Alauda OS and Provider Compatibility](./providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+:::
+
+:::info
 The **kube-ovn (chart)** column is the `acp/chart-cpaas-kube-ovn` Helm chart version, which tracks the ACP release line (for example, ACP v4.2.2 ships chart `v4.2.24`). It is **not** the Kube-OVN component (binary) version such as `v1.14.x` or `v1.15.x`.
 
 Use this chart version — not the component version — when you set the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource and when you patch the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision`. See the provider-specific upgrade guides for the procedure.

--- a/docs/en/overview/providers/huawei-cloud-stack.mdx
+++ b/docs/en/overview/providers/huawei-cloud-stack.mdx
@@ -8,6 +8,7 @@ queries:
   - hcs cluster api
   - hcs infrastructure provider
   - hcs web ui cluster management
+  - hcs availability zone selection
 ---
 
 # Huawei Cloud Stack Provider
@@ -30,7 +31,7 @@ HCS provider `v1.0.1` or later supports pool-managed persistent disks. Declare d
 - **Machine Configuration Pools**: Pre-defined hostnames, static IP addresses, and persistent disk slots for predictable VM provisioning
 - **Pool-Managed Persistent Disks**: EVS disks can be detached from an old ECS and attached to the replacement ECS during rolling upgrades
 - **Control Plane Security Bootstrap**: Supports kube-apiserver audit, admission, encryption provider, and kubelet certificate configuration through kubeadm bootstrap data
-- **Availability Zone Selection**: Supports specifying the target availability zone for HCS machines
+- **Per-Node-Pool Availability Zone Selection**: Select one HCS availability zone for the control plane or each worker node pool; separate worker pools can target different zones. See [Availability Zone Placement](../../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement)
 
 ## Cluster Management Capabilities
 

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -24,6 +24,12 @@ Pool-managed persistent disks are first supported in DCS provider `v1.0.16`.
 In `v1.0.16`, `DCSIpHostnamePool.spec.pool[].persistentDisk` is managed through YAML only; the web UI does not expose this configuration.
 :::
 
+## Alauda OS and Provider Compatibility \{#alauda-os-and-provider-compatibility}
+
+For a Huawei DCS cluster that uses Alauda OS, select the Alauda OS image from the [OS Support Matrix](../../overview/os-support-matrix.mdx) row for the ACP release installed on the cluster.
+
+For ACP `v4.3.2` or later, including ACP `v4.4.0` and later, install DCS Provider `v1.0.21` or later. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image for an ACP release earlier than `v4.3.2`.
+
 ## Key Features
 
 - **Virtual Machine Management**: Provision and manage VMs on DCS platform

--- a/docs/en/release-notes/huawei_cloud_stack.mdx
+++ b/docs/en/release-notes/huawei_cloud_stack.mdx
@@ -4,6 +4,7 @@ queries:
   - hcs release notes
   - huawei cloud stack version
   - what changed hcs provider
+  - hcs availability zone version
 ---
 
 # Huawei Cloud Stack Provider Release Notes
@@ -20,11 +21,13 @@ For the current full capability list and installation steps, see [Huawei Cloud S
 
 ### New Features
 
-- **Web UI for HCS cluster management** — HCS clusters can now be created and managed through the web UI. A guided wizard creates clusters, the Node Pools tab manages the control plane and worker node pools, and the Manage IPs dialog edits the reserved node IP addresses of an existing pool. This workflow requires Fleet Essentials `1.0.2` or later. See [Creating Clusters on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx#using-the-web-ui) and [Managing Nodes on Huawei Cloud Stack](../manage-nodes/huawei-cloud-stack.mdx#managing-node-pools-using-the-web-ui).
+- **Web UI node pool workflow stabilization** — This release is the documented minimum HCS Provider version for the web UI workflow and requires Fleet Essentials `1.0.2` or later. It improves the Node Pools cards, prevents duplicate or stale subnet IP selections, validates required subnet and IP values, and corrects the day-2 Manage IPs workflow. When you create a control plane or worker node pool, the Availability Zone list uses zones reported by HCS and disables zones reported as unavailable. See [Creating Clusters on Huawei Cloud Stack](../create-cluster/huawei-cloud-stack.mdx#using-the-web-ui) and [Managing Nodes on Huawei Cloud Stack](../manage-nodes/huawei-cloud-stack.mdx#managing-node-pools-using-the-web-ui).
 
 ## v1.0.2 (2026-06-26) \{#v1-0-2}
 
 ### New Features
+
+- **Initial HCS web UI integration** — The Provider package now includes the initial HCS web UI for guided cluster creation and Node Pools operations. The UI loads infrastructure values, including flavors and availability zones, through the selected HCS credential. For the documented web UI workflow and subsequent node pool fixes, use HCS Provider `v1.0.3` or later with Fleet Essentials `1.0.2` or later.
 
 - **Control plane high availability (server group anti-affinity)** — `HCSCluster` accepts a new `spec.controlPlaneHA` block with `enabled` and `policy` (`anti-affinity` or `soft-anti-affinity`). When enabled, the provider creates and maintains an HCS server group and spreads the control-plane ECS instances across different physical hosts. The feature covers the control plane only, the provider owns the server group rather than referencing an existing one, and existing clusters converge through control plane rolling replacement. See [Configure HCSCluster](../create-cluster/huawei-cloud-stack.mdx#configure-hcscluster) for the field reference and [Control Plane HA Placement Plan](../infrastructure/huawei-cloud-stack.mdx#control-plane-ha-placement) for planning guidance.
 
@@ -41,6 +44,8 @@ For the current full capability list and installation steps, see [Huawei Cloud S
 ### New Features
 
 - **Cluster lifecycle on Huawei Cloud Stack** — Create, scale, and delete Kubernetes clusters that use HCS as the infrastructure backend. Cluster creation reuses an existing VPC, subnet, and security group; the provider creates and binds the control plane ELB automatically and writes back the resulting `controlPlaneEndpoint`.
+
+- **Availability zone selection** — Set `HCSMachineTemplate.spec.template.spec.availabilityZone` to place the control plane or a worker node pool in one provider-recognized HCS availability zone. Different worker node pools can use different templates and availability zones, but replicas in one pool are not automatically spread across zones. If the field is omitted, the Provider selects an availability zone reported as available by HCS. See [Availability Zone Placement](../infrastructure/huawei-cloud-stack.mdx#availability-zone-placement).
 
 - **Reserved hostname and IP pool (`HCSMachineConfigPool`)** — Reserve fixed hostnames, subnet assignments, and static IP slots for cluster nodes. Slots are released and reused when nodes are deleted. Required when persistent node-local disks must be preserved across node replacement.
 

--- a/docs/en/release-notes/huawei_dcs.mdx
+++ b/docs/en/release-notes/huawei_dcs.mdx
@@ -24,6 +24,10 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 
 - **More efficient DCS authentication during reconciliation** — The provider reuses valid DCS SDK authentication tokens and clients instead of repeatedly requesting new remote logins, reducing unnecessary control-plane traffic during normal operations.
 
+### Fixed Issues
+
+- **Alauda OS compatibility for ACP v4.3.2 and later** — The provider reliably applies the configured primary node address on multi-NIC nodes during bootstrap. DCS Provider `v1.0.21` is required when a DCS cluster uses the Alauda OS image for ACP `v4.3.2` or later, including ACP `v4.4.0` and later. Select the image from the OS Support Matrix row for the same ACP release. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image for an ACP release earlier than `v4.3.2`. See [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+
 ## v1.0.20 (2026-06-04) \{#v1-0-20}
 
 ### New Features
@@ -31,10 +35,6 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 - **Thin-provisioning option for pool-managed persistent disks** — `DCSIpHostnamePool.spec.pool[].persistentDisk.isThin` lets you request the DCS thin-provisioning setting when the provider creates a new persistent volume. This field is creation-only: changing it does not convert an existing volume.
 
 - **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
-
-### Fixed Issues
-
-- **Configured primary node IP on multi-NIC Alauda OS nodes** — The configured kubelet `node-ip` is now applied through the supported bootstrap configuration path, so a node with multiple NICs reliably registers the intended primary address.
 
 ## v1.0.19 (2026-05-29) \{#v1-0-19}
 

--- a/docs/en/release-notes/huawei_dcs.mdx
+++ b/docs/en/release-notes/huawei_dcs.mdx
@@ -14,6 +14,34 @@ This page tracks release notes for the Alauda Container Platform Huawei DCS Infr
 
 For the current full capability list and installation steps, see [Huawei DCS Provider Installation](../install/huawei-dcs.mdx).
 
+## v1.0.21 (2026-06-17) \{#v1-0-21}
+
+### New Features
+
+- **Control plane high availability on Huawei DCS** — Set `DCSCluster.spec.controlPlaneHA.enabled` to have the provider create and maintain a DCS DRS mutual-exclusion rule for the control-plane VMs. DCS performs the actual placement and migration; the provider updates the rule as control-plane VMs change. This option requires DRS to be enabled and sufficient host capacity. See [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
+
+### Enhancements
+
+- **More efficient DCS authentication during reconciliation** — The provider reuses valid DCS SDK authentication tokens and clients instead of repeatedly requesting new remote logins, reducing unnecessary control-plane traffic during normal operations.
+
+## v1.0.20 (2026-06-04) \{#v1-0-20}
+
+### New Features
+
+- **Thin-provisioning option for pool-managed persistent disks** — `DCSIpHostnamePool.spec.pool[].persistentDisk.isThin` lets you request the DCS thin-provisioning setting when the provider creates a new persistent volume. This field is creation-only: changing it does not convert an existing volume.
+
+- **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
+
+### Fixed Issues
+
+- **Configured primary node IP on multi-NIC Alauda OS nodes** — The configured kubelet `node-ip` is now applied through the supported bootstrap configuration path, so a node with multiple NICs reliably registers the intended primary address.
+
+## v1.0.19 (2026-05-29) \{#v1-0-19}
+
+### Enhancements
+
+- **Alauda OS template compatibility** — Node bootstrap configuration now renders the `/home` mount only for compatible Alauda OS templates. Existing manifests require no change.
+
 ## v1.0.18 (2026-05-19) \{#v1-0-18}
 
 ### New Features

--- a/docs/en/release-notes/huawei_dcs.mdx
+++ b/docs/en/release-notes/huawei_dcs.mdx
@@ -20,6 +20,8 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 
 - **Control plane high availability on Huawei DCS** — Set `DCSCluster.spec.controlPlaneHA.enabled` to have the provider create and maintain a DCS DRS mutual-exclusion rule for the control-plane VMs. DCS performs the actual placement and migration; the provider updates the rule as control-plane VMs change. This option requires DRS to be enabled and sufficient host capacity. See [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
 
+- **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
+
 ### Enhancements
 
 - **More efficient DCS authentication during reconciliation** — The provider reuses valid DCS SDK authentication tokens and clients instead of repeatedly requesting new remote logins, reducing unnecessary control-plane traffic during normal operations.
@@ -33,8 +35,6 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 ### New Features
 
 - **Thin-provisioning option for pool-managed persistent disks** — `DCSIpHostnamePool.spec.pool[].persistentDisk.isThin` lets you request the DCS thin-provisioning setting when the provider creates a new persistent volume. This field is creation-only: changing it does not convert an existing volume.
-
-- **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
 
 ## v1.0.19 (2026-05-29) \{#v1-0-19}
 

--- a/docs/en/release-notes/kubeadm.mdx
+++ b/docs/en/release-notes/kubeadm.mdx
@@ -16,6 +16,24 @@ The Kubeadm Provider is platform-wide and is consumed by every infrastructure pr
 
 For installation and capability details, see the platform installation documentation.
 
+## v1.0.12 (2026-07-28) \{#v1-0-12}
+
+### Fixed Issues
+
+- **Standby Global Cluster protection** — Kubeadm bootstrap and control-plane reconciliation remain inactive on a standby Global Cluster. Replicated workload-cluster resources are therefore not acted on until the standby cluster is promoted during disaster recovery.
+
+## v1.0.11 (2026-06-10) \{#v1-0-11}
+
+### Fixed Issues
+
+- **More reliable control-plane rollout readiness** — The rollout gate now validates the identity of replacement control-plane nodes and waits for a stable control-plane node set before refreshing platform registry state. This prevents stale node records from leaving a rollout waiting indefinitely.
+
+## v1.0.10 (2026-05-25) \{#v1-0-10}
+
+### Fixed Issues
+
+- **Platform registry refresh after control-plane VM replacement** — A Global Cluster now refreshes the platform registry state when a replacement control-plane VM reuses the prior node name and IP address. This allows the rolling update to continue after node-local platform services are prepared on the replacement VM.
+
 ## v1.0.9 (2026-05-21) \{#v1-0-9}
 
 ### Notes

--- a/docs/en/release-notes/vmware_vsphere.mdx
+++ b/docs/en/release-notes/vmware_vsphere.mdx
@@ -14,6 +14,36 @@ This page tracks release notes for the Alauda Container Platform VMware vSphere 
 
 For the current full capability list and installation steps, see [VMware vSphere Provider Installation](../install/vmware-vsphere.mdx).
 
+## v1.0.15 (2026-07-09) \{#v1-0-15}
+
+### Fixed Issues
+
+- **Reliable primary node address and identity** — The vSphere cloud provider now honors the configured node IP when choosing a node address and resolves the provider ID from the VM's registered system UUID. This avoids incorrect node identity or address selection, especially for VMs with multiple NICs.
+
+- **More reliable Kube-OVN bootstrap** — The provider waits for a valid control-plane node set before reconciling Kube-OVN, avoiding CNI reconciliation while the initial control plane is incomplete.
+
+## v1.0.14 (2026-06-08) \{#v1-0-14}
+
+### Notes
+
+`v1.0.14` is a re-tag of `v1.0.13` at the same source revision. It contains no additional changes; see [v1.0.13](#v1-0-13).
+
+## v1.0.13 (2026-06-08) \{#v1-0-13}
+
+### Fixed Issues
+
+- **Safer pool-managed persistent disk replacement** — A machine-configuration pool slot is not reused while persistent disks from the previous VM are still attached. This prevents a replacement VM from racing the disk-detach operation.
+
+- **Standby Global Cluster reconciliation** — vSphere provider resources can reconcile correctly on a standby Global Cluster, supporting the documented disaster recovery procedure.
+
+## v1.0.12 (2026-05-25) \{#v1-0-12}
+
+### Fixed Issues
+
+- **vSphere CPI can start during Kube-OVN bootstrap** — The vSphere cloud provider is scheduled on control-plane nodes and tolerates their taints, allowing it to start before the cluster network is ready.
+
+- **Kube-OVN waits for the initial control plane** — The provider defers Kube-OVN reconciliation until the number of ready control-plane nodes matches the intended control-plane replica count.
+
 ## v1.0.11 (2026-05-21) \{#v1-0-11}
 
 ### Fixed Issues

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -33,6 +33,12 @@ DCS provider `v1.0.16` is the first release that supports pool-managed persisten
 :::
 
 :::info
+**Alauda OS and Provider Compatibility**
+
+Before selecting the target provider package and VM template, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+:::
+
+:::info
 **Existing Cluster Migration**
 
 If your cluster runs ACP `v4.2.1` or later and you are moving to DCS provider `v1.0.16` or later, complete the migration procedure in [Migrate Existing Huawei DCS Clusters to Pool-Managed Persistent Disks](../how-to/dcs_persistent_disk_upgrade.mdx) before you rely on upgrade-time disk preservation.


### PR DESCRIPTION
## Summary
- add DCS v1.0.19 through v1.0.21 release notes
- add Kubeadm v1.0.10 through v1.0.12 release notes
- add VMware vSphere v1.0.12 through v1.0.15 release notes

## Validation
- yarn lint docs/en/release-notes (0 errors, 0 warnings)
- git diff --check

The entries are based on the corresponding released Provider tags and source diffs. HCS already matches its current release tag; Bare Metal has no release tag suitable for a customer-facing version timeline.