### PR TITLE
[AIT-73302] Align master immutable upgrade guidance for ACP 4.4

### DIFF
--- a/docs/en/create-cluster/huawei-dcs.mdx
+++ b/docs/en/create-cluster/huawei-dcs.mdx
@@ -93,17 +93,10 @@ Configure the public registry credentials. This includes:
 
 ## Using the Web UI
 
-:::warning
-**Fleet Essentials UI does not support ACP 4.3 cluster upgrades**
+:::info
+**Fleet Essentials upgrade boundary**
 
-The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. Do not use the Fleet Essentials UI to upgrade DCS clusters on ACP 4.3.
-
-Two supported alternatives:
-
-- **YAML path** — Follow the YAML-based upgrade procedure documented later on this page.
-- **ACP Core cluster management UI** — Use the two-step upgrade flow built into the ACP Core platform; see <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#request-the-upgrade" children="Request the upgrade for the global cluster" /> or <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
-
-Cluster creation and node-pool management through the Fleet Essentials UI are unaffected by this limitation.
+Fleet Essentials 1.0.4 and later can request the ACP 4.3-and-later Distribution Version upgrade through CVO. It does not perform the DCS Kubernetes and Alauda OS replacement. Use [Upgrading Kubernetes on Huawei DCS](../upgrade-cluster/huawei-dcs.mdx) for that Phase 2 YAML procedure. Cluster creation through Fleet Essentials is unaffected by this boundary.
 :::
 
 **Version requirement**: This workflow requires Fleet Essentials and Alauda Container Platform DCS Infrastructure Provider `1.0.13` or later. If the provider version is earlier than `1.0.13`, use YAML manifests. If you use pool-managed persistent disks, use DCS provider `v1.0.16` or later. In `v1.0.16`, configure `DCSIpHostnamePool.spec.pool[].persistentDisk` through YAML because the web UI does not expose that field.

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -163,7 +163,7 @@ Update the control plane resources:
 
 - Export the current `VSphereMachineTemplate`, give the copy a new name, remove server-generated metadata and `status`, and set `spec.template.spec.template` to the target Alauda OS VM template from the OS Support Matrix.
 - Preserve the existing vCenter, folder, datastore, network, clone-mode, CPU, memory, and disk configuration unless the release procedure explicitly changes it. Leave `spec.template.spec.providerID` unset.
-- Keep preserved node-local data, including `/var/cpaas`, in `VSphereMachineConfigPool.spec.slot[].persistentDisks`; do not move it into the machine template.
+- Keep preserved node-local data, including `/var/cpaas`, in `VSphereMachineConfigPool.spec.configs[].persistentDisks[]`; do not move it into the machine template.
 - Set `KubeadmControlPlane.spec.version`, CoreDNS, and etcd tags from the same OS Support Matrix row.
 - When the target is Kubernetes 1.35 or later, update the control-plane kubelet patch in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the same manifest edit.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `VSphereMachineTemplate`.

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -19,7 +19,7 @@ For a Huawei DCS `global` cluster, review [Alauda OS and Provider Compatibility]
 Choose this upgrade path when:
 
 - The `global` cluster was originally installed on Immutable Infrastructure. See [Installing the global Cluster](./install.mdx).
-- Your infrastructure is one of the documented providers: Huawei DCS or Huawei Cloud Stack. VMware vSphere and bare-metal support for the `global` cluster are planned.
+- Your infrastructure is one of the documented providers: Huawei DCS, VMware vSphere, or Huawei Cloud Stack. Bare-metal support for the `global` cluster is planned.
 
 For traditional-OS `global` clusters, use <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="the standard upgrade path" /> instead.
 
@@ -27,7 +27,7 @@ For traditional-OS `global` clusters, use <ExternalSiteLink name="acp" href="/up
 
 Like workload clusters, the `global` cluster on Immutable Infrastructure follows a two-phase upgrade.
 
-1. **Phase 1 — Distribution Version**: aligned and agnostic extensions are upgraded to the target Distribution Version. The procedure is shared with workload clusters; see [Upgrading Clusters](../upgrade-cluster/index.mdx) for the Phase 1 mechanics.
+1. **Phase 1 — ACP Core and Distribution Version**: prepare artifacts and plugin packages, then use CVO to move the global tier to the target Distribution Version. The ACP product documentation owns this procedure; see <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" /> and <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="Upgrade the global cluster" />.
 2. **Phase 2 — Kubernetes and OS Image**: nodes are replaced with new Alauda OS images that contain the target Kubernetes version. This document focuses on Phase 2 for the `global` cluster.
 
 <Directive type="info" title="Phase 1 Compatibility">
@@ -38,7 +38,8 @@ Like workload clusters, the `global` cluster on Immutable Infrastructure follows
 
 - The `global` cluster has completed Phase 1 (Distribution Version upgrade).
 - An etcd backup of the `global` cluster has been taken and verified.
