### PR TITLE
docs: backport provider release notes to release-1.0

### DIFF
--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -15,6 +15,8 @@ queries:
 
 This document provides instructions for creating Kubernetes clusters on the Huawei DCS platform. YAML-based cluster creation is available through manifests. If Fleet Essentials is installed and Alauda Container Platform DCS Infrastructure Provider is `1.0.13` or later, you can also create clusters through the web UI. If the workflow relies on pool-managed persistent disks, use DCS provider `v1.0.16` or later. In `v1.0.16`, the `persistentDisk` declaration on `DCSIpHostnamePool` is available through YAML only and is not exposed in the web UI. In ACP v4.4 or later, YAML-based cluster creation can use `Self-built VIP` for the control plane endpoint.
 
+Before choosing a VM template and provider package, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+
 :::info
 The web UI provides a guided workflow with validation, while YAML offers more automation flexibility.
 :::

--- a/docs/en/global/install.mdx
+++ b/docs/en/global/install.mdx
@@ -14,6 +14,8 @@ queries:
 
 This document describes how to install the `global` cluster onto Immutable Infrastructure. The `global` cluster is the platform control plane and is provisioned through Cluster API. Use this path when the platform control plane must run on an immutable operating system such as Alauda OS.
 
+For a `global` cluster on Huawei DCS, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility) before selecting the DCS Provider package and VM template.
+
 ## When to Use This Path
 
 Choose this installation path when all of the following conditions apply:

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -12,6 +12,8 @@ queries:
 
 This document describes how to upgrade a `global` cluster that runs on Immutable Infrastructure. Upgrades replace nodes with new Alauda OS images managed by the Cluster API provider; in-place node upgrades are not used.
 
+For a Huawei DCS `global` cluster, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility) before selecting the target DCS Provider package and Alauda OS image.
+
 ## When to Use This Path
 
 Choose this upgrade path when:

--- a/docs/en/install/huawei-dcs.mdx
+++ b/docs/en/install/huawei-dcs.mdx
@@ -13,6 +13,8 @@ Before installing the provider, ensure you have:
 - Access to the <Term name="product" textCase="capitalize" /> `global` cluster
 - Access to Customer Portal for downloading plugins
 
+Before selecting the provider package and Alauda OS image, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+
 ## Downloading
 
 :::info

--- a/docs/en/overview/os-support-matrix.mdx
+++ b/docs/en/overview/os-support-matrix.mdx
@@ -37,6 +37,12 @@ This requirement applies when you create or upgrade cluster nodes with ACP-provi
 | v4.3.2 | **alaudaos-43.m55.202606251459-0.x86_64**<br />**alaudaos-43.k.202606260612-0.aarch64** | v1.34.5-3 | 2.2.1-5 | 1.14.2-v4.3.11 | v3.5.28-260625 | 3.10 | v4.3.11 |
 
 :::info