-- The new Alauda OS image and the matching `KubeadmControlPlane` and `MachineDeployment` versions are available on the platform's registry.
+- The target row in [OS Support Matrix](../overview/os-support-matrix.mdx) is available, and its Alauda OS image, Kubernetes version, CoreDNS tag, etcd tag, and Kube-OVN chart are staged.
+- The previous machine templates and bootstrap templates are retained until Phase 2 is verified.
 - A maintenance window plan that accounts for rolling control plane replacement.
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and OS images are pre-staged. See [Cross-Version Upgrade Preparation](../upgrade-cluster/index.mdx#cross-version-preparation).
 
@@ -50,7 +51,57 @@ After installation, the Cluster API controllers that manage the `global` cluster
   `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. On the hop to Kubernetes 1.35 or later, add it to the kubelet patch used by every replacement node. Update the control-plane file in the same `KubeadmControlPlane` edit as `spec.version`. For workers, create a new `KubeadmConfigTemplate` with the updated patch and switch `MachineDeployment.spec.template.spec.bootstrap.configRef.name` in the same edit as the version. Do not add this parameter for Kubernetes 1.34 or earlier. See [Required kubelet patch for Kubernetes 1.35](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch).
 </Directive>
 
-### Step 1 — Update the global Cluster Manifest
+### Step 1 — Upgrade Kube-OVN
+
+Read the **kube-ovn (chart)** value from the target OS Support Matrix row. Move Kube-OVN to that revision and wait for the `cni-kube-ovn` `AppRelease` to reach `phase=Success` before changing the control plane.
+
+<Tabs>
+  <Tab label="Huawei DCS">
+
+Record the target revision on the `Cluster`, then patch the existing `AppRelease`. The DCS provider reconciles `spec.values` but does not change an existing chart revision from the annotation alone.
+
+```shell
+kubectl annotate cluster global -n cpaas-system \
+  cpaas.io/kube-ovn-version=<target-kube-ovn-chart-version> --overwrite
+kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<target-kube-ovn-chart-version>"}]'
+```
+
+  </Tab>
+  <Tab label="VMware vSphere">
+
+Verify that `Cluster.metadata.annotations["cpaas.io/network-type"]` is `kube-ovn`, then update the version annotation. The vSphere provider reconciles the complete Kube-OVN `AppRelease` specification.
+
+```shell
+kubectl annotate cluster global -n cpaas-system \
+  cpaas.io/kube-ovn-version=<target-kube-ovn-chart-version> --overwrite
+```
+
+  </Tab>
+  <Tab label="Huawei Cloud Stack">
+
+Record the target revision on the `Cluster`, then patch the existing `AppRelease`. The HCS provider reconciles `spec.values` but does not change an existing chart revision from the annotation alone.
+
+```shell
+kubectl annotate cluster global -n cpaas-system \
+  cpaas.io/kube-ovn-version=<target-kube-ovn-chart-version> --overwrite
+kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<target-kube-ovn-chart-version>"}]'
+```
+
+  </Tab>
+</Tabs>
+
+Verify both the installed revision and the chart phase:
+
+```shell
+kubectl get apprelease cni-kube-ovn -n cpaas-system \
+  -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
+```
+
+Do not start control-plane replacement until the installed revision matches the target and `phase` is `Success`.
+
+### Step 2 — Update the global Cluster Manifest
 
 Update the Cluster API manifests of the `global` cluster to reference the new Alauda OS image and Kubernetes version. The manifest fields to update are provider-specific.
 
@@ -64,6 +115,7 @@ Update the control plane resources:
 - Create a new `DCSMachineTemplate` for the target image and set `spec.template.spec.vmTemplateName` to the Alauda OS template that matches the target Kubernetes version.
 - Keep preserved node-local data, including `/var/cpaas`, in `DCSIpHostnamePool.spec.pool[].persistentDisk`. Do not move preserved disks back into `DCSMachineTemplate`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.
+- Set the CoreDNS and etcd image tags in `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration` from the same OS Support Matrix row.
 - When the target is Kubernetes 1.35 or later, update the control-plane kubelet patch in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the same manifest edit.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `DCSMachineTemplate`.
 - Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the cluster uses pool-managed persistent disks.
@@ -105,9 +157,27 @@ Use the IP pool status to confirm that preserved disks are detached from old VMs
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere upgrade support for the `global` cluster on Immutable Infrastructure is planned. This procedure will be added in a later release.
-</Directive>
+For vSphere, create new immutable infrastructure templates instead of editing templates that are already referenced by running machines.
+
+Update the control plane resources:
+
+- Export the current `VSphereMachineTemplate`, give the copy a new name, remove server-generated metadata and `status`, and set `spec.template.spec.template` to the target Alauda OS VM template from the OS Support Matrix.
+- Preserve the existing vCenter, folder, datastore, network, clone-mode, CPU, memory, and disk configuration unless the release procedure explicitly changes it. Leave `spec.template.spec.providerID` unset.
+- Keep preserved node-local data, including `/var/cpaas`, in `VSphereMachineConfigPool.spec.slot[].persistentDisks`; do not move it into the machine template.
+- Set `KubeadmControlPlane.spec.version`, CoreDNS, and etcd tags from the same OS Support Matrix row.
+- When the target is Kubernetes 1.35 or later, update the control-plane kubelet patch in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the same manifest edit.
+- Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `VSphereMachineTemplate`.
+- Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the control plane pool uses fixed slots or pool-managed persistent disks.
+
+Update worker node resources:
+
+- Create a new worker `VSphereMachineTemplate` with the target VM template and the retained provider configuration.
+- Set each `MachineDeployment.spec.template.spec.version` to the target Kubernetes version.
+- When the target is Kubernetes 1.35 or later, create a new worker `KubeadmConfigTemplate` with the required kubelet patch and point `MachineDeployment.spec.template.spec.bootstrap.configRef.name` to it.
+- Point each `MachineDeployment.spec.template.spec.infrastructureRef.name` to the new worker `VSphereMachineTemplate`.
+- Keep each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` when the worker pool uses fixed slots or pool-managed persistent disks.
+
+`VSphereMachineTemplate.spec.template.spec` is immutable. Keep the previous control-plane and worker templates until the new rollout is verified.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
@@ -120,6 +190,7 @@ Update the control plane resources:
 - Keep preserved node-local data, including `/var/cpaas`, in `HCSMachineConfigPool.spec.configs[].persistentDisks[]`. Do not move preserved disks back into `HCSMachineTemplate.spec.template.spec.dataVolumes[]`.
 - Leave runtime identity fields unset in the new template, including `spec.template.spec.providerID` and `spec.template.spec.serverId`.
 - Set `KubeadmControlPlane.spec.version` to the target Kubernetes version.
+- Set the CoreDNS and etcd image tags in `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration` from the same OS Support Matrix row.
 - When the target is Kubernetes 1.35 or later, update the control-plane kubelet patch in `KubeadmControlPlane.spec.kubeadmConfigSpec.files` in the same manifest edit.
 - Point `KubeadmControlPlane.spec.machineTemplate.infrastructureRef.name` to the new `HCSMachineTemplate`.
 - Keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` when the control plane pool uses pool-managed persistent disks.
@@ -169,7 +240,7 @@ Do not treat HCS `dataVolumes[]` as preserved state during node replacement. Thi
   </Tab>
 </Tabs>
 
-### Step 2 — Apply the Updated Manifest
+### Step 3 — Apply the Updated Manifest
 
 Apply the updated manifest against the `global` cluster.
 
@@ -179,7 +250,7 @@ kubectl --kubeconfig <global-kubeconfig> apply -f <updated-manifest>
 
 The Cluster API provider begins replacing control plane and worker nodes by using the new image. When `maxSurge: 0` is set, each old node is drained and deleted before its replacement can reuse the same fixed identity, IP address, or preserved disk.
 
-### Step 3 — Monitor the Rolling Replacement
+### Step 4 — Monitor the Rolling Replacement
 
 Watch the rolling replacement until all control plane and worker nodes have been replaced.
 
@@ -202,11 +273,15 @@ kubectl --kubeconfig <global-kubeconfig> get pods -n cpaas-system
 
 All nodes must report the new Kubernetes version, the `ClusterVersionShadow` must reflect the target Distribution Version, and core platform pods must be `Running`.
 
-## Rollback Considerations
+## Recovery Considerations
 
-Rollback after a partial Phase 2 upgrade is provider-specific. In general:
+Do not treat a Kubernetes minor downgrade as an ordinary rollback. Choose the recovery path from the rollout stage:
 
-If the upgrade has not yet replaced any control plane node, revert the manifest to the previous image and reapply. If control plane nodes have been replaced, restore from the etcd backup taken before starting the upgrade, then revert the manifest.
+1. **No target-version control-plane `Machine` has been created**: restore the previous Kube-OVN state and the previous manifest values. This cancels the target rollout before a new control-plane data format is introduced.
+2. **Only the machine template or OS image changed, and the Kubernetes minor did not change**: point the controlling resource back to the previous template and let Cluster API perform another replacement rollout. Keep the Kubernetes minor unchanged.
+3. **A control-plane `Machine` on the target Kubernetes minor has joined the cluster**: do not patch Kubernetes, CoreDNS, or etcd back to the previous minor. Stop further rollout and repair forward on the target minor, or recover the `global` cluster from the verified pre-upgrade etcd backup or Global DR procedure.
+
+If a target-minor control-plane `Machine` was created but never joined, restore healthy etcd quorum and determine whether the failed replacement can be removed safely before changing manifests.
 
 <Tabs>
   <Tab label="Huawei DCS">
@@ -215,19 +290,17 @@ For DCS clusters that use pool-managed persistent disks, confirm disk state befo
 
 First, check `DCSIpHostnamePool.status.persistentDiskStatus` before deleting or recreating machines. Do not delete retained DCS volumes that are listed in `DCSIpHostnamePool.spec.pool[].persistentDisk`.
 
-Keep `maxSurge: 0` while reverting to the previous machine templates so replacement happens one node at a time. If the control plane was already replaced and cluster state is inconsistent, restore from the verified etcd backup before reapplying the previous manifest.
+For stage 1, restore both the previous Kube-OVN annotation and the existing `AppRelease` chart revision. Keep `maxSurge: 0` while returning to previous machine templates in a same-minor replacement recovery. If a target-minor control-plane machine has joined, retain the target baseline and use forward recovery or backup restore.
 
   </Tab>
   <Tab label="VMware vSphere">
 
-<Directive type="info" title="Status: Planned">
-  VMware vSphere rollback guidance for the `global` cluster on Immutable Infrastructure is planned.
-</Directive>
+For stage 1, restore the previous `cpaas.io/kube-ovn-version` annotation; the vSphere provider reconciles the complete `AppRelease` specification. For a same-minor template recovery, keep `maxSurge: 0`, point the control plane and worker resources to the retained previous `VSphereMachineTemplate` resources, and verify that each fixed slot reattaches its pool-managed persistent disks. If a target-minor control-plane machine has joined, retain the target Kubernetes, CoreDNS, etcd, and Kube-OVN baseline and use forward recovery or backup restore.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
 
-For HCS, rollback depends on platform and etcd backups. Node-local data on HCS `dataVolumes[]` is not a reliable rollback source because node replacement may delete the old VM and attached volumes. Data declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is reattached during replacement. If the control plane was already replaced, restore from the verified etcd backup, then reapply the previous manifest with the previous `HCSMachineTemplate` references and Kubernetes versions.
+Node-local data on HCS `dataVolumes[]` is not a recovery source because node replacement may delete the old VM and attached volumes. Data declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is reattached during replacement. For stage 1, restore both the previous Kube-OVN annotation and the existing `AppRelease` chart revision. For a same-minor template recovery, keep `maxSurge: 0` and point the controlling resources to the retained previous `HCSMachineTemplate` resources. If a target-minor control-plane machine has joined, retain the target baseline and use forward recovery or backup restore.
 
   </Tab>
   <Tab label="Bare Metal">

--- a/docs/en/global/upgrade.mdx
+++ b/docs/en/global/upgrade.mdx
@@ -19,7 +19,7 @@ For a Huawei DCS `global` cluster, review [Alauda OS and Provider Compatibility]
 Choose this upgrade path when:
 
 - The `global` cluster was originally installed on Immutable Infrastructure. See [Installing the global Cluster](./install.mdx).
-- Your infrastructure is one of the documented providers: Huawei DCS, VMware vSphere, or Huawei Cloud Stack. Bare-metal support for the `global` cluster is planned.
+- Your infrastructure is one of the documented providers: Huawei DCS, VMware vSphere, Huawei Cloud Stack, or Bare Metal when provider `v0.0.1` or later is included in the installed release.
 
 For traditional-OS `global` clusters, use <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="the standard upgrade path" /> instead.
 
@@ -48,58 +48,14 @@ Like workload clusters, the `global` cluster on Immutable Infrastructure follows
 After installation, the Cluster API controllers that manage the `global` cluster run on the `global` cluster itself. Use the `global` kubeconfig for the `kubectl` commands in this procedure.
 
 <Directive type="warning" title="Required when the target is Kubernetes 1.35">
-  `imagePullCredentialsVerificationPolicy: NeverVerify` is required only starting with Kubernetes 1.35. On the hop to Kubernetes 1.35 or later, add it to the kubelet patch used by every replacement node. Update the control-plane file in the same `KubeadmControlPlane` edit as `spec.version`. For workers, create a new `KubeadmConfigTemplate` with the updated patch and switch `MachineDeployment.spec.template.spec.bootstrap.configRef.name` in the same edit as the version. Do not add this parameter for Kubernetes 1.34 or earlier. See [Required kubelet patch for Kubernetes 1.35](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch).
+  In Kubernetes 1.35, kubelet credential verification can apply to images that are already present on a node. On the hop to Kubernetes 1.35 or later, add `imagePullCredentialsVerificationPolicy: NeverVerify` to the kubelet patch used by every replacement node. Update the control-plane file in the same `KubeadmControlPlane` edit as `spec.version`. For workers, create a new `KubeadmConfigTemplate` with the updated patch and switch `MachineDeployment.spec.template.spec.bootstrap.configRef.name` in the same edit as the version. Do not add this parameter for Kubernetes 1.34 or earlier. See [Required kubelet patch for Kubernetes 1.35](../upgrade-cluster/index.mdx#kubernetes-1-35-kubelet-patch).
 </Directive>
 
 ### Step 1 — Upgrade Kube-OVN
 
-Read the **kube-ovn (chart)** value from the target OS Support Matrix row. Move Kube-OVN to that revision and wait for the `cni-kube-ovn` `AppRelease` to reach `phase=Success` before changing the control plane.
+Read the **kube-ovn (chart)** value from the target OS Support Matrix row, then follow the shared [provider-version-specific Kube-OVN procedure](../upgrade-cluster/index.mdx#upgrade-kube-ovn-before-the-control-plane) with `<cluster-name>` set to `global`.
 
-<Tabs>
-  <Tab label="Huawei DCS">
-
-Record the target revision on the `Cluster`, then patch the existing `AppRelease`. The DCS provider reconciles `spec.values` but does not change an existing chart revision from the annotation alone.
-
-```shell
-kubectl annotate cluster global -n cpaas-system \
-  cpaas.io/kube-ovn-version=<target-kube-ovn-chart-version> --overwrite
-kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<target-kube-ovn-chart-version>"}]'
-```
-
-  </Tab>
-  <Tab label="VMware vSphere">
-
-Verify that `Cluster.metadata.annotations["cpaas.io/network-type"]` is `kube-ovn`, then update the version annotation. The vSphere provider reconciles the complete Kube-OVN `AppRelease` specification.
-
-```shell
-kubectl annotate cluster global -n cpaas-system \
-  cpaas.io/kube-ovn-version=<target-kube-ovn-chart-version> --overwrite
-```
-
-  </Tab>
-  <Tab label="Huawei Cloud Stack">
-
-Record the target revision on the `Cluster`, then patch the existing `AppRelease`. The HCS provider reconciles `spec.values` but does not change an existing chart revision from the annotation alone.
-
-```shell
-kubectl annotate cluster global -n cpaas-system \
-  cpaas.io/kube-ovn-version=<target-kube-ovn-chart-version> --overwrite
-kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<target-kube-ovn-chart-version>"}]'
-```
-
-  </Tab>
-</Tabs>
-
-Verify both the installed revision and the chart phase:
-
-```shell
-kubectl get apprelease cni-kube-ovn -n cpaas-system \
-  -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-```
-
-Do not start control-plane replacement until the installed revision matches the target and `phase` is `Success`.
+That procedure first checks the installed provider revision, then selects the supported new or legacy flow, handles the Kube-OVN chart-name boundary at `v4.4`, and verifies the chart name, target revision, installed revision, phase, and conditions. Use the `global` kubeconfig for both the provider and `cni-kube-ovn` `AppRelease` checks. Do not begin control-plane replacement until all shared verification criteria pass.
 
 ### Step 2 — Update the global Cluster Manifest
 
@@ -234,9 +190,54 @@ Do not treat HCS `dataVolumes[]` as preserved state during node replacement. Thi
 
   </Tab>
   <Tab label="Bare Metal">
-    <Directive type="info" title="Status: Planned">
-      Bare-metal support for the `global` cluster on Immutable Infrastructure is planned.
-    </Directive>
+
+This YAML workflow requires Bare Metal provider `v0.0.1` or later. Use it only after that provider package and the target OS Support Matrix row are available in the installed release. Before editing Cluster API resources, confirm that the provider `AppRelease` requested and installed revisions match and its chart phase is `Success`.
+
+Verify that the target Kubernetes version exists in `elemental-image-catalog`:
+
+```shell
+kubectl --kubeconfig <global-kubeconfig> -n cpaas-system \
+  get configmap elemental-image-catalog -o yaml
+```
+
+The target version must appear as a key with a reachable base-image reference. The Bare Metal provider resolves the replacement image from `Machine.spec.version`; a Kubernetes-only upgrade does not require a new `BaremetalMachineTemplate` unless the control plane or workers must move to a different `MachineInventoryPool`.
+
+Update the existing `KubeadmControlPlane` manifest with values from the same OS Support Matrix row. Preserve all fields not shown here:
+
+```yaml
+spec:
+  version: <target-kubernetes-version>
+  rolloutStrategy:
+    rollingUpdate:
+      maxSurge: 0
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      dns:
+        imageTag: <target-coredns-tag>
+      etcd:
+        local:
+          imageTag: <target-etcd-tag>
+```
+
+Retain the existing `spec.kubeadmConfigSpec.files` entries. For Kubernetes 1.35 or later, update the existing `kubeletconfiguration0+strategic.json` entry in that list as documented above; do not replace the list with an empty value.
+
+For each worker `MachineDeployment`, set the target Kubernetes version and keep `maxSurge: 0`. When the target is Kubernetes 1.35 or later, first create a new immutable `KubeadmConfigTemplate` containing the required kubelet patch, then reference it in the same manifest change:
+
+```yaml
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+  template:
+    spec:
+      version: <target-kubernetes-version>
+      bootstrap:
+        configRef:
+          name: <target-kubeadm-config-template>
+```
+
+Omit the `bootstrap.configRef` change for an earlier target when no bootstrap setting changes. Apply the complete retained manifests in Step 3. The provider deletes each old machine, cleans its inventory, allocates an available inventory from the same pool, and writes a `reprovision` plan for the target image.
+
   </Tab>
 </Tabs>
 
@@ -290,23 +291,25 @@ For DCS clusters that use pool-managed persistent disks, confirm disk state befo
 
 First, check `DCSIpHostnamePool.status.persistentDiskStatus` before deleting or recreating machines. Do not delete retained DCS volumes that are listed in `DCSIpHostnamePool.spec.pool[].persistentDisk`.
 
-For stage 1, restore both the previous Kube-OVN annotation and the existing `AppRelease` chart revision. Keep `maxSurge: 0` while returning to previous machine templates in a same-minor replacement recovery. If a target-minor control-plane machine has joined, retain the target baseline and use forward recovery or backup restore.
+For stage 1, use the DCS rule in [Restore Kube-OVN During Stage-1 Recovery](../upgrade-cluster/index.mdx#restore-kube-ovn-during-stage-1-recovery); the action depends on the installed provider version. Keep `maxSurge: 0` while returning to previous machine templates in a same-minor replacement recovery. If a target-minor control-plane machine has joined, retain the target baseline and use forward recovery or backup restore.
 
   </Tab>
   <Tab label="VMware vSphere">
 
-For stage 1, restore the previous `cpaas.io/kube-ovn-version` annotation; the vSphere provider reconciles the complete `AppRelease` specification. For a same-minor template recovery, keep `maxSurge: 0`, point the control plane and worker resources to the retained previous `VSphereMachineTemplate` resources, and verify that each fixed slot reattaches its pool-managed persistent disks. If a target-minor control-plane machine has joined, retain the target Kubernetes, CoreDNS, etcd, and Kube-OVN baseline and use forward recovery or backup restore.
+For stage 1, use the vSphere rule in [Restore Kube-OVN During Stage-1 Recovery](../upgrade-cluster/index.mdx#restore-kube-ovn-during-stage-1-recovery). For a same-minor template recovery, keep `maxSurge: 0`, point the control plane and worker resources to the retained previous `VSphereMachineTemplate` resources, and verify that each fixed slot reattaches its pool-managed persistent disks. If a target-minor control-plane machine has joined, retain the target Kubernetes, CoreDNS, etcd, and Kube-OVN baseline and use forward recovery or backup restore.
 
   </Tab>
   <Tab label="Huawei Cloud Stack">
 
-Node-local data on HCS `dataVolumes[]` is not a recovery source because node replacement may delete the old VM and attached volumes. Data declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is reattached during replacement. For stage 1, restore both the previous Kube-OVN annotation and the existing `AppRelease` chart revision. For a same-minor template recovery, keep `maxSurge: 0` and point the controlling resources to the retained previous `HCSMachineTemplate` resources. If a target-minor control-plane machine has joined, retain the target baseline and use forward recovery or backup restore.
+Node-local data on HCS `dataVolumes[]` is not a recovery source because node replacement may delete the old VM and attached volumes. Data declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is reattached during replacement. For stage 1, use the HCS rule in [Restore Kube-OVN During Stage-1 Recovery](../upgrade-cluster/index.mdx#restore-kube-ovn-during-stage-1-recovery); the action depends on the installed provider version. For a same-minor template recovery, keep `maxSurge: 0` and point the controlling resources to the retained previous `HCSMachineTemplate` resources. If a target-minor control-plane machine has joined, retain the target baseline and use forward recovery or backup restore.
 
   </Tab>
   <Tab label="Bare Metal">
-    <Directive type="info" title="Status: Planned">
-      Bare-metal rollback guidance for the `global` cluster on Immutable Infrastructure is planned.
-    </Directive>
+
+For stage 1, use the Bare Metal rule in [Restore Kube-OVN During Stage-1 Recovery](../upgrade-cluster/index.mdx#restore-kube-ovn-during-stage-1-recovery), then restore the previous manifests only if no target-minor control-plane `Machine` has been created.
+
+Every host that completes a `reprovision` plan has already replaced its OS image and cleared Kubernetes-managed state. If a target-minor control-plane machine has joined, do not patch Kubernetes, CoreDNS, or etcd back to the previous minor. Repair forward, or recover the `global` cluster through the verified etcd backup or Global DR procedure.
+
   </Tab>
 </Tabs>
 

--- a/docs/en/manage-nodes/huawei-dcs.mdx
+++ b/docs/en/manage-nodes/huawei-dcs.mdx
@@ -895,23 +895,16 @@ Existing machines continue using the old bootstrap configuration. Only newly cre
 
 ### Upgrading Kubernetes Version
 
-For Kubernetes upgrades on Huawei DCS, see [Upgrading Kubernetes on Huawei DCS](../upgrade-cluster/huawei-dcs.mdx). That guide covers the required upgrade order, the YAML workflow for `MachineDeployment` resources, and the web UI workflow for Node Pool upgrades.
+For Kubernetes and Alauda OS upgrades on Huawei DCS, see [Upgrading Kubernetes on Huawei DCS](../upgrade-cluster/huawei-dcs.mdx). That guide covers the required order and the YAML workflow for control plane and worker replacement.
 
 ---
 
 ## Managing Node Pools Using the Web UI
 
-:::warning
-**Fleet Essentials UI does not support ACP 4.3 cluster upgrades**
+:::info
+**Fleet Essentials upgrade boundary**
 
-The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. Do not use the Fleet Essentials UI to upgrade DCS clusters on ACP 4.3.
-
-Two supported alternatives:
-
-- **YAML path** — Follow the YAML-based upgrade procedure in [Upgrading Kubernetes on Huawei DCS](../upgrade-cluster/huawei-dcs.mdx).
-- **ACP Core cluster management UI** — Use the two-step upgrade flow built into the ACP Core platform; see <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#request-the-upgrade" children="Request the upgrade for the global cluster" /> or <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
-
-Adding, deleting, and viewing node pools through the Fleet Essentials UI are unaffected by this limitation.
+Fleet Essentials 1.0.4 and later can request the ACP 4.3-and-later Distribution Version upgrade through CVO. It does not perform the DCS Kubernetes and Alauda OS replacement. Use [Upgrading Kubernetes on Huawei DCS](../upgrade-cluster/huawei-dcs.mdx) for that Phase 2 YAML procedure. Adding, deleting, and viewing node pools through Fleet Essentials are unaffected by this boundary.
 :::
 
 Node pools provide a declarative way to manage groups of nodes with identical configurations. You can view, add, and delete worker node pools through the web UI.

--- a/docs/en/overview/intro.mdx
+++ b/docs/en/overview/intro.mdx
@@ -11,4 +11,4 @@ Welcome to the documentation for **Immutable Infrastructure** on the <Term name=
 - **Declarative Configuration**: All infrastructure is defined as code
 - **Version Control**: Infrastructure changes are tracked and versioned
 - **Reproducible Deployments**: Consistent environments across different deployments
-- **Rollback Capability**: Easy rollback to previous infrastructure states
+- **Stage-Aware Recovery**: Reproducible machine replacement for safe template recovery, with backup-based recovery when a Kubernetes minor upgrade has changed control-plane state

--- a/docs/en/overview/os-support-matrix.mdx
+++ b/docs/en/overview/os-support-matrix.mdx
@@ -43,9 +43,9 @@ For Huawei DCS clusters that use the Alauda OS image from ACP `v4.3.2` or a late
 :::
 
 :::info
-The **kube-ovn (chart)** column is the `acp/chart-cpaas-kube-ovn` Helm chart version, which tracks the ACP release line (for example, ACP v4.2.2 ships chart `v4.2.24`). It is **not** the Kube-OVN component (binary) version such as `v1.14.x` or `v1.15.x`.
+The **kube-ovn (chart)** column contains the Helm chart version that tracks the ACP release line (for example, ACP v4.2.2 ships chart `v4.2.24`). It is **not** the Kube-OVN component (binary) version such as `v1.14.x` or `v1.15.x`.
 
-Use this chart version — not the component version — when you set the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource and when you patch the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision`. See the provider-specific upgrade guides for the procedure.
+Chart versions earlier than `v4.4` use `acp/chart-cpaas-kube-ovn`; chart `v4.4` and later use `acp/chart-kube-ovn`. Use the matrix value with the [provider-version-specific Kube-OVN upgrade procedure](../upgrade-cluster/index.mdx#upgrade-kube-ovn-before-the-control-plane). Do not assume that every provider version supports both chart sources.
 :::
 
 ## Image Format by Provider
@@ -56,7 +56,7 @@ A single Alauda OS image build (one row in the matrix above) is delivered in dif
 | :--- | :--- |
 | Huawei DCS | `qcow2` |
 | Huawei Cloud Stack (HCS) | `qcow2` |
-| VMware vSphere | `vmdk` |
+| VMware vSphere | `ova` |
 | Bare metal | `iso` |
 
 The format does not change the OS content — it only changes the packaging for the target platform. The version identifier in the matrix above is format-independent; append the provider's format when you reference the downloaded file.

--- a/docs/en/overview/providers/huawei-dcs.mdx
+++ b/docs/en/overview/providers/huawei-dcs.mdx
@@ -46,17 +46,10 @@ It also supports **UI-based** cluster management when **Fleet Essentials** is in
 
 ### UI-Based Management (Fleet Essentials)
 
-:::warning
-**Fleet Essentials UI does not support ACP 4.3 cluster upgrades**
+:::info
+**Fleet Essentials upgrade boundary**
 
-The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. Do not use the Fleet Essentials UI to upgrade DCS clusters on ACP 4.3.
-
-Two supported alternatives:
-
-- **YAML path** — Follow the YAML-based upgrade procedure in [Upgrading Kubernetes on Huawei DCS](../../upgrade-cluster/huawei-dcs.mdx).
-- **ACP Core cluster management UI** — Use the two-step upgrade flow built into the ACP Core platform; see <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#request-the-upgrade" children="Request the upgrade for the global cluster" /> or <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
-
-Cluster creation and node-pool management through the Fleet Essentials UI are unaffected by this limitation.
+Fleet Essentials 1.0.4 and later can request the ACP 4.3-and-later Distribution Version upgrade through CVO. It does not perform the DCS Kubernetes and Alauda OS replacement. Use [Upgrading Kubernetes on Huawei DCS](../../upgrade-cluster/huawei-dcs.mdx) for that Phase 2 YAML procedure. Cluster creation and routine node-pool management through Fleet Essentials are unaffected by this boundary.
 :::
 
 Fleet Essentials provides the UI extension anchors that allow Alauda Container Platform DCS Infrastructure Provider to add DCS-specific pages dynamically.

--- a/docs/en/overview/providers/vmware-vsphere.mdx
+++ b/docs/en/overview/providers/vmware-vsphere.mdx
@@ -27,7 +27,7 @@ VMware vSphere is the industry-leading virtualization platform from VMware. The 
 - **Multi-NIC Support**: Primary and additional NICs per node, where the primary NIC drives the kubelet `node-ip` and additional NICs are attached in declared order for management, storage, or service networks
 - **Multiple Datacenters and Failure Domains**: Distribute control plane and worker nodes across multiple vCenter datacenters or compute clusters through `VSphereFailureDomain` and `VSphereDeploymentZone` for high availability
 - **Flexible Persistent Disks**: Declarative data disks with optional format/mount, `wipeFilesystem` control for etcd rolling updates, and raw-device mode exposed at `/dev/disk/by-capv/<name>` for application-managed disks
-- **Immutable-Template Rolling Updates**: Control plane and worker updates go through new `VSphereMachineTemplate` and `KubeadmConfigTemplate` resources, giving Cluster API a clean rollback path on failed upgrades
+- **Immutable-Template Rolling Updates**: Control plane and worker updates use new `VSphereMachineTemplate` and `KubeadmConfigTemplate` resources, enabling reproducible replacement and same-minor template recovery
 
 ## Supported Resources
 

--- a/docs/en/upgrade-cluster/bare-metal.mdx
+++ b/docs/en/upgrade-cluster/bare-metal.mdx
@@ -209,15 +209,29 @@ Every host that completed a `reprovision` plan has already replaced its OS image
 After the rollout completes:
 
 ```bash
-kubectl -n cpaas-system get baremetalmachines.infrastructure.cluster.x-k8s.io
-kubectl -n cpaas-system get machines.cluster.x-k8s.io
+kubectl -n cpaas-system get baremetalmachines.infrastructure.cluster.x-k8s.io \
+  -l cluster.x-k8s.io/cluster-name=<cluster-name> \
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.phase,INVENTORY:.status.machineInventoryRef.name,PLAN_SECRET:.status.planSecretRef.name'
+kubectl -n cpaas-system get machines.cluster.x-k8s.io \
+  -l cluster.x-k8s.io/cluster-name=<cluster-name>
 kubectl -n cpaas-system get apprelease cni-kube-ovn
 kubectl get nodes -o wide
 ```
 
-The `cni-kube-ovn` `AppRelease` should report the target installed revision with `phase=Success`. All `BaremetalMachine` objects should be `Running`. Every CAPI `Machine` should report the new `spec.version`. Every workload `Node` should be `Ready` with the new `kubelet` version, and every `MachineInventory` plan secret should carry `baremetal.alauda.io/plan.type=reprovision` (the most recent plan applied).
+The `cni-kube-ovn` `AppRelease` should report the target installed revision with `phase=Success`. For the target cluster, every current `BaremetalMachine` should be `Running`, every CAPI `Machine` should report the new `spec.version`, and every workload `Node` should be `Ready` with the new `kubelet` version.
 
-`MachineInventoryPool.status` should satisfy `available + allocated + preparing + reprovisioning + unavailable = total` with `preparing = reprovisioning = 0`.
+For each current `BaremetalMachine`, use the `INVENTORY` and `PLAN_SECRET` columns to verify the inventory and plan that back the running node:
+
+```bash
+kubectl -n cpaas-system get machineinventories.elemental.cattle.io <inventory-name> \
+  -o jsonpath='{.status.plan.state}{"\n"}'
+kubectl -n cpaas-system get secret <plan-secret-name> \
+  -o jsonpath='{.metadata.annotations.baremetal\.alauda\.io/plan\.type}{"\n"}'
+```
+
+Each referenced `MachineInventory` should report `Applied`, and each referenced plan Secret should report `reprovision`. Apply this check only to inventories referenced by the current `BaremetalMachine` objects. A spare inventory that did not participate in the rollout may have no `reprovision` plan. An inventory that completed a `clean` plan but was not selected for a replacement Machine may still report `clean`; neither case means that the rollout is incomplete.
+
+`MachineInventoryPool.status` should satisfy `available + allocated + preparing + reprovisioning + unavailable = total` with `preparing = reprovisioning = 0`. `available` may remain greater than zero when the pool contains spare inventories; those inventories are outside the plan verification above.
 
 ## Troubleshooting
 

--- a/docs/en/upgrade-cluster/bare-metal.mdx
+++ b/docs/en/upgrade-cluster/bare-metal.mdx
@@ -68,12 +68,17 @@ Before you start, ensure all of the following prerequisites are met:
 - The installed Bare Metal provider is `v0.0.1` or later and its `AppRelease` reports the same requested and installed revision with `phase=Success`.
 - The control plane is reachable through the existing `<control-plane-vip>:<control-plane-port>`.
 - All current nodes are healthy and `Ready`.
+- Before changing Kube-OVN or reprovisioning any node, use <ExternalSiteLink name="acp" href="/configure/backup/etcd.html" children="ACP Cluster Enhancer" /> to create a current on-demand etcd backup. Verify that the newest `status.records` entry reports `result: Success`, record its `backupTimestamp` and `fileName`, and confirm that the corresponding backup archive exists and will remain retrievable if any control-plane node is reprovisioned or becomes unavailable.
 - The target Kubernetes version is a key in `elemental-image-catalog`. If it is not, add it before starting (see [Update the Image Catalog](#update-the-image-catalog)).
 - The target **kube-ovn (chart)** version has been read from the matching ACP row in the [OS Support Matrix](../overview/os-support-matrix.mdx).
 - `BaremetalCluster.spec.networkType` is `kube-ovn`; the provider skips Kube-OVN reconciliation for any other value.
 - The platform registry is reachable from every host in the cluster.
 - Both `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0` are set — bare-metal does not over-provision physical hosts.
 - The relevant pools have enough capacity to replace one node at a time without falling below the desired replica count.
+
+:::info
+The default local archive under `/var/cpaas/backup` can be used for recovery; S3-compatible storage is not required. However, bare-metal replacement can make the original node-local copy unavailable, and the replacement `Machine` is not guaranteed to use the same `MachineInventory`. If your recovery design cannot guarantee access to the local archive after node replacement or failure, keep an off-node copy in S3-compatible storage or another secure location outside the node before starting Phase 2.
+:::
 
 ## Update the Image Catalog \{#update-the-image-catalog}
 
@@ -200,7 +205,9 @@ The version values always come from the OS Support Matrix; they are not fixed ex
 Do not treat a Kubernetes minor downgrade as an ordinary rollback:
 
 1. If no target-version control-plane `Machine` has been created, restore Kube-OVN by using [Restore Kube-OVN During Stage-1 Recovery](./index.mdx#restore-kube-ovn-during-stage-1-recovery), then restore the previous `KubeadmControlPlane` and `MachineDeployment` manifest values.
-2. If a target-minor control-plane machine has joined, stop further rollout and repair forward on the target minor, or restore the cluster from the verified pre-upgrade backup by using the supported ACP recovery procedure. Do not patch Kubernetes, CoreDNS, or etcd back to the previous minor.
+2. If a target-minor control-plane machine has joined, stop further rollout and repair forward on the target minor. If forward repair cannot restore cluster health, restore the cluster from the verified pre-upgrade backup by following the <ExternalSiteLink name="acp" href="/configure/backup/etcd.html#etcd-restore" children="ACP etcd restore procedure" />. Do not patch Kubernetes, CoreDNS, or etcd back to the previous minor.
+
+Restoring etcd is a disaster-recovery action, not a pre-upgrade validation step. Do not run the restore procedure on a healthy cluster merely to verify the backup.
 
 Every host that completed a `reprovision` plan has already replaced its OS image and cleared Kubernetes-managed state. Changing version fields does not reconstruct that earlier node state.
 

--- a/docs/en/upgrade-cluster/bare-metal.mdx
+++ b/docs/en/upgrade-cluster/bare-metal.mdx
@@ -1,6 +1,6 @@
 ---
 weight: 40
-title: Upgrading Kubernetes on Bare Metal
+title: Upgrading Clusters on Bare Metal
 author: gangwang@alauda.io
 category: howto
 queries:
@@ -10,7 +10,7 @@ queries:
   - elemental upgrade reprovision
 ---
 
-# Upgrading Kubernetes on Bare Metal
+# Upgrading Clusters on Bare Metal
 
 This guide explains how to complete Phase 2 of the upgrade workflow for clusters on bare metal. Before you upgrade Kubernetes, complete the Distribution Version upgrade described in [Upgrading Clusters](index.mdx).
 
@@ -65,6 +65,7 @@ Skipping step 1 risks two failure modes: the old provider silently ignores new s
 Before you start, ensure all of the following prerequisites are met:
 
 - The Distribution Version upgrade is complete.
+- The installed Bare Metal provider is `v0.0.1` or later and its `AppRelease` reports the same requested and installed revision with `phase=Success`.
 - The control plane is reachable through the existing `<control-plane-vip>:<control-plane-port>`.
 - All current nodes are healthy and `Ready`.
 - The target Kubernetes version is a key in `elemental-image-catalog`. If it is not, add it before starting (see [Update the Image Catalog](#update-the-image-catalog)).
@@ -79,7 +80,7 @@ Before you start, ensure all of the following prerequisites are met:
 `elemental-image-catalog` is the resource that introduces a Kubernetes version to the bare-metal provider.
 
 :::info
-In most upgrades you do not edit this ConfigMap by hand. The bare-metal provider plugin re-renders `elemental-image-catalog` with the Kubernetes versions shipped by the new distribution when it is reapplied during the Distribution Version upgrade (Phase 1). Your task is normally just to **verify** that the target version is present (see the verification step below). The two options that follow are only needed when you must add an out-of-band version — for example a digest-pinned or test build that the plugin does not ship.
+In most upgrades you do not edit this ConfigMap by hand. The bare-metal provider plugin re-renders `elemental-image-catalog` with the Kubernetes versions shipped by the new distribution when it is reapplied during the Distribution Version upgrade (Phase 1). Your task is normally just to **verify** that the target version is present (see the verification step below). The two options that follow are only needed when technical support supplies an approved out-of-band image reference.
 :::
 
 **Option A — Add a chart override.** Append the new version under `provider.imageCatalog.images` (uses `global.registry.address` as the registry):
@@ -88,17 +89,14 @@ In most upgrades you do not edit this ConfigMap by hand. The bare-metal provider
 provider:
   imageCatalog:
     images:
-      v1.33.7-2:
+      <new-kubernetes-version>:
         repository: tkestack/baremetal-base-image
-        tag: v0.0.0-beta-1.33.7-2
-      <new-kubernetes-version>:                # for example, v1.34.5
-        repository: tkestack/baremetal-base-image
-        tag: <new-tag>                         # for example, v0.0.0-dev.0-1.34.5
+        tag: <official-image-tag>
 ```
 
 Reapply the bare-metal provider plugin. The chart re-renders the ConfigMap; the provider's in-process watch hot-reloads the cache without restarting.
 
-**Option B — Patch the ConfigMap directly.** Useful for digest-pinned images or out-of-band test versions:
+**Option B — Patch the ConfigMap directly.** Use this only for an approved image reference that must be pinned directly in the catalog:
 
 ```bash
 kubectl -n cpaas-system patch configmap elemental-image-catalog \
@@ -118,69 +116,13 @@ When the new version corresponds to a new Alauda OS / base-image release, the IS
 
 ## Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
 
-Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`. This ordering ensures that the target network components are already running before bare-metal control-plane nodes begin delete-reprovision replacement.
+Follow the Bare Metal `v0.0.1+` flow in [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane). Bare Metal has no earlier supported provider flow in this documentation.
 
-The bare-metal provider's reconciliation behavior makes two operations necessary:
-
-- It reconciles Kube-OVN only when `BaremetalCluster.spec.networkType` is exactly `kube-ovn`.
-- It reads `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` before falling back to the `kube-ovn` `ModulePlugin` version. However, after `cni-kube-ovn` already exists, the provider updates only `AppRelease.spec.values` and preserves `spec.source`, including the existing chart `targetRevision`. Therefore, changing the annotation alone records the intended version but does not upgrade the existing chart.
-
-1. **Verify that provider-managed Kube-OVN reconciliation is enabled**
-
-   Run this command against the management (`global`) cluster:
-
-   ```bash
-   kubectl -n cpaas-system get baremetalcluster <cluster-name> \
-     -o jsonpath='{.spec.networkType}{"\n"}'
-   # Expected output: kube-ovn
-   ```
-
-   If the output is empty or different, correct `BaremetalCluster.spec.networkType` before continuing. Otherwise, the provider skips Kube-OVN reconciliation, including the control-plane node list updates needed during replacement.
-
-2. **Record the target chart version on the CAPI `Cluster`**
-
-   Use the **kube-ovn (chart)** value from the target ACP row in the [OS Support Matrix](../overview/os-support-matrix.mdx):
-
-   ```bash
-   kubectl annotate cluster <cluster-name> -n cpaas-system \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   Run this command against the management (`global`) cluster where the CAPI `Cluster` exists. The annotation takes precedence over the provider's `ModulePlugin` fallback and keeps the cluster's recorded target deterministic.
-
-3. **Patch the existing `AppRelease` chart revision**
-
-   Run this command against the workload cluster's API server, not the management cluster:
-
-   ```bash
-   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
-   ```
-
-   Use the same chart version that you set in the annotation. Do not change the provider-managed chart name (`acp/chart-cpaas-kube-ovn`) or release name (`cpaas-kube-ovn`).
-
-4. **Wait for reconciliation to complete before upgrading the control plane**
-
-   ```bash
-   # Overall AppRelease state — Sync and Health must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. Do not start the KCP rollout based on `installedRevision` alone: it changes during `HealthChecking`, before Kube-OVN pods have been verified Ready. Continue only when `phase` is `Success` **and** `installedRevision` matches the target chart version.
-
-   If the `AppRelease` reaches `DownloadFailed`, `DeployFailed`, or `NotReady`, stop before changing `KubeadmControlPlane` and inspect the condition messages:
-
-   ```bash
-   kubectl describe apprelease cni-kube-ovn -n cpaas-system
-   ```
+The shared procedure verifies `BaremetalCluster.spec.networkType`, updates the CAPI `Cluster` annotation, lets the provider reconcile the complete chart source and specification, and checks the chart name, requested revision, installed revision, phase, and conditions. Do not patch the `AppRelease` source manually.
 
 ## Upgrade the Control Plane \{#upgrade-control-plane}
 
-Before continuing, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that `cni-kube-ovn` is at the target installed revision with `phase=Success`.
+Before continuing, complete the shared [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) procedure and verify that `cni-kube-ovn` is at the target installed revision with `phase=Success`.
 
 Patch `KubeadmControlPlane.spec.version` to the new Kubernetes version. Where component image tags are pinned (DNS, etcd), update them in the same edit:
 
@@ -253,6 +195,15 @@ For each intermediate row, and finally for the target row:
 
 The version values always come from the OS Support Matrix; they are not fixed examples in this guide. The bare-metal rollout strategy already serializes node replacement, so cross-version upgrades do not require additional pool capacity beyond what is needed for a same-minor upgrade.
 
+## Recovering From a Failed Phase 2 Upgrade
+
+Do not treat a Kubernetes minor downgrade as an ordinary rollback:
+
+1. If no target-version control-plane `Machine` has been created, restore Kube-OVN by using [Restore Kube-OVN During Stage-1 Recovery](./index.mdx#restore-kube-ovn-during-stage-1-recovery), then restore the previous `KubeadmControlPlane` and `MachineDeployment` manifest values.
+2. If a target-minor control-plane machine has joined, stop further rollout and repair forward on the target minor, or restore the cluster from the verified pre-upgrade backup by using the supported ACP recovery procedure. Do not patch Kubernetes, CoreDNS, or etcd back to the previous minor.
+
+Every host that completed a `reprovision` plan has already replaced its OS image and cleared Kubernetes-managed state. Changing version fields does not reconstruct that earlier node state.
+
 ## Verification
 
 After the rollout completes:
@@ -272,7 +223,7 @@ The `cni-kube-ovn` `AppRelease` should report the target installed revision with
 
 | Issue | What to check |
 |---|---|
-| The Kube-OVN annotation changed but the installed chart revision did not | This is expected for an existing `AppRelease`: the bare-metal provider preserves `spec.source` and updates only `spec.values`. Patch `spec.source.charts[0].targetRevision` directly as described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane). |
+| The Kube-OVN annotation changed but the chart name, target revision, or installed revision did not converge | Confirm that the installed Bare Metal provider is `v0.0.1` or later, then inspect the `AppRelease` conditions and provider logs. Follow the shared [Kube-OVN verification](./index.mdx#verify-the-kube-ovn-apprelease); do not patch the source manually. |
 | Rollout stuck on the first new node | `BaremetalMachine.status.conditions[ImageResolved]` — confirm the new key is in `elemental-image-catalog` and that the `Cluster` carries `cpaas.io/registry-address`. |
 | Host reboots into a state that never joins the cluster | `MachineInventory.status.plan.state` (`Failed` is terminal); inspect the host's serial console for `elemental upgrade` errors. Verify the platform registry is reachable from the host. |
 | New control-plane node fails `kubeadm join` | Confirm the VIP is still reachable; `alive` may have lost the lock. Check `kubectl -n kube-system get lease`, `ipvsadm -Ln`, `keepalived` logs from the static pod. |

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -188,72 +188,19 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` and the provider-managed `cni-kube-ovn` `AppRelease` | Complete the shared [provider-version-specific Kube-OVN procedure](./index.mdx#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. The provider version and target chart version determine the chart name and whether a legacy direct revision patch is required. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the HCS provider watches it independently of the Kubernetes control plane rollout.
 
 #### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
 
-Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`, its component image tags, or its machine template reference. This ordering ensures that the target network components are already running before control-plane nodes begin rolling replacement.
+Follow [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) and select the Huawei Cloud Stack procedure that matches the **installed** HCS provider version. That shared procedure owns the provider version boundary, the Kube-OVN chart-name migration at `v4.4`, legacy behavior, and the required `AppRelease` health checks.
 
-Kube-OVN is a Core lifecycle component, but on immutable OS the HCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
-
-:::warning
-**Why two steps are required on HCS**
-
-The HCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
-:::
-
-1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
-
-   ```bash
-   kubectl annotate cluster <cluster-name> -n cpaas-system \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
-
-2. **Patch the `AppRelease` chart revision on the workload cluster**
-
-   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
-
-   ```bash
-   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
-   ```
-
-   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
-
-3. **Wait for reconciliation to complete before upgrading the control plane**
-
-   Watch the chart phase and the installed revision:
-
-   ```bash
-   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
-
-   | Phase | Meaning | `installedRevision` |
-   |---|---|---|
-   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
-   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
-   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
-
-   :::warning
-   Do not start the KCP upgrade based on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. Start the control-plane rollout only when `phase` is `Success` **and** `installedRevision` matches the target.
-   :::
-
-   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
+Do not use the legacy direct `targetRevision` patch for a Kube-OVN `v4.4+` target. Upgrade the HCS provider to `v1.0.4` or later first so it can reconcile the complete source and the related component repository changes.
 
 #### Upgrade the Control Plane Kubernetes Version
 
-Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success` before continuing.
+Complete the shared [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) procedure and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success` before continuing.
 
 1. **Create a new `HCSMachineTemplate` for the target Kubernetes version**
 
@@ -330,17 +277,7 @@ Keep these infrastructure facts in mind during any recovery:
 - **The old `HCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
 - **Only pool-managed persistent disks preserve node-local state.** Data written to `HCSMachineTemplate.spec.template.spec.dataVolumes[]` during the upgrade window is lost when that VM is replaced. Data written to disks declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is retained and reattached to the replacement VM. Application data should still use external persistent storage such as HCS EVS CSI unless your operational design explicitly depends on node-local state.
 
-For stage 1, restore the provider-managed Kube-OVN state in both places. The HCS provider reconciles `AppRelease.spec.values`, but it does not restore an existing chart revision from the `Cluster` annotation alone:
-
-```bash
-kubectl annotate cluster <cluster-name> -n cpaas-system \
-  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
-
-kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
-```
-
-Wait until `installedRevision` matches the restored revision and `phase=Success` before changing control-plane manifests. If the target-minor control plane has already joined, keep the target Kube-OVN baseline and use forward recovery or backup restore instead of attempting an independent chart downgrade.
+For stage 1, use the HCS rule in [Restore Kube-OVN During Stage-1 Recovery](./index.mdx#restore-kube-ovn-during-stage-1-recovery). The recovery action depends on the installed provider version: current providers restore the complete source from the annotation, while legacy providers require the earlier-chart revision patch. Wait until the restored `AppRelease` passes the shared verification before changing control-plane manifests.
 
 The `KubeadmControlPlane` controller can block replacement while etcd is unhealthy. Recover quorum before retrying any safe replacement action.
 

--- a/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
+++ b/docs/en/upgrade-cluster/huawei-cloud-stack.mdx
@@ -70,6 +70,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The Distribution Version upgrade is complete.
 - The control plane is reachable.
 - All nodes are healthy and in `Ready` state.
+- A current etcd backup has been taken and verified by using the supported ACP backup procedure.
 - The target VM image is present in the HCS environment under the same name as the **Alauda OS Image Version** value in the OS Support Matrix row. The upgrade fails if the image is not present when the new `HCSMachineTemplate` is applied.
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM images are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
@@ -108,9 +109,9 @@ Every upgrade step on this page therefore creates a new `HCSMachineTemplate` wit
 :::
 
 :::info
-**Fleet Essentials UI does not support ACP 4.3 cluster upgrades**
+**Fleet Essentials boundary**
 
-The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. HCS clusters do not currently expose a Fleet Essentials UI upgrade path; use the YAML procedure documented below, or the two-step upgrade flow built into the ACP Core platform — see <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
+Fleet Essentials 1.0.4 and later can request the ACP 4.3-and-later Distribution Version upgrade through CVO. It does not perform the HCS Kubernetes and Alauda OS replacement described on this page. Complete Phase 1 with the ACP workflow, then use the YAML procedure below for Phase 2.
 :::
 
 ## Control Plane Upgrades
@@ -313,31 +314,35 @@ Worker node upgrades are managed via `MachineDeployment` resources.
 For detailed worker node procedures, see the [Managing Nodes](../manage-nodes/huawei-cloud-stack.mdx#upgrading-kubernetes-version) section.
 :::
 
-## Rolling Back a Failed Upgrade
+## Recovering From a Failed Phase 2 Upgrade
 
-If the rolling update fails — new VMs fail to boot, nodes do not become `Ready`, or the new Kubernetes minor version surfaces an incompatibility — revert the template reference and Kubernetes-version fields back to the previous values. Cluster API treats the reversion as a new spec drift and rolls the v2 machines back to the previous template, one at a time.
+Do not treat a Kubernetes minor downgrade as an ordinary rollback. Choose the recovery path from the rollout stage:
 
-Three facts to internalize before rolling back:
+1. **No target-version control-plane `Machine` has been created**: restore the previous Kube-OVN state and the previous `KubeadmControlPlane` and `MachineDeployment` manifest values. This cancels the target rollout before a new control-plane data format is introduced.
+2. **Only the machine template or OS image changed, and the Kubernetes minor did not change**: point the controlling resource back to the previous template. Cluster API performs another replacement rollout. Keep the Kubernetes minor unchanged.
+3. **A control-plane `Machine` on the target Kubernetes minor has joined the cluster**: do not patch Kubernetes, CoreDNS, or etcd back to the previous minor. Stop further rollout, repair forward on the target minor, or restore the cluster from the verified pre-upgrade backup by using the supported ACP recovery procedure.
 
-- **The old VMs are gone.** They were destroyed during the upgrade. Rollback uses the old template to build a fresh set of replacement machines; it does not restore the original VMs.
-- **The old `HCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before rolling back.
+If a target-minor control-plane `Machine` was created but never joined, first restore healthy etcd quorum and determine whether the failed replacement can be removed safely. Do not assume that changing the version fields alone is sufficient.
+
+Keep these infrastructure facts in mind during any recovery:
+
+- **The old VMs are gone.** They were destroyed during the upgrade. Template recovery builds a fresh set of replacement machines; it does not restore the original VMs.
+- **The old `HCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
 - **Only pool-managed persistent disks preserve node-local state.** Data written to `HCSMachineTemplate.spec.template.spec.dataVolumes[]` during the upgrade window is lost when that VM is replaced. Data written to disks declared in `HCSMachineConfigPool.spec.configs[].persistentDisks[]` is retained and reattached to the replacement VM. Application data should still use external persistent storage such as HCS EVS CSI unless your operational design explicitly depends on node-local state.
 
-Procedure:
+For stage 1, restore the provider-managed Kube-OVN state in both places. The HCS provider reconciles `AppRelease.spec.values`, but it does not restore an existing chart revision from the `Cluster` annotation alone:
 
-- **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
-- **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane).
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
 
-  ```bash
-  kubectl annotate cluster <cluster-name> -n cpaas-system \
-    cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
+kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
+```
 
-  kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-    -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
-  ```
+Wait until `installedRevision` matches the restored revision and `phase=Success` before changing control-plane manifests. If the target-minor control plane has already joined, keep the target Kube-OVN baseline and use forward recovery or backup restore instead of attempting an independent chart downgrade.
 
-If the new control plane never reached etcd quorum, the `KubeadmControlPlane` controller may refuse to roll back any machine because its preflight checks block on an unhealthy etcd. Recover etcd quorum first (operator intervention) before retrying the rollback.
+The `KubeadmControlPlane` controller can block replacement while etcd is unhealthy. Recover quorum before retrying any safe replacement action.
 
 ## Additional Resources
 

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -1,6 +1,6 @@
 ---
 weight: 10
-title: Upgrading Kubernetes on Huawei DCS
+title: Upgrading Clusters on Huawei DCS
 author: dev@alauda.io
 category: howto
 queries:
@@ -9,7 +9,7 @@ queries:
   - upgrade dcs worker nodes
 ---
 
-# Upgrading Kubernetes on Huawei DCS
+# Upgrading Clusters on Huawei DCS
 
 This guide explains how to complete Phase 2 of the upgrade workflow for clusters on Huawei DCS. Before you upgrade Kubernetes, complete the Distribution Version upgrade described in [Upgrading Clusters](index.mdx).
 
@@ -125,7 +125,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` **and** the `cni-kube-ovn` `AppRelease` `spec.source.charts[0].targetRevision` on the workload cluster | The annotation records the intended chart version; on an existing cluster the chart revision must be patched separately. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` and the provider-managed `cni-kube-ovn` `AppRelease` | Complete the shared [provider-version-specific Kube-OVN procedure](./index.mdx#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. The provider version and target chart version determine the chart name and whether a legacy direct revision patch is required. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the DCS provider watches it independently of the Kubernetes control plane rollout.
 
@@ -133,62 +133,9 @@ Confirm with the cluster's platform owner that the target Alauda OS image has al
 
 ### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
 
-Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`, its component image tags, or its machine template reference. This ordering ensures that the target network components are already running before control-plane nodes begin rolling replacement.
+Follow [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) and select the Huawei DCS procedure that matches the **installed** DCS provider version. That shared procedure owns the provider version boundary, the Kube-OVN chart-name migration at `v4.4`, legacy behavior, and the required `AppRelease` health checks.
 
-Kube-OVN is a Core lifecycle component, but on immutable OS the DCS provider does not pin its chart version to the cluster's Kubernetes version. The chart version is carried by a separate `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster, and you move it forward in two steps: update the annotation on the `Cluster` resource for bookkeeping and future re-creation, then patch the existing `AppRelease` directly to bump the chart revision.
-
-:::warning
-**Why two steps are required on DCS**
-
-The DCS provider creates the `cni-kube-ovn` `AppRelease` the first time the cluster is built, and from then on it reconciles only the `spec.values` block (cluster name, CIDRs, registry, control-plane node list). It does not write to `spec.source.charts[0].targetRevision` on an `AppRelease` that already exists. As a result, changing `cpaas.io/kube-ovn-version` on the `Cluster` resource alone does not move the chart version on the workload cluster. The annotation must still be updated so the recorded target matches the OS Support Matrix row, but the chart upgrade itself is driven by a direct `AppRelease` patch.
-:::
-
-1. **Update the `cpaas.io/kube-ovn-version` annotation on the `Cluster` resource**
-
-   ```bash
-   kubectl annotate cluster <cluster-name> -n cpaas-system \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   The annotation does not update automatically when `spec.version` changes; keep it in step with the **kube-ovn (chart)** column of the target row.
-
-2. **Patch the `AppRelease` chart revision on the workload cluster**
-
-   Run the patch against the workload cluster's API server (not the bootstrap KIND or the `global` cluster):
-
-   ```bash
-   kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-     -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
-   ```
-
-   Use the same value you set in the annotation. The `releaseName` (`cpaas-kube-ovn`) and `name` (`acp/chart-cpaas-kube-ovn`) are managed by the provider; do not change them.
-
-3. **Wait for reconciliation to complete before upgrading the control plane**
-
-   Watch the chart phase and the installed revision:
-
-   ```bash
-   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
-
-   | Phase | Meaning | `installedRevision` |
-   |---|---|---|
-   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
-   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
-   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
-
-   :::warning
-   Do not start the KCP upgrade based on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. Start the control-plane rollout only when `phase` is `Success` **and** `installedRevision` matches the target.
-   :::
-
-   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
+Do not use the legacy direct `targetRevision` patch for a Kube-OVN `v4.4+` target. Upgrade the DCS provider to `v1.0.22` or later first so it can reconcile the complete source and the related component repository changes.
 
 ### Upgrade Control Plane Infrastructure
 
@@ -242,7 +189,7 @@ Upgrading the control plane machine template lets you roll out updated VM specif
 
 Upgrading the control plane Kubernetes version on immutable OS is a delete-recreate workflow. The control plane VMs are replaced one by one from a new `DCSMachineTemplate` that points at the target Alauda OS VM template, and the `KubeadmControlPlane` resource is patched to carry the matching Kubernetes version, CoreDNS image tag, and etcd image tag.
 
-Before you start, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success`. Then collect every required control-plane value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
+Before you start, complete the shared [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) procedure and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success`. Then collect every required control-plane value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
 
 #### Procedure
 
@@ -322,17 +269,7 @@ Keep these infrastructure facts in mind during any recovery:
 - **The old `DCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
 - **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `DCSIpHostnamePool.spec.pool[].persistentDisk` reattach to the replacement machines at the same IP slot, but data written during the upgrade window remains on those disks.
 
-For stage 1, restore the provider-managed Kube-OVN state in both places. The DCS provider reconciles `AppRelease.spec.values`, but it does not restore an existing chart revision from the `Cluster` annotation alone:
-
-```bash
-kubectl annotate cluster <cluster-name> -n cpaas-system \
-  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
-
-kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
-```
-
-Wait until `installedRevision` matches the restored revision and `phase=Success` before changing control-plane manifests. If the target-minor control plane has already joined, keep the target Kube-OVN baseline and use forward recovery or backup restore instead of attempting an independent chart downgrade.
+For stage 1, use the DCS rule in [Restore Kube-OVN During Stage-1 Recovery](./index.mdx#restore-kube-ovn-during-stage-1-recovery). The recovery action depends on the installed provider version: current providers restore the complete source from the annotation, while legacy providers require the earlier-chart revision patch. Wait until the restored `AppRelease` passes the shared verification before changing control-plane manifests.
 
 The `KubeadmControlPlane` controller can block replacement while etcd is unhealthy. Recover quorum before retrying any safe replacement action.
 

--- a/docs/en/upgrade-cluster/huawei-dcs.mdx
+++ b/docs/en/upgrade-cluster/huawei-dcs.mdx
@@ -67,6 +67,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The Distribution Version upgrade is complete
 - The control plane is reachable
 - All nodes are healthy and in Ready state
+- A current etcd backup has been taken and verified by using the supported ACP backup procedure
 - The IP Pool has sufficient capacity for rolling updates
 - The VM template supports the target Kubernetes version. See [OS Support Matrix](../overview/os-support-matrix.mdx) for version mapping
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation)
@@ -305,126 +306,43 @@ Before you start, read the **Alauda OS Image Version** and **Kubernetes Version*
 
    `MachineDeployment.spec.strategy.rollingUpdate.maxSurge` must remain `0` when the cluster relies on pool-managed persistent disks, so the worker nodes are replaced one at a time.
 
-### Rolling Back a Failed Upgrade
+### Recovering From a Failed Phase 2 Upgrade
 
-If the rolling update fails — new VMs fail to boot, nodes do not become `Ready`, or the new Kubernetes minor version surfaces an incompatibility — revert the template reference and Kubernetes-version fields back to the previous values. Cluster API treats the reversion as a new spec drift and rolls the v2 machines back to the previous template, one at a time.
+Do not treat a Kubernetes minor downgrade as an ordinary rollback. Choose the recovery path from the rollout stage:
 
-Three facts to internalize before rolling back:
+1. **No target-version control-plane `Machine` has been created**: restore the previous Kube-OVN state and the previous `KubeadmControlPlane` and `MachineDeployment` manifest values. This cancels the target rollout before a new control-plane data format is introduced.
+2. **Only the machine template or OS image changed, and the Kubernetes minor did not change**: point the controlling resource back to the previous template. Cluster API performs another replacement rollout. Keep the Kubernetes minor unchanged.
+3. **A control-plane `Machine` on the target Kubernetes minor has joined the cluster**: do not patch Kubernetes, CoreDNS, or etcd back to the previous minor. Stop further rollout, repair forward on the target minor, or restore the cluster from the verified pre-upgrade backup by using the supported ACP recovery procedure.
 
-- **The old VMs are gone.** They were destroyed during the upgrade. Rollback uses the old template to build a fresh set of replacement machines; it does not restore the original VMs.
-- **The old `DCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before rolling back.
-- **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `DCSIpHostnamePool.spec.pool[].persistentDisk` reattach to the rolled-back machines at the same IP slot, but any data written to those disks during the upgrade window (for example, etcd entries in the new Kubernetes minor format) stays. If the new format is unreadable by the older Kubernetes minor version, the rollback may still fail and require manual etcd restoration.
+If a target-minor control-plane `Machine` was created but never joined, first restore healthy etcd quorum and determine whether the failed replacement can be removed safely. Do not assume that changing the version fields alone is sufficient.
 
-Procedure:
+Keep these infrastructure facts in mind during any recovery:
 
-- **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
-- **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the Kube-OVN chart was upgraded, revert it the same way the upgrade was applied — first restore the annotation, then patch the `AppRelease` chart revision back. Verify with the same `installedRevision` + `phase=Success` check described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane).
+- **The old VMs are gone.** They were destroyed during the upgrade. Template recovery builds a fresh set of replacement machines; it does not restore the original VMs.
+- **The old `DCSMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
+- **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `DCSIpHostnamePool.spec.pool[].persistentDisk` reattach to the replacement machines at the same IP slot, but data written during the upgrade window remains on those disks.
 
-  ```bash
-  kubectl annotate cluster <cluster-name> -n cpaas-system \
-    cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
+For stage 1, restore the provider-managed Kube-OVN state in both places. The DCS provider reconciles `AppRelease.spec.values`, but it does not restore an existing chart revision from the `Cluster` annotation alone:
 
-  kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
-    -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
-  ```
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
 
-If the new control plane never reached etcd quorum, the `KubeadmControlPlane` controller may refuse to roll back any machine because its preflight checks block on an unhealthy etcd. Recover etcd quorum first (operator intervention) before retrying the rollback.
+kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
+```
 
----
+Wait until `installedRevision` matches the restored revision and `phase=Success` before changing control-plane manifests. If the target-minor control plane has already joined, keep the target Kube-OVN baseline and use forward recovery or backup restore instead of attempting an independent chart downgrade.
 
-## Using the Web UI
-
-:::warning
-**Fleet Essentials UI does not support ACP 4.3 cluster upgrades**
-
-The Fleet Essentials UI workflow has not been adapted to the Cluster Version Operator (CVO) mechanism introduced in ACP 4.3. Do not use the Fleet Essentials UI to upgrade DCS clusters on ACP 4.3.
-
-Two supported alternatives:
-
-- **YAML path** — Follow the YAML-based upgrade procedure documented earlier on this page.
-- **ACP Core cluster management UI** — Use the two-step upgrade flow built into the ACP Core platform; see <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#request-the-upgrade" children="Request the upgrade for the global cluster" /> or <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
-
-Cluster creation and node-pool management through the Fleet Essentials UI are unaffected by this limitation.
-:::
-
-Use this workflow to upgrade Kubernetes from the web UI after Phase 1 is complete.
-
-**Version requirement**: This workflow requires Fleet Essentials and Alauda Container Platform DCS Infrastructure Provider `1.0.13` or later. If the provider version is earlier than `1.0.13`, use YAML manifests. If the upgrade relies on pool-managed persistent disks, use DCS provider `v1.0.16` or later. In `v1.0.16`, the `persistentDisk` declaration on `DCSIpHostnamePool` remains YAML-only and is not exposed in the web UI.
-
-### Prerequisites
-
-- The Distribution Version upgrade is complete. See [Upgrading Distribution Version](index.mdx)
-- Kube-OVN has been upgraded to the target chart version and the `cni-kube-ovn` `AppRelease` has reached `phase=Success`. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) with YAML before using the UI to upgrade a node pool.
-- The Control Plane Node Pool is in Running state
-- The IP Pool has sufficient capacity for rolling updates
-- If the upgrade relies on pool-managed persistent disks, ensure the required `DCSIpHostnamePool.spec.pool[].persistentDisk` entries have already been created or updated through YAML
-
-### Upgrade Workflow
-
-Kubernetes upgrades follow this sequence after the Distribution Version upgrade:
-
-1. Upgrade Kube-OVN with the YAML procedure and wait for the `AppRelease` to reach `phase=Success`.
-2. Upgrade the Control Plane Node Pool.
-3. Wait for the Control Plane Node Pool upgrade to complete.
-4. Upgrade Worker Node Pools in any order.
-
-### Checking Available Upgrades
-
-**Navigation**: Clusters → Clusters → Select cluster → Node Pools Tab
-
-Node Pools with available upgrades show **Upgrade available** indicator. Click on the Node Pool card to view Current vs Target versions.
-
-### Upgrade the Control Plane Node Pool
-
-**Steps**:
-1. In the Node Pools Tab, locate the **Control Plane Node Pool**
-2. Click **Upgrade**
-3. Review upgrade information:
-   - **Current Version**: Current Kubernetes version
-   - **Target Version**: Latest minor version supported (automatically selected)
-4. Click **Confirm** to start
-
-**Monitoring**:
-- Watch the Node Pool status
-- Nodes will roll update one by one (`maxSurge=0`). This one-by-one replacement is also required when the cluster relies on persistent disks.
-- Upgrade time depends on node count and resources
-
-### Upgrade Worker Node Pools
-
-:::warning
-Worker Node Pools cannot be upgraded until the Control Plane Node Pool upgrade completes.
-:::
-
-**When Worker Pool Upgrade is Available**:
-- Control Plane Kubernetes Version matches global cluster version
-- Control Plane is in Running state
-
-**Upgrade Steps**:
-1. For each Worker Node Pool:
-   - Click **Upgrade** button
-   - Review and confirm
-2. Pools can be upgraded in parallel after Control Plane completes
-
-**Upgrade Constraints**:
-
-| Pool State | Upgrade Button |
-|------------|----------------|
-| Not Running | ❌ Disabled: "Upgrade is unavailable when the Worker Node Pool is not in the Running state" |
-| Control Plane not started | ❌ Disabled: "Upgrade the Control Plane Node Pool first" |
-| Control Plane upgrading | ❌ Disabled: "Wait for the Control Plane Node Pool upgrade to complete" |
-| Control Plane upgraded | ✅ Enabled |
-
-### Troubleshooting
-
-| Issue | Solution |
-|-------|----------|
-| Upgrade button disabled | Check pool status and Control Plane version |
-| Upgrade stuck | Check IP Pool availability, DCS platform resources |
-| Nodes not joining | Verify network connectivity, DNS settings |
-| Preserved disk did not reattach | Verify the disk is declared in `DCSIpHostnamePool.spec.pool[].persistentDisk`, check `status.persistentDiskStatus`, and confirm the cluster has already been migrated to the pool-managed layout |
+The `KubeadmControlPlane` controller can block replacement while etcd is unhealthy. Recover quorum before retrying any safe replacement action.
 
 ---
+
+## Fleet Essentials Boundary
+
+Fleet Essentials 1.0.4 and later can request the ACP 4.3-and-later Distribution Version upgrade through CVO. That is Phase 1 of this guide. Fleet Essentials does not perform the DCS Kubernetes and Alauda OS replacement in Phase 2, and it does not manage `DCSIpHostnamePool.spec.pool[].persistentDisk`. Use the YAML procedure on this page for the complete Phase 2 rollout.
+
+Cluster creation and routine node-pool management through Fleet Essentials are outside this upgrade limitation.
 
 ## Additional Resources
 

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -77,6 +77,233 @@ After upgrading the Distribution Version, upgrade Kubernetes and the Alauda OS i
 
 For Huawei DCS, Huawei Cloud Stack, VMware vSphere, and bare-metal clusters, upgrade the Kube-OVN chart for the current upgrade hop **before** changing `KubeadmControlPlane`. Wait until the workload cluster's `cni-kube-ovn` `AppRelease` reports the target installed revision and `phase=Success`, then upgrade the control plane, followed by worker nodes. Repeat this Kube-OVN-first ordering for every intermediate Kubernetes minor in a cross-version upgrade.
 
+### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
+
+Use this section as the authoritative Kube-OVN procedure for workload and `global` clusters. For every Kubernetes and OS hop, read the **kube-ovn (chart)** version from the matching [OS Support Matrix](../overview/os-support-matrix.mdx) row, complete the provider-version-specific procedure below, and verify the resulting `AppRelease` before changing `KubeadmControlPlane`.
+
+Run provider-version checks and `Cluster` or infrastructure-cluster commands against the management cluster. Run `cni-kube-ovn` `AppRelease` commands against the cluster being upgraded. When upgrading the `global` cluster, both resources are on the `global` cluster, so use the `global` kubeconfig for all commands.
+
+#### Identify the Installed Provider Version
+
+Do not infer the provider version from the ACP Distribution Version. Inspect the provider `AppRelease` on the management cluster. The resource name can vary, so the following command finds the provider by chart name and prints the requested and installed revisions:
+
+```bash
+kubectl -n cpaas-system get apprelease \
+  -o custom-columns='APPRELEASE:.metadata.name,CHART:.spec.source.charts[*].name,REQUESTED:.spec.source.charts[*].targetRevision,INSTALLED:.status.charts[*].installedRevision,PHASE:.status.charts[*].phase'
+```
+
+Find the row whose chart name ends with `chart-cluster-api-provider-dcs`, `chart-cluster-api-provider-hcs`, `chart-cluster-api-provider-vsphere`, or `chart-cluster-api-provider-baremetal`, as appropriate. Use the **installed revision** to select a tab. If the requested and installed revisions differ, or the provider chart is not in `Success`, finish or repair the provider upgrade before starting the cluster upgrade.
+
+| Provider | Full-source reconciliation | Legacy behavior retained in this guide |
+|---|---|---|
+| Huawei DCS | `v1.0.22` and later | `v1.0.21` and earlier |
+| Huawei Cloud Stack | `v1.0.4` and later | `v1.0.3` and earlier |
+| VMware vSphere | `v1.0.16` and later | `v1.0.15` and earlier |
+| Bare Metal | `v0.0.1` and later | None; `v0.0.1` is the first supported release for this procedure. |
+
+The Kube-OVN chart source also changes at chart version `v4.4`:
+
+| Target Kube-OVN chart version | Expected `spec.source.charts[0].name` |
+|---|---|
+| Earlier than `v4.4` | `acp/chart-cpaas-kube-ovn` |
+| `v4.4` and later | `acp/chart-kube-ovn` |
+
+If the target OS Support Matrix row uses Kube-OVN chart `v4.4` or later, upgrade the infrastructure provider to the full-source reconciliation version in the table before continuing. A manual Kube-OVN source patch is not a substitute for that provider upgrade because the same provider releases also reconcile the required CoreDNS and kube-proxy repository changes.
+
+#### Apply the Provider-Version-Specific Procedure
+
+##### Huawei DCS
+
+Verify that the DCS infrastructure cluster uses Kube-OVN:
+
+```bash
+kubectl get dcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{.spec.networkType}{"\n"}'
+# Expected output: kube-ovn
+```
+
+<Tabs>
+  <Tab label="DCS v1.0.22+">
+
+Update the target chart version on the CAPI `Cluster`. The provider selects the chart name from the target version and reconciles the complete `AppRelease` source and specification.
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+```
+
+Do not patch the `AppRelease` source manually. Continue with [Verify the Kube-OVN AppRelease](#verify-the-kube-ovn-apprelease).
+
+  </Tab>
+  <Tab label="DCS v1.0.21 and earlier">
+
+:::warning
+This legacy flow is valid only when the target Kube-OVN chart is earlier than `v4.4`. For chart `v4.4` or later, upgrade the DCS provider to `v1.0.22` or later first.
+:::
+
+The legacy provider updates `spec.values` but preserves the existing source. Record the target on the `Cluster`, then patch only the existing legacy chart revision on the cluster being upgraded:
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+
+kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+```
+
+Keep the legacy chart name `acp/chart-cpaas-kube-ovn`. Do not use this patch to move an old provider to chart `v4.4` or later.
+
+  </Tab>
+</Tabs>
+
+##### Huawei Cloud Stack
+
+Verify that the HCS infrastructure cluster uses Kube-OVN:
+
+```bash
+kubectl get hcscluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{.spec.networkType}{"\n"}'
+# Expected output: kube-ovn
+```
+
+<Tabs>
+  <Tab label="HCS v1.0.4+">
+
+Update the target chart version on the CAPI `Cluster`. The provider selects the chart name from the target version and reconciles the complete `AppRelease` source and specification.
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+```
+
+Do not patch the `AppRelease` source manually. Continue with [Verify the Kube-OVN AppRelease](#verify-the-kube-ovn-apprelease).
+
+  </Tab>
+  <Tab label="HCS v1.0.3 and earlier">
+
+:::warning
+This legacy flow is valid only when the target Kube-OVN chart is earlier than `v4.4`. For chart `v4.4` or later, upgrade the HCS provider to `v1.0.4` or later first.
+:::
+
+The legacy provider updates `spec.values` but preserves the existing source. Record the target on the `Cluster`, then patch only the existing legacy chart revision on the cluster being upgraded:
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+
+kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+  -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<kube-ovn-version-from-matrix>"}]'
+```
+
+Keep the legacy chart name `acp/chart-cpaas-kube-ovn`. Do not use this patch to move an old provider to chart `v4.4` or later.
+
+  </Tab>
+</Tabs>
+
+##### VMware vSphere
+
+Verify that the CAPI `Cluster` enables Kube-OVN reconciliation:
+
+```bash
+kubectl get cluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{.metadata.annotations.cpaas\.io/network-type}{"\n"}'
+# Expected output: kube-ovn
+```
+
+<Tabs>
+  <Tab label="vSphere v1.0.16+">
+
+Update the target chart version on the CAPI `Cluster`. The provider selects the chart name from the target version and reconciles the complete `AppRelease` source and specification.
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+```
+
+Do not patch the `AppRelease` source manually. Continue with [Verify the Kube-OVN AppRelease](#verify-the-kube-ovn-apprelease).
+
+  </Tab>
+  <Tab label="vSphere v1.0.15 and earlier">
+
+:::warning
+This legacy flow is valid only when the target Kube-OVN chart is earlier than `v4.4`. For chart `v4.4` or later, upgrade the vSphere provider to `v1.0.16` or later first. The legacy controller hardcodes the old chart name and can overwrite an unsupported manual source change.
+:::
+
+For an earlier target chart, update the annotation only. The legacy provider reconciles the complete specification but keeps the legacy chart name.
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+```
+
+  </Tab>
+</Tabs>
+
+##### Bare Metal
+
+This procedure applies to Bare Metal provider `v0.0.1` and later. There is no earlier supported release flow to select.
+
+Verify that the infrastructure cluster uses Kube-OVN, then update the target chart version on the CAPI `Cluster`:
+
+```bash
+kubectl get baremetalcluster <cluster-name> -n cpaas-system \
+  -o jsonpath='{.spec.networkType}{"\n"}'
+# Expected output: kube-ovn
+
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
+```
+
+The provider selects the chart name from the target version and reconciles the complete `AppRelease` source and specification. Do not patch the `AppRelease` source manually.
+
+#### Verify the Kube-OVN AppRelease \{#verify-the-kube-ovn-apprelease}
+
+Run these commands against the cluster being upgraded:
+
+```bash
+kubectl get apprelease cni-kube-ovn -n cpaas-system \
+  -o jsonpath='Chart: {.spec.source.charts[0].name}{"\n"}Target: {.spec.source.charts[0].targetRevision}{"\n"}Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
+
+kubectl get apprelease cni-kube-ovn -n cpaas-system \
+  -o jsonpath='{range .status.conditions[*]}{.type}={.status} ({.reason}){"\n"}{end}'
+```
+
+Before changing the control plane, verify all of the following:
+
+- `spec.source.charts[0].name` matches the chart-name boundary above.
+- `targetRevision` and `installedRevision` both match the OS Support Matrix row.
+- `phase` is `Success`.
+- The `Sync` and `Health` conditions are `True`.
+
+The normal phase sequence is `Upgrading → HealthChecking → Success`. Do not continue based on `installedRevision` alone: it can change during `HealthChecking`, before Kube-OVN pods have been verified Ready. If the `AppRelease` reaches `DownloadFailed`, `DeployFailed`, or `NotReady`, stop and inspect its condition messages:
+
+```bash
+kubectl describe apprelease cni-kube-ovn -n cpaas-system
+```
+
+#### Restore Kube-OVN During Stage-1 Recovery \{#restore-kube-ovn-during-stage-1-recovery}
+
+Use this recovery only when no control-plane `Machine` on the target Kubernetes minor has been created. If a target-minor control-plane machine has joined, keep the target Kube-OVN baseline and use forward recovery or the supported backup or DR restore procedure.
+
+Restore the previous chart version on the CAPI `Cluster` in the management cluster:
+
+```bash
+kubectl annotate cluster <cluster-name> -n cpaas-system \
+  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
+```
+
+- **DCS `v1.0.22+`, HCS `v1.0.4+`, vSphere `v1.0.16+`, and Bare Metal `v0.0.1+`**: restore the previous `cpaas.io/kube-ovn-version` annotation. The provider restores the matching chart name, revision, and complete specification. Do not patch the source manually.
+- **DCS `v1.0.21` and earlier or HCS `v1.0.3` and earlier, with a target earlier than chart `v4.4`**: after restoring the annotation, patch the existing `targetRevision` back to the previous chart revision on the cluster being recovered:
+
+  ```bash
+  kubectl patch apprelease cni-kube-ovn -n cpaas-system --type='json' \
+    -p='[{"op":"replace","path":"/spec/source/charts/0/targetRevision","value":"<previous-kube-ovn-version>"}]'
+  ```
+
+- **vSphere `v1.0.15` and earlier, with a target earlier than chart `v4.4`**: restore the previous annotation only; the provider reconciles the complete legacy specification.
+
+After restoring the previous target, repeat [Verify the Kube-OVN AppRelease](#verify-the-kube-ovn-apprelease) before changing any control-plane manifests.
+
 ### Required kubelet patch for Kubernetes 1.35 \{#kubernetes-1-35-kubelet-patch}
 
 When an upgrade hop targets Kubernetes 1.35 or later, the kubelet patch file at `/etc/kubernetes/patches/kubeletconfiguration0+strategic.json` must include the following setting:
@@ -87,7 +314,7 @@ When an upgrade hop targets Kubernetes 1.35 or later, the kubelet patch file at 
 }
 ```
 
-`imagePullCredentialsVerificationPolicy` is required only starting with Kubernetes 1.35. Setting it to `NeverVerify` prevents the kubelet from requiring registry credential verification for images that are already present in the immutable OS image.
+In Kubernetes 1.35, kubelet credential verification can apply even when an image is already present on the node. `NeverVerify` tells the kubelet not to verify pull credentials for these pre-pulled images. Add this field only to kubelet configurations that will run on Kubernetes 1.35 or later; do not add it for Kubernetes 1.34 or earlier.
 
 Apply this change only on the hop to Kubernetes 1.35 or later:
 
@@ -153,7 +380,7 @@ Select your platform for detailed upgrade instructions:
 | [Huawei DCS](./huawei-dcs.mdx) | Huawei Datacenter Virtualization Solution | ✅ Available |
 | [Huawei Cloud Stack](./huawei-cloud-stack.mdx) | Huawei Cloud Stack | ✅ Available |
 | [VMware vSphere](./vmware-vsphere.mdx) | VMware vSphere virtualization platform | ✅ Available |
-| [Bare Metal](./bare-metal.mdx) | Bare-metal servers without virtualization | ✅ Available (YAML only) |
+| [Bare Metal](./bare-metal.mdx) | Bare-metal servers without virtualization | YAML; requires provider `v0.0.1+` in the installed release |
 
 ---
 

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -19,82 +19,61 @@ This section provides instructions for upgrading Kubernetes clusters managed by 
 
 Cluster upgrades on Immutable Infrastructure follow a two-phase approach:
 
-1. **Phase 1**: Upgrade Distribution Version (Aligned Extensions)
-2. **Phase 2**: Upgrade Kubernetes Version
+1. **Phase 1**: Upgrade ACP Core and the cluster Distribution Version through CVO.
+2. **Phase 2**: Upgrade Kubernetes and replace nodes with the matching Alauda OS image.
 
 :::info
-This two-phase upgrade ensures that all cluster extensions and plugins are compatible with the new platform version before upgrading the underlying Kubernetes components.
+The ACP product documentation owns Phase 1 prerequisites, supported ACP upgrade paths, artifact preparation, and CVO procedures. This site owns the Immutable Infrastructure Kubernetes and OS replacement procedures in Phase 2.
 :::
 
 ### Distribution Version vs Kubernetes Version
 
-| Component | Description | Managed By |
+| Component | Description | Managed by |
 |-----------|-------------|------------|
-| Distribution Version | ACP platform version (e.g., ACP 4.3.0) | Aligned Extensions upgrade |
-| Kubernetes Version | Kubernetes component version | Node Pool upgrade |
+| Distribution Version | The ACP Core release installed on the cluster. | CVO workflow documented in the ACP product documentation. |
+| Kubernetes and OS baseline | A validated Kubernetes minor, component set, and Alauda OS image for the installed ACP release. | Cluster API and the provider-specific Phase 2 procedure. |
 
-Each Distribution Version corresponds to a specific Kubernetes version. Upgrading the Distribution Version updates cluster extensions and may enable new Kubernetes versions.
+An ACP minor release line can offer more than one validated Kubernetes target over its patch lifecycle. Use [OS Support Matrix](../overview/os-support-matrix.mdx) for the exact patch-specific Kubernetes, component, and Alauda OS image values offered for Phase 2.
 
 ### Prerequisites
 
-- Control Plane is reachable and healthy
-- All nodes are in Ready state
-- Sufficient IP Pool capacity for rolling updates
+- Complete <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />, including validation that the source ACP release can upgrade to the target Distribution Version.
+- Complete the ACP Core and Distribution Version upgrade before starting Phase 2.
+- Verify that the control plane is reachable and healthy.
+- Verify that all nodes are in the `Ready` state.
+- Take and verify the backups required by the provider-specific procedure.
+- Confirm sufficient IP or machine-slot capacity for rolling replacement.
 
 ---
 
-## Phase 1: Upgrading Distribution Version (Aligned Extensions)
+## Phase 1: Upgrade ACP Core and Distribution Version
 
-Upgrading the Distribution Version updates the cluster's Aligned Extensions (L3 and L4 plugins).
+Use the ACP product documentation as the single procedure owner for this phase:
 
-### Using the Web UI
+- <ExternalSiteLink name="acp" href="/upgrade/overview.html" children="Upgrade Overview" />
+- <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />
+- <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html" children="Upgrade the global cluster" />
+- <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html" children="Upgrade workload clusters" />
 
-**Navigation**: Clusters → Clusters → Select cluster → Aligned Extensions Tab → Click **Upgrade**
+Follow that sequence to prepare artifacts and plugin packages, upgrade the `global` tier, and then move each workload cluster to the target Distribution Version through CVO. Do not use intermediate Kubernetes hops in Phase 2 to bypass an unsupported ACP Core upgrade path.
 
-#### Step 1: Review Modifications
-
-:::warning
-⚠️ All modifications must be reviewed with technical support to confirm whether they should be preserved or deleted. Unconfirmed modifications may cause the upgrade to fail.
+:::info
+Fleet Essentials 1.0.4 and later can use the ACP 4.3-and-later CVO workflow to request a Distribution Version upgrade. That capability covers Phase 1 only. Fleet Essentials does not replace immutable nodes or perform the Kubernetes and Alauda OS rollout in Phase 2; use the provider-specific YAML procedure on this site.
 :::
-
-Review any detected modifications that may affect the upgrade.
-
-**Operations**:
-- **Acknowledge**: Confirm review and proceed to Step 2
-- **Cancel**: Abort the upgrade process
-
-#### Step 2: Upgrade Aligned Extensions
-
-**Version Information**:
-- **Current Version**: The cluster's current Distribution Version
-- **Target Version**: The global cluster's Distribution Version
-
-**Plugin Impact Assessment**:
-
-| Plugin | Current Version | Target Version | Impact |
-|--------|----------------|----------------|--------|
-| [Plugin List] | ... | ... | Low/Medium/High |
-
-For Medium and High impact plugins, check **Acknowledge** to confirm you understand the risks.
-
-**Operations**:
-- **Back**: Return to Step 1 to re-review modifications
-- **Start Upgrade**: Begin the upgrade (only available after acknowledging Medium/High impacts)
-- **Cancel**: Abort the upgrade process
 
 ### Post-Upgrade Verification
 
 After the Distribution Version upgrade completes:
-- Cluster's Distribution Version is updated
-- Node Pools' Kubernetes versions are now lower than the new Distribution Version supports
-- Proceed to Phase 2 to upgrade Kubernetes
+
+- Verify that the cluster reports the target Distribution Version and CVO is no longer progressing or blocked.
+- Confirm that the target row and all required intermediate rows exist in the OS Support Matrix.
+- Proceed to Phase 2 only after the management-side Cluster API providers are healthy.
 
 ---
 
 ## Phase 2: Upgrading Kubernetes Version
 
-After upgrading Distribution Version, upgrade Kubernetes on each Node Pool.
-Provider-specific guides contain the Phase 2 procedures for each platform.
+After upgrading the Distribution Version, upgrade Kubernetes and the Alauda OS image through the provider-specific Cluster API procedure.
 
 For Huawei DCS, Huawei Cloud Stack, VMware vSphere, and bare-metal clusters, upgrade the Kube-OVN chart for the current upgrade hop **before** changing `KubeadmControlPlane`. Wait until the workload cluster's `cni-kube-ovn` `AppRelease` reports the target installed revision and `phase=Success`, then upgrade the control plane, followed by worker nodes. Repeat this Kube-OVN-first ordering for every intermediate Kubernetes minor in a cross-version upgrade.
 
@@ -130,7 +109,7 @@ See platform-specific guides:
 
 When the target ACP Distribution Version is more than one Kubernetes minor above the cluster's current version, additional preparation is required before starting Phase 2. Single-minor upgrades skip this section.
 
-On Immutable Infrastructure, each Kubernetes minor is baked into a matching OS image, and each Kubernetes minor maps to a specific ACP version row in [OS Support Matrix](../overview/os-support-matrix.mdx). The Kubernetes version therefore moves forward one minor at a time, stepping through the OS image of each intermediate ACP row. The ACP Core (Distribution Version) itself is still upgraded directly to the target version through the Cluster Version Operator — only the Kubernetes version steps through the intermediate minors.
+On Immutable Infrastructure, each Kubernetes minor is baked into a matching OS image, and each Kubernetes minor maps to a specific ACP version row in [OS Support Matrix](../overview/os-support-matrix.mdx). The Kubernetes version therefore moves forward one minor at a time, stepping through the OS image of each intermediate ACP row. The ACP Core (Distribution Version) moves according to the supported path in <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />; only the Kubernetes and OS rollout uses the intermediate minor hops described here.
 
 Identify every ACP minor between the current and target versions, use the latest patch in each row, and complete the following pre-staging for each intermediate version before starting Phase 2.
 

--- a/docs/en/upgrade-cluster/index.mdx
+++ b/docs/en/upgrade-cluster/index.mdx
@@ -109,13 +109,15 @@ See platform-specific guides:
 
 When the target ACP Distribution Version is more than one Kubernetes minor above the cluster's current version, additional preparation is required before starting Phase 2. Single-minor upgrades skip this section.
 
-On Immutable Infrastructure, each Kubernetes minor is baked into a matching OS image, and each Kubernetes minor maps to a specific ACP version row in [OS Support Matrix](../overview/os-support-matrix.mdx). The Kubernetes version therefore moves forward one minor at a time, stepping through the OS image of each intermediate ACP row. The ACP Core (Distribution Version) moves according to the supported path in <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />; only the Kubernetes and OS rollout uses the intermediate minor hops described here.
+On Immutable Infrastructure, each Kubernetes minor is baked into a matching OS image, and each Kubernetes minor maps to a specific ACP version row in [OS Support Matrix](../overview/os-support-matrix.mdx). The Kubernetes version therefore moves forward one minor at a time through the required intermediate OS images. Keep these Kubernetes and OS hops separate from the ACP Core upgrade path: the Distribution Version must follow every source-to-target hop offered by CVO, while Phase 2 can require additional intermediate rows only to advance Kubernetes and the OS image.
 
-Identify every ACP minor between the current and target versions, use the latest patch in each row, and complete the following pre-staging for each intermediate version before starting Phase 2.
+Before starting Phase 2, identify every intermediate Kubernetes minor and its matching OS Support Matrix row. Confirm separately that Phase 1 completed every required Distribution Version hop according to <ExternalSiteLink name="acp" href="/upgrade/pre-upgrade.html" children="Pre-Upgrade Preparation" />.
 
-### Step 1 — Pre-sync intermediate Core images to the registry
+### Step 1 — Confirm Core hops and pre-sync intermediate images
 
-For each intermediate ACP version, download its Core package and synchronize only its images into the registry. Do not request a Core upgrade to the intermediate version.
+If CVO offers an intermediate Distribution Version as part of the supported Core path, perform the full ACP artifact preparation and Core/CVO upgrade for that hop during Phase 1. This is required for paths such as ACP 4.0.x to 4.4, and `--only-sync-image` does not replace it. Verify `availableUpdates` and `VersionUpgradePath` at every Core hop.
+
+After all required Core hops are complete, some intermediate OS Support Matrix rows may still be needed only for the sequential Kubernetes and OS rollout in Phase 2. For each of these Kubernetes/OS-only rows, download the corresponding Core package and synchronize only its images into the registry. Do not request an additional Core upgrade solely because a row is used as a Kubernetes or OS stepping stone.
 
 ```bash
 bash upgrade.sh --only-sync-image
@@ -125,20 +127,20 @@ See <ExternalSiteLink name="acp" href="/upgrade/upgrade_global_cluster.html#sync
 
 This places the intermediate-version CoreDNS, etcd, and Kube-OVN chart images in the registry so the staged Kubernetes rollout can pull them when `KubeadmControlPlane` is patched to the matching OS Support Matrix row. In an air-gapped environment, missing intermediate images prevent the new control plane components from starting.
 
-Aligned plugins do not need an extra `violet push` for the intermediate versions; they move directly to the target version with the Core upgrade, and the Kube-OVN chart used by each intermediate Kubernetes hop is already covered by the Core image sync above.
+For a required Core hop, prepare and upgrade Aligned plugins as directed by the ACP Phase 1 procedure. For a Kubernetes/OS-only intermediate row, Aligned plugins do not need an extra `violet push`; the Kube-OVN chart used by that intermediate Kubernetes hop is covered by the Core image sync above.
 
 ### Step 2 — Stage intermediate OS images for the provisioning mechanism
 
-For each intermediate ACP version, make the matching OS image (the **Alauda OS Image Version** value from the OS Support Matrix row) available to the node provisioning mechanism so the Kubernetes step can replace nodes from each image in turn:
+For each intermediate Kubernetes/OS row, make the matching OS image (the **Alauda OS Image Version** value from the OS Support Matrix row) available to the node provisioning mechanism so the Kubernetes step can replace nodes from each image in turn:
 
 - **IaaS providers (Huawei DCS, VMware vSphere, Huawei Cloud Stack)**: upload the OS image and register it as a VM template (or VM image, depending on the platform) under the exact name listed in the OS Support Matrix row.
 - **Bare metal**: make the OS image available to the node re-provisioning flow used by your cluster.
 
 The control plane and worker rollouts then step through the intermediate OS images one at a time, matched to the staged Kubernetes minor, until the cluster reaches the target ACP version row.
 
-### Step 3 — Apply the platform-specific procedure for each intermediate version
+### Step 3 — Apply the platform-specific procedure for each intermediate Kubernetes/OS row
 
-Repeat the platform-specific Phase 2 procedure for each intermediate ACP version in turn, using that version's row in [OS Support Matrix](../overview/os-support-matrix.mdx) for Kube-OVN, `KubeadmControlPlane`, and `MachineDeployment` values. For each hop, upgrade Kube-OVN first and wait for `phase=Success`, then upgrade the control plane, followed by workers. On the hop to Kubernetes 1.35, also apply the [required kubelet patch](#kubernetes-1-35-kubelet-patch) to the control-plane and worker bootstrap configurations. Complete the whole hop before starting the next one. After all intermediate hops succeed, apply the same procedure once more for the target ACP version.
+Repeat the platform-specific Phase 2 procedure for each intermediate Kubernetes/OS row in turn, using that row in [OS Support Matrix](../overview/os-support-matrix.mdx) for Kube-OVN, `KubeadmControlPlane`, and `MachineDeployment` values. For each hop, upgrade Kube-OVN first and wait for `phase=Success`, then upgrade the control plane, followed by workers. On the hop to Kubernetes 1.35, also apply the [required kubelet patch](#kubernetes-1-35-kubelet-patch) to the control-plane and worker bootstrap configurations. Complete the whole hop before starting the next one. After all intermediate hops succeed, apply the same procedure once more for the target row.
 
 ---
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -44,10 +44,12 @@ Before you begin, ensure the following conditions are met:
 - The distribution-version upgrade is complete.
 - The control plane is healthy and reachable.
 - All nodes are in the `Ready` state.
+- A current etcd backup has been taken and verified by using the supported ACP backup procedure.
 - The target VM template is present in the vSphere environment under the same name as the **Alauda OS Image Version** value in the OS Support Matrix row. The upgrade fails if the template is not present when the new `VSphereMachineTemplate` is applied.
 - For cross-version upgrades that span more than one Kubernetes minor, the intermediate-version Core images and VM templates are pre-staged. See [Cross-Version Upgrade Preparation](./index.mdx#cross-version-preparation).
 - The target Kubernetes version is compatible with your workloads and add-ons.
 - The machine config pools have enough capacity for rolling updates.
+- If you rely on pool-managed persistent disks, keep `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge: 0` and each `MachineDeployment.spec.strategy.rollingUpdate.maxSurge: 0` so the replacement can reuse the same slot and disk identity.
 - Review the Kubernetes upgrade path and version skew policy.
 
 :::warning
@@ -72,9 +74,9 @@ Upgrades rely on Cluster API's rolling replacement mechanism. Each cluster has f
 :::
 
 :::info
-**Fleet Essentials UI does not support ACP 4.3 cluster upgrades**
+**Fleet Essentials boundary**
 
-vSphere clusters do not currently expose a Fleet Essentials UI upgrade path. Use the YAML procedure documented below, or the two-step upgrade flow built into the ACP Core platform — see <ExternalSiteLink name="acp" href="/upgrade/upgrade_workload_cluster.html#request-the-upgrade" children="Request the upgrade for workload clusters" />.
+Fleet Essentials 1.0.4 and later can request the ACP 4.3-and-later Distribution Version upgrade through CVO. It does not perform the vSphere Kubernetes and Alauda OS replacement described on this page. Complete Phase 1 with the ACP workflow, then use the YAML procedure below for Phase 2.
 :::
 
 ## Required Values From the OS Support Matrix \{#required-values}
@@ -260,28 +262,32 @@ kubectl --kubeconfig=/tmp/<cluster_name>.kubeconfig get nodes -o wide
 
 </Steps>
 
-## Rolling Back a Failed Upgrade
+## Recovering From a Failed Phase 2 Upgrade
 
-If the rolling update fails — new VMs fail to boot, nodes do not become `Ready`, or the new Kubernetes minor version surfaces an incompatibility — revert the template reference and Kubernetes-version fields back to the previous values. Cluster API treats the reversion as a new spec drift and rolls the v2 machines back to the previous template, one at a time.
+Do not treat a Kubernetes minor downgrade as an ordinary rollback. Choose the recovery path from the rollout stage:
 
-Three facts to internalize before rolling back:
+1. **No target-version control-plane `Machine` has been created**: restore the previous Kube-OVN annotation and the previous `KubeadmControlPlane` and `MachineDeployment` manifest values. This cancels the target rollout before a new control-plane data format is introduced.
+2. **Only the machine template or OS image changed, and the Kubernetes minor did not change**: point the controlling resource back to the previous template. Cluster API performs another replacement rollout. Keep the Kubernetes minor unchanged.
+3. **A control-plane `Machine` on the target Kubernetes minor has joined the cluster**: do not patch Kubernetes, CoreDNS, or etcd back to the previous minor. Stop further rollout, repair forward on the target minor, or restore the cluster from the verified pre-upgrade backup by using the supported ACP recovery procedure.
 
-- **The old VMs are gone.** They were destroyed during the upgrade. Rollback uses the old template to build a fresh set of replacement machines; it does not restore the original VMs.
-- **The old `VSphereMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before rolling back.
-- **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `VSphereMachineConfigPool.spec.slot[].persistentDisks` reattach to the rolled-back machines at the same slot, but any data written to those disks during the upgrade window (for example, etcd entries in the new Kubernetes minor format) stays. If the new format is unreadable by the older Kubernetes minor version, the rollback may still fail and require manual etcd restoration.
+If a target-minor control-plane `Machine` was created but never joined, first restore healthy etcd quorum and determine whether the failed replacement can be removed safely. Do not assume that changing the version fields alone is sufficient.
 
-Procedure:
+Keep these infrastructure facts in mind during any recovery:
 
-- **Control plane**: patch `KubeadmControlPlane` to restore the previous `spec.machineTemplate.infrastructureRef.name`, `spec.version`, `spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag`, and `spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag`.
-- **Workers**: patch each `MachineDeployment` to restore the previous `spec.template.spec.infrastructureRef.name` and `spec.template.spec.version`.
-- **Kube-OVN**: if the kube-ovn annotation was changed, restore the previous value on the `Cluster` resource and verify reconciliation with the same target-revision and `phase=Success` checks described in [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane):
+- **The old VMs are gone.** They were destroyed during the upgrade. Template recovery builds a fresh set of replacement machines; it does not restore the original VMs.
+- **The old `VSphereMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
+- **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `VSphereMachineConfigPool.spec.slot[].persistentDisks` reattach to the replacement machines at the same slot, but data written during the upgrade window remains on those disks.
 
-  ```bash
-  kubectl annotate cluster <cluster_name> -n <namespace> \
-    cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
-  ```
+For stage 1, restore the previous Kube-OVN annotation:
 
-If the new control plane never reached etcd quorum, the `KubeadmControlPlane` controller may refuse to roll back any machine because its preflight checks block on an unhealthy etcd. Recover etcd quorum first (operator intervention) before retrying the rollback.
+```bash
+kubectl annotate cluster <cluster_name> -n <namespace> \
+  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
+```
+
+The vSphere provider reconciles the complete Kube-OVN `AppRelease` specification from this annotation. Wait until `installedRevision` matches the restored revision and `phase=Success` before changing control-plane manifests. If the target-minor control plane has already joined, keep the target Kube-OVN baseline and use forward recovery or backup restore instead of attempting an independent chart downgrade.
+
+The `KubeadmControlPlane` controller can block replacement while etcd is unhealthy. Recover quorum before retrying any safe replacement action.
 
 ## Verification
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -61,7 +61,7 @@ Upgrades rely on Cluster API's rolling replacement mechanism. Each cluster has f
 |---|---|---|---|
 | System disk (root volume) | The VM template used for `spec.template.spec.template` | ❌ Never | OS + kubelet/kubeadm/containerd. Rebuilt from the new template every replacement. |
 | Template-local disks | `VSphereMachineTemplate.spec.template.spec.*` (additional disks declared in the template) | ❌ Never | Ephemeral cache. Destroyed with the old VM. |
-| Pool-managed persistent disks | `VSphereMachineConfigPool.spec.slot[].persistentDisks` | ✅ Detached from old VM and reattached to the new VM at the same slot | Platform state such as `/var/cpaas`. |
+| Pool-managed persistent disks | `VSphereMachineConfigPool.spec.configs[].persistentDisks[]` | ✅ Detached from old VM and reattached to the new VM at the same slot | Platform state such as `/var/cpaas`. |
 | External CSI volumes (vSphere CSI, etc.) | Workload PVCs / CSI driver | ✅ Unrelated to node lifecycle | Application data. |
 
 **"Preserved" means the same disk identity is reattached** — it does not mean the disk's contents are time-traveled. Anything written to a pool-managed disk during the upgrade window stays after the upgrade and stays after a rollback.
@@ -276,7 +276,7 @@ Keep these infrastructure facts in mind during any recovery:
 
 - **The old VMs are gone.** They were destroyed during the upgrade. Template recovery builds a fresh set of replacement machines; it does not restore the original VMs.
 - **The old `VSphereMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
-- **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `VSphereMachineConfigPool.spec.slot[].persistentDisks` reattach to the replacement machines at the same slot, but data written during the upgrade window remains on those disks.
+- **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `VSphereMachineConfigPool.spec.configs[].persistentDisks[]` reattach to the replacement machines at the same slot, but data written during the upgrade window remains on those disks.
 
 For stage 1, restore the previous Kube-OVN annotation:
 

--- a/docs/en/upgrade-cluster/vmware-vsphere.mdx
+++ b/docs/en/upgrade-cluster/vmware-vsphere.mdx
@@ -91,7 +91,7 @@ The cells you read from that row map to the upgrade manifests as follows:
 | **Kubernetes Version** | `KubeadmControlPlane.spec.version` and `MachineDeployment.spec.template.spec.version` | Both control plane and worker |
 | **coredns** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.dns.imageTag` | Control plane only |
 | **etcd** | `KubeadmControlPlane.spec.kubeadmConfigSpec.clusterConfiguration.etcd.local.imageTag` | Control plane only |
-| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` | Cluster scope; the vSphere provider reconciles the Kube-OVN AppRelease from this annotation. Complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. This is the `acp/chart-cpaas-kube-ovn` chart version (for example `v4.3.3`), not the Kube-OVN component version. |
+| **kube-ovn (chart)** | `Cluster.metadata.annotations["cpaas.io/kube-ovn-version"]` and the provider-managed `cni-kube-ovn` `AppRelease` | Complete the shared [provider-version-specific Kube-OVN procedure](./index.mdx#upgrade-kube-ovn-before-the-control-plane) before changing `KubeadmControlPlane`. The provider version and target chart version determine the chart name and supported reconciliation flow. |
 
 The CoreDNS and etcd image tags are control-plane-only because `clusterConfiguration` is a `KubeadmControlPlane` field. Worker nodes inherit container image versions from the new VM template; the `MachineDeployment` does not carry its own `dns`/`etcd` tags. The Kube-OVN annotation lives on the `Cluster` resource, not on `KubeadmControlPlane`, because the vSphere provider watches it independently of the Kubernetes control plane rollout.
 
@@ -100,57 +100,9 @@ The CoreDNS and etcd image tags are control-plane-only because `clusterConfigura
 <Steps>
 ### Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
 
-Upgrade Kube-OVN and wait for it to become healthy before you change `KubeadmControlPlane.spec.version`, its component image tags, or its machine template reference. This ordering ensures that the target network components are already running before control-plane nodes begin rolling replacement.
+Follow [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) and select the VMware vSphere procedure that matches the **installed** provider version. The shared procedure includes the vSphere-specific network annotation check, the chart-name migration at Kube-OVN `v4.4`, the legacy-provider boundary, and the required `AppRelease` health checks.
 
-1. **Verify the Kube-OVN reconcile gating annotation**
-
-   On vSphere, the provider reconciles the Kube-OVN `AppRelease` only when the `Cluster` resource carries the annotation `cpaas.io/network-type: kube-ovn`. This annotation is normally set at cluster creation. If it is missing, updating the version annotation will not reconcile the Kube-OVN `AppRelease`.
-
-   ```bash
-   kubectl get cluster <cluster_name> -n <namespace> \
-     -o jsonpath='{.metadata.annotations.cpaas\.io/network-type}{"\n"}'
-   # Expected output: kube-ovn
-   ```
-
-   This precondition is vSphere-specific. The DCS and Huawei Cloud Stack providers use the `DCSCluster` / `HCSCluster` `spec.networkType` field instead and do not require this annotation.
-
-2. **Update the Kube-OVN version annotation on the `Cluster` resource**
-
-   If the target ACP row in the OS Support Matrix shows a different **kube-ovn (chart)** value than the current cluster, patch the annotation on the `Cluster` resource so the vSphere provider reconciles the new Kube-OVN AppRelease:
-
-   ```bash
-   kubectl annotate cluster <cluster_name> -n <namespace> \
-     cpaas.io/kube-ovn-version=<kube-ovn-version-from-matrix> --overwrite
-   ```
-
-   Kube-OVN is a Core lifecycle component, but on immutable OS the vSphere provider drives its delivery from this annotation; the annotation does not update automatically when `spec.version` changes.
-
-3. **Wait for reconciliation to complete before upgrading the control plane**
-
-   The vSphere provider reconciles a single Kube-OVN `AppRelease` named `cni-kube-ovn` in the `cpaas-system` namespace of the workload cluster. Run the following on the workload cluster (not the bootstrap KIND or the `global` cluster):
-
-   ```bash
-   # Overall AppRelease state — Sync and Health columns must reach a Success-equivalent reason
-   kubectl get apprelease cni-kube-ovn -n cpaas-system
-
-   # Installed revision and chart phase
-   kubectl get apprelease cni-kube-ovn -n cpaas-system \
-     -o jsonpath='Installed: {.status.charts.*.installedRevision}{"\n"}Phase: {.status.charts.*.phase}{"\n"}'
-   ```
-
-   The normal sequence is `Upgrading → HealthChecking → Success`. On small clusters the full transition typically completes within about one minute. Read the phases as follows:
-
-   | Phase | Meaning | `installedRevision` |
-   |---|---|---|
-   | `Upgrading` | Helm release upgrade in progress. `Sync` condition is `Unknown(Syncing)`. | Still the previous version |
-   | `HealthChecking` | Helm release applied; controller is verifying Kube-OVN pods. `Sync` condition is `True(Synced)`. | Already the target version |
-   | `Success` | All three conditions (`Validate`, `Sync`, `Health`) are `True`. | Target version |
-
-   :::warning
-   Do not start the KCP upgrade based on `installedRevision` alone. The field flips to the target value during `HealthChecking`, before pods have been verified Ready. Start the control-plane rollout only when `phase` is `Success` **and** `installedRevision` matches the target.
-   :::
-
-   The `AppRelease` API also defines `Downloading`, `Installing`, `Syncing`, `DownloadFailed`, `DeployFailed`, and `NotReady`. The first three are transient and the upgrade should converge on its own. The last three indicate a failure that needs manual investigation; start with `kubectl describe apprelease cni-kube-ovn -n cpaas-system` to read the per-condition `message` field.
+For a Kube-OVN `v4.4+` target, upgrade the vSphere provider to `v1.0.16` or later first. Do not patch the chart source manually with an earlier provider because its controller can reconcile the legacy chart name back over the change.
 
 ### Create the target machine templates
 
@@ -192,7 +144,7 @@ Before you start the rolling upgrade, create new `VSphereMachineTemplate` resour
 
 ### Upgrade the control plane
 
-Before you start, complete [Upgrade Kube-OVN Before the Control Plane](#upgrade-kube-ovn-before-the-control-plane) and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success`. Then collect every required control-plane value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
+Before you start, complete the shared [Upgrade Kube-OVN Before the Control Plane](./index.mdx#upgrade-kube-ovn-before-the-control-plane) procedure and verify that the `cni-kube-ovn` `AppRelease` is at the target revision with `phase=Success`. Then collect every required control-plane value from the target ACP row in the OS Support Matrix as described in [Required Values From the OS Support Matrix](#required-values).
 
 1. **Patch the `KubeadmControlPlane` with the target Kubernetes values**
 
@@ -278,14 +230,7 @@ Keep these infrastructure facts in mind during any recovery:
 - **The old `VSphereMachineTemplate` resource must still exist.** Do not delete the previous template until the new rollout is healthy. If you already deleted it, recreate it from version control or backup before attempting same-minor template recovery.
 - **Pool-managed disk identity is preserved, but data state is not.** Disks declared in `VSphereMachineConfigPool.spec.configs[].persistentDisks[]` reattach to the replacement machines at the same slot, but data written during the upgrade window remains on those disks.
 
-For stage 1, restore the previous Kube-OVN annotation:
-
-```bash
-kubectl annotate cluster <cluster_name> -n <namespace> \
-  cpaas.io/kube-ovn-version=<previous-kube-ovn-version> --overwrite
-```
-
-The vSphere provider reconciles the complete Kube-OVN `AppRelease` specification from this annotation. Wait until `installedRevision` matches the restored revision and `phase=Success` before changing control-plane manifests. If the target-minor control plane has already joined, keep the target Kube-OVN baseline and use forward recovery or backup restore instead of attempting an independent chart downgrade.
+For stage 1, use the vSphere rule in [Restore Kube-OVN During Stage-1 Recovery](./index.mdx#restore-kube-ovn-during-stage-1-recovery). Both current and legacy vSphere providers restore from the annotation, but the shared rule preserves the chart-version and provider-version boundary. Wait until the restored `AppRelease` passes the shared verification before changing control-plane manifests.
 
 The `KubeadmControlPlane` controller can block replacement while etcd is unhealthy. Recover quorum before retrying any safe replacement action.
 


### PR DESCRIPTION
## Purpose

- Provide the `master` counterpart of #147, which targets `release-1.0`, so the same immutable-infrastructure upgrade guidance is retained when the next release branch is cut from `master`.
- Carry the same three logical commits as #147, cherry-picked with `-x` provenance.
- Keep AIT-73366 installation and vSphere disk-lifecycle improvements out of this PR; those changes remain on an independent branch and will be rebased after both AIT-73302 PRs merge.

## Changes

- Align Phase 1 ACP Core/CVO prerequisites with the ACP product documentation and keep provider-specific Kubernetes/Alauda OS replacement in Phase 2.
- Add provider-version-aware Kube-OVN upgrade paths, including legacy procedures for older DCS, HCS, and vSphere providers and the single release flow for Bare Metal.
- Clarify stage-1 recovery boundaries, required intermediate Core upgrades, vSphere persistent-disk fields, Bare Metal workflow conditions, and provider page naming.
- Preserve the same exclusions and release-artifact boundaries documented in #147.

## Relationship to #147

- Source PR: #147 (`release-1.0`)
- This PR: equivalent documentation changes for `master`
- The changed-file set and logical commit sequence match #147; commit hashes differ because the commits were replayed onto the current `master` base.

## Validation

- `git diff --check`
- `git range-diff` against the three source commits from #147
- Changed-file set comparison against #147: 12 files, exact match
- `yarn install --immutable`
- `yarn lint` — 0 errors, 0 warnings
- `yarn build` — passed; only the existing `import.meta.env.SSR` DefinePlugin warnings remain