+**Huawei DCS provider pairing**
+
+For Huawei DCS clusters that use the Alauda OS image from ACP `v4.3.2` or a later row, including ACP `v4.4.0` and later, use DCS Provider `v1.0.21` or later. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image from a release earlier than ACP `v4.3.2`. For the complete requirement, see [Alauda OS and Provider Compatibility](./providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+:::
+
+:::info
 The **kube-ovn (chart)** column is the `acp/chart-cpaas-kube-ovn` Helm chart version, which tracks the ACP release line (for example, ACP v4.2.2 ships chart `v4.2.24`). It is **not** the Kube-OVN component (binary) version such as `v1.14.x` or `v1.15.x`.
 
 Use this chart version — not the component version — when you set the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource and when you patch the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision`. See the provider-specific upgrade guides for the procedure.

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -24,6 +24,12 @@ Pool-managed persistent disks are first supported in DCS provider `v1.0.16`.
 In `v1.0.16`, `DCSIpHostnamePool.spec.pool[].persistentDisk` is managed through YAML only; the web UI does not expose this configuration.
 :::
 
+## Alauda OS and Provider Compatibility \{#alauda-os-and-provider-compatibility}
+
+For a Huawei DCS cluster that uses Alauda OS, select the Alauda OS image from the [OS Support Matrix](../../overview/os-support-matrix.mdx) row for the ACP release installed on the cluster.
+
+For ACP `v4.3.2` or later, including ACP `v4.4.0` and later, install DCS Provider `v1.0.21` or later. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image for an ACP release earlier than `v4.3.2`.
+
 ## Key Features
 
 - **Virtual Machine Management**: Provision and manage VMs on DCS platform

--- a/docs/en/release-notes/huawei_dcs.mdx
+++ b/docs/en/release-notes/huawei_dcs.mdx
@@ -24,6 +24,10 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 
 - **More efficient DCS authentication during reconciliation** — The provider reuses valid DCS SDK authentication tokens and clients instead of repeatedly requesting new remote logins, reducing unnecessary control-plane traffic during normal operations.
 
+### Fixed Issues
+
+- **Alauda OS compatibility for ACP v4.3.2 and later** — The provider reliably applies the configured primary node address on multi-NIC nodes during bootstrap. DCS Provider `v1.0.21` is required when a DCS cluster uses the Alauda OS image for ACP `v4.3.2` or later, including ACP `v4.4.0` and later. Select the image from the OS Support Matrix row for the same ACP release. Do not pair DCS Provider `v1.0.21` or later with an Alauda OS image for an ACP release earlier than `v4.3.2`. See [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+
 ## v1.0.20 (2026-06-04) \{#v1-0-20}
 
 ### New Features
@@ -31,10 +35,6 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 - **Thin-provisioning option for pool-managed persistent disks** — `DCSIpHostnamePool.spec.pool[].persistentDisk.isThin` lets you request the DCS thin-provisioning setting when the provider creates a new persistent volume. This field is creation-only: changing it does not convert an existing volume.
 
 - **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
-
-### Fixed Issues
-
-- **Configured primary node IP on multi-NIC Alauda OS nodes** — The configured kubelet `node-ip` is now applied through the supported bootstrap configuration path, so a node with multiple NICs reliably registers the intended primary address.
 
 ## v1.0.19 (2026-05-29) \{#v1-0-19}
 

--- a/docs/en/release-notes/huawei_dcs.mdx
+++ b/docs/en/release-notes/huawei_dcs.mdx
@@ -14,6 +14,34 @@ This page tracks release notes for the Alauda Container Platform Huawei DCS Infr
 
 For the current full capability list and installation steps, see [Huawei DCS Provider Installation](../install/huawei-dcs.mdx).
 
+## v1.0.21 (2026-06-17) \{#v1-0-21}
+
+### New Features
+
+- **Control plane high availability on Huawei DCS** — Set `DCSCluster.spec.controlPlaneHA.enabled` to have the provider create and maintain a DCS DRS mutual-exclusion rule for the control-plane VMs. DCS performs the actual placement and migration; the provider updates the rule as control-plane VMs change. This option requires DRS to be enabled and sufficient host capacity. See [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
+
+### Enhancements
+
+- **More efficient DCS authentication during reconciliation** — The provider reuses valid DCS SDK authentication tokens and clients instead of repeatedly requesting new remote logins, reducing unnecessary control-plane traffic during normal operations.
+
+## v1.0.20 (2026-06-04) \{#v1-0-20}
+
+### New Features
+
+- **Thin-provisioning option for pool-managed persistent disks** — `DCSIpHostnamePool.spec.pool[].persistentDisk.isThin` lets you request the DCS thin-provisioning setting when the provider creates a new persistent volume. This field is creation-only: changing it does not convert an existing volume.
+
+- **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
+
+### Fixed Issues
+
+- **Configured primary node IP on multi-NIC Alauda OS nodes** — The configured kubelet `node-ip` is now applied through the supported bootstrap configuration path, so a node with multiple NICs reliably registers the intended primary address.
+
+## v1.0.19 (2026-05-29) \{#v1-0-19}
+
+### Enhancements
+
+- **Alauda OS template compatibility** — Node bootstrap configuration now renders the `/home` mount only for compatible Alauda OS templates. Existing manifests require no change.
+
 ## v1.0.18 (2026-05-19) \{#v1-0-18}
 
 ### New Features

--- a/docs/en/release-notes/huawei_dcs.mdx
+++ b/docs/en/release-notes/huawei_dcs.mdx
@@ -20,6 +20,8 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 
 - **Control plane high availability on Huawei DCS** — Set `DCSCluster.spec.controlPlaneHA.enabled` to have the provider create and maintain a DCS DRS mutual-exclusion rule for the control-plane VMs. DCS performs the actual placement and migration; the provider updates the rule as control-plane VMs change. This option requires DRS to be enabled and sufficient host capacity. See [Cross-Host High Availability for Control Plane](../infrastructure/huawei-dcs.mdx#cross-host-ha).
 
+- **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
+
 ### Enhancements
 
 - **More efficient DCS authentication during reconciliation** — The provider reuses valid DCS SDK authentication tokens and clients instead of repeatedly requesting new remote logins, reducing unnecessary control-plane traffic during normal operations.
@@ -33,8 +35,6 @@ For the current full capability list and installation steps, see [Huawei DCS Pro
 ### New Features
 
 - **Thin-provisioning option for pool-managed persistent disks** — `DCSIpHostnamePool.spec.pool[].persistentDisk.isThin` lets you request the DCS thin-provisioning setting when the provider creates a new persistent volume. This field is creation-only: changing it does not convert an existing volume.
-
-- **Automatic CD-ROM detach after node bootstrap** — The provider detaches the bootstrapping CD-ROM after the VM is created, removing a common constraint on later DRS migration and control-plane placement operations.
 
 ## v1.0.19 (2026-05-29) \{#v1-0-19}
 

--- a/docs/en/release-notes/kubeadm.mdx
+++ b/docs/en/release-notes/kubeadm.mdx
@@ -16,6 +16,24 @@ The Kubeadm Provider is platform-wide and is consumed by every infrastructure pr
 
 For installation and capability details, see the platform installation documentation.
 
+## v1.0.12 (2026-07-28) \{#v1-0-12}
+
+### Fixed Issues
+
+- **Standby Global Cluster protection** — Kubeadm bootstrap and control-plane reconciliation remain inactive on a standby Global Cluster. Replicated workload-cluster resources are therefore not acted on until the standby cluster is promoted during disaster recovery.
+
+## v1.0.11 (2026-06-10) \{#v1-0-11}
+
+### Fixed Issues
+
+- **More reliable control-plane rollout readiness** — The rollout gate now validates the identity of replacement control-plane nodes and waits for a stable control-plane node set before refreshing platform registry state. This prevents stale node records from leaving a rollout waiting indefinitely.
+
+## v1.0.10 (2026-05-25) \{#v1-0-10}
+
+### Fixed Issues
+
+- **Platform registry refresh after control-plane VM replacement** — A Global Cluster now refreshes the platform registry state when a replacement control-plane VM reuses the prior node name and IP address. This allows the rolling update to continue after node-local platform services are prepared on the replacement VM.
+
 ## v1.0.9 (2026-05-21) \{#v1-0-9}
 
 ### Notes

--- a/docs/en/release-notes/vmware_vsphere.mdx
+++ b/docs/en/release-notes/vmware_vsphere.mdx
@@ -14,6 +14,36 @@ This page tracks release notes for the Alauda Container Platform VMware vSphere 
 
 For the current full capability list and installation steps, see [VMware vSphere Provider Installation](../install/vmware-vsphere.mdx).
 
+## v1.0.15 (2026-07-09) \{#v1-0-15}
+
+### Fixed Issues
+
+- **Reliable primary node address and identity** — The vSphere cloud provider now honors the configured node IP when choosing a node address and resolves the provider ID from the VM's registered system UUID. This avoids incorrect node identity or address selection, especially for VMs with multiple NICs.
+
+- **More reliable Kube-OVN bootstrap** — The provider waits for a valid control-plane node set before reconciling Kube-OVN, avoiding CNI reconciliation while the initial control plane is incomplete.
+
+## v1.0.14 (2026-06-08) \{#v1-0-14}
+
+### Notes
+
+`v1.0.14` is a re-tag of `v1.0.13` at the same source revision. It contains no additional changes; see [v1.0.13](#v1-0-13).
+
+## v1.0.13 (2026-06-08) \{#v1-0-13}
+
+### Fixed Issues
+
+- **Safer pool-managed persistent disk replacement** — A machine-configuration pool slot is not reused while persistent disks from the previous VM are still attached. This prevents a replacement VM from racing the disk-detach operation.
+
+- **Standby Global Cluster reconciliation** — vSphere provider resources can reconcile correctly on a standby Global Cluster, supporting the documented disaster recovery procedure.
+
+## v1.0.12 (2026-05-25) \{#v1-0-12}
+
+### Fixed Issues
+
+- **vSphere CPI can start during Kube-OVN bootstrap** — The vSphere cloud provider is scheduled on control-plane nodes and tolerates their taints, allowing it to start before the cluster network is ready.
+
+- **Kube-OVN waits for the initial control plane** — The provider defers Kube-OVN reconciliation until the number of ready control-plane nodes matches the intended control-plane replica count.
+
 ## v1.0.11 (2026-05-21) \{#v1-0-11}
 
 ### Fixed Issues

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -33,6 +33,12 @@ DCS provider `v1.0.16` is the first release that supports pool-managed persisten
 :::
 
 :::info
+**Alauda OS and Provider Compatibility**
+
+Before selecting the target provider package and VM template, review [Alauda OS and Provider Compatibility](../overview/providers/huawei-dcs.mdx#alauda-os-and-provider-compatibility).
+:::
+
+:::info
 **Existing Cluster Migration**
 
 If your cluster runs ACP `v4.2.1` or later and you are moving to DCS provider `v1.0.16` or later, complete the migration procedure in [Migrate Existing Huawei DCS Clusters to Pool-Managed Persistent Disks](../how-to/dcs_persistent_disk_upgrade.mdx) before you rely on upgrade-time disk preservation.


### PR DESCRIPTION
## Summary

- Backport the reviewed provider release-note updates from master.
- Add Huawei DCS Provider v1.0.19 through v1.0.21, Kubeadm Provider v1.0.10 through v1.0.12, and VMware vSphere Provider v1.0.12 through v1.0.15 release entries.
- Document the Huawei DCS and Alauda OS provider pairing requirement for ACP v4.3.2 and later, including ACP v4.4.0 and later.

## Validation

- yarn lint