### PR TITLE
docs: document bare-metal managed storage

### DIFF
--- a/docs/en/apis/providers/bare-metal/index.mdx
+++ b/docs/en/apis/providers/bare-metal/index.mdx
@@ -9,7 +9,7 @@ weight: 40
 The Bare Metal Infrastructure Provider builds on `elemental-operator` and Cluster API. Operators interact with two CRD groups, both documented here:
 
 - `infrastructure.cluster.x-k8s.io/v1beta1` — the provider's own resources.
-- `elemental.cattle.io/v1beta1` — owned by `elemental-operator`; the provider only reads and annotates them, but operators must author the registration/seed objects and inspect inventory objects on every workflow.
+- `elemental.cattle.io/v1beta1` — owned by `elemental-operator`; operators author registration and seed objects and may declare inventory-owned managed storage, while the provider reads, annotates, plans against, and updates storage lifecycle status on inventory objects.
 
 ## Custom Resources
 
@@ -28,7 +28,7 @@ The Bare Metal Infrastructure Provider builds on `elemental-operator` and Cluste
 |---|---|---|
 | `MachineRegistration` | Registration URL + first-install cloud-config. Authored once per cluster. | [MachineRegistration](./machineregistration.mdx) |
 | `SeedImage` | Triggers ISO build with the registration baked in. | [SeedImage](./seedimage.mdx) |
-| `MachineInventory` | Long-lived host identity; consumed by `MachineInventoryPool`. The provider also reads `spec.observedNetwork` (Alauda-fork-only) and writes the `baremetal.alauda.io/*` annotations. | [MachineInventory](./machineinventory.mdx) |
+| `MachineInventory` | Long-lived host identity consumed by `MachineInventoryPool`; carries observed network, optional managed-storage desired state, objective storage observations, and provider-owned storage lifecycle status. | [MachineInventory](./machineinventory.mdx) |
 
 ## Upstream Cluster API resources
 

--- a/docs/en/apis/providers/bare-metal/machineinventory.mdx
+++ b/docs/en/apis/providers/bare-metal/machineinventory.mdx
@@ -4,14 +4,21 @@ weight: 70
 
 # MachineInventory [elemental.cattle.io/v1beta1]
 
-`MachineInventory` is the long-lived identity object for a physical host. It is created by `elemental-register` after a host boots the seed ISO, and it survives reprovisioning — `BaremetalMachine` only borrows it for the lifetime of one Kubernetes node.
+`MachineInventory` is the long-lived identity object for a physical host. It is created by `elemental-register` after a host boots the seed ISO, and it survives reprovisioning — `BaremetalMachine` only borrows it for the lifetime of one Kubernetes node. Inventory-owned managed data volumes also survive deletion of that temporary Machine.
 
-The bare-metal provider reads two parts of this resource:
+The bare-metal provider and its host-side observer use these parts of the resource:
 
-- `metadata.name` — must appear in a `MachineInventoryPool.spec.inventoryNames` entry for the host to be allocatable.
+- `metadata.name` — must appear in a `MachineInventoryPool.spec.machineInventories[].name` entry for the host to be allocatable.
 - `spec.observedNetwork` — an Alauda-fork-only field captured during registration; the provider replays it as cloud-init `network-config` v2 on every reprovision, so the host comes back with the same interface/bond/VLAN/IP layout as when it was first inventoried.
+- `spec.storage` — optional operator-authored desired state for up to 32 inventory-owned data volumes. It selects devices by stable IDs, defines `Adopt` or `InitializeIfBlank`, XFS or ext4, mount paths, required behavior, and a retry nonce.
+- `status.observedStorage` — objective devices, identities, signatures, filesystems, mounts, multipath health, and observation watermark reported by `elemental-storage-observer.service`.
+- `status.storage` — provider-owned lifecycle state and journal for Prepare, Activate, Deactivate, and Release, including applied volume identities and `StoragePrepared` / `StorageActive` conditions.
 
-The provider also writes `metadata.annotations` (`baremetal.alauda.io/owner-*`, `baremetal.alauda.io/plan.type`) and updates `status.plan` / `status.conditions` during clean/reprovision.
+The provider also writes `metadata.annotations` (`baremetal.alauda.io/owner-*` and storage plan-claim metadata), updates `status.plan` / `status.conditions`, and serializes `storage-prepare`, `reprovision`, `clean`, and `storage-release` work through the inventory's default plan Secret.
+
+`InitializeIfBlank` is destructive when its target is blank. Admission requires an approval bound to the current Inventory UID, normalized storage hash, and a monotonically increasing counter, plus `update` authorization on the virtual `machineinventories/storageinitialize` subresource. Use the matching `storagectl` binary to create the atomic patch; do not calculate or edit this approval by hand.
+
+For device-selection rules, lifecycle semantics, compatibility boundaries, and a complete example, see [Manage Data Disks on Bare-Metal Hosts](../../../how-to/manage-bare-metal-storage.mdx).
 
 {/* cspell:disable-next-line */}
 <K8sCrd name="machineinventories.elemental.cattle.io" />

--- a/docs/en/create-cluster/bare-metal.mdx
+++ b/docs/en/create-cluster/bare-metal.mdx
@@ -38,6 +38,8 @@ kubectl -n cpaas-system get configmap elemental-image-catalog -o yaml
 
 Every value used as `Machine.spec.version` (for both the control plane and worker `MachineDeployment` resources) must appear as a key in this ConfigMap, with the leading `v` preserved. The provider resolves the image at reprovision time by substituting the platform registry address for the registry portion of the entry. If a target version is missing, no `reprovision` plan is written and `BaremetalMachine` ends up in `Failed / Reason=ImageCatalogMiss` until the entry is added.
 
+Obtain the matching `base-image` and `base-image-iso` references from Alauda technical support. Use `base-image` for host reprovisioning through the image catalog and `base-image-iso` for `SeedImage` / live installation. Do not derive one reference from the other or substitute an independently built image.
+
 ### 3. Network Connectivity \{#network-connectivity}
 
 - Every physical host must be able to reach `global.platformUrl` (`elemental-system-agent` registration, plan secret polling).
@@ -71,23 +73,28 @@ Set `MachineRegistration.spec.config.elemental.registration.emulate-tpm` from wh
 
 ### 6. Host Disk and Boot Preparation
 
-Prepare **every** disk and virtual disk (VD) on each host before you boot the `SeedImage` ISO:
+Classify **every** disk and virtual disk (VD) on each host before you boot the `SeedImage` ISO. Record which device is the OS install target and which devices, if any, must retain application data:
 
-- Wipe all disks so that no bootable previous operating system remains. The host must boot the ISO, not an old on-disk OS.
+- Wipe the selected OS install disk and any other obsolete boot disks so that no bootable previous operating system remains. The host must boot the ISO, not an old on-disk OS. Set `MachineRegistration.spec.config.elemental.install.device` to the exact OS disk.
+- Do **not** wipe a data disk that you intend to manage with the `Adopt` policy. Back it up independently, record its stable ID and filesystem UUID, and make sure it cannot be selected as the install device.
+- A disk intended for `InitializeIfBlank` must be disposable and objectively blank. Formatting still requires a separate initialization approval after the host registers; the registration manifest does not authorize it.
 - Remove residual Elemental partition labels — `COS_STATE`, `COS_PERSISTENT`, `COS_OEM`, `COS_RECOVERY` — from **all** disks, not only the intended install disk. Elemental resolves partitions by label (`blkid -L COS_STATE`); a stale label left on a second disk (for example from a previous install or a leftover multipath member) makes it resolve the wrong device and the reprovision snapshotter fails.
 - On hosts where the same disk can appear through more than one path (multipath), make sure none of those paths exposes a disk that still carries a `COS_*` label; a residual label on any path can be resolved ahead of the intended install disk. Clean the disk rather than disabling multipath — the image keeps it enabled for network-attached storage boot.
 - Set the boot order so the host boots the virtual CD / ISO first.
+
+Use only stable storage identities reported by the registered inventory. Linux paths such as `/dev/sdX`, `/dev/vdX`, `/dev/nvmeXnY`, and `/dev/mapper/mpathX` are runtime paths and must not be placed in `MachineInventory.spec.storage`.
 
 ---
 
 ## Cluster Creation Workflow
 
-When using YAML, the workflow proceeds through five steps. Every step must be applied in the `cpaas-system` namespace.
+When using YAML, the workflow proceeds through five required steps, with an optional storage-preparation step before pool membership. Every Kubernetes resource must be applied in the `cpaas-system` namespace.
 
 | Step | Apply or perform | Result |
 |---|---|---|
 | 1 | `MachineRegistration` and `SeedImage` | `elemental-operator` builds the bootable ISO. |
 | 2 | Boot the ISO on each physical host | The host runs `elemental install` and registers as a `MachineInventory`. |
+| 2a (optional) | Declare and prepare `MachineInventory.spec.storage` | Explicit data volumes are validated and prepared while the inventory is unallocated. |
 | 3 | `MachineInventoryPool` resources, one per role | The allowed control-plane and worker inventories are declared before CAPI creates Machines. |
 | 4 | `BaremetalCluster`, control-plane `BaremetalMachineTemplate`, `KubeadmControlPlane`, and `Cluster` | Cluster API starts the control-plane rollout using the control-plane pool. |
 | 5 | Worker `KubeadmConfigTemplate`, worker `BaremetalMachineTemplate`, and `MachineDeployment` | Cluster API starts the worker rollout using the worker pool. |
@@ -112,7 +119,7 @@ The example manifests below use `<placeholder>` syntax for environment-specific 
 |---|---|---|
 | `<cluster-name>` | Operator-supplied workload cluster name. Must not be `global`. | Choose once and use consistently for `Cluster`, `BaremetalCluster`, pools, templates, and registration resources. |
 | `<kubernetes-version>` | `elemental-image-catalog` ConfigMap key (with leading `v`, for example `v1.33.7-2`). | `kubectl -n cpaas-system get cm elemental-image-catalog -o yaml` |
-| `<base-image-iso>` | Same ConfigMap entry, with `-iso` appended to the repository. Tag/digest matches the catalog value. | See the [SeedImage step](#step-1-machineregistration-seedimage). |
+| `<base-image-iso>` | ISO image paired with the target release's `base-image`. | Obtain the exact supported reference from Alauda technical support; do not derive it from the image catalog entry. |
 | `<registry-address>` | Platform registry (same value as `global.registry.address` on the install chart). | `kubectl get cluster global -n cpaas-system -o jsonpath='{.metadata.annotations.cpaas\.io/registry-address}'` (when one exists). |
 | `<control-plane-load-balancer-type>` | Operator decision. Use `Internal` for provider-managed Alive or `External` for an existing load balancer. | Review [Plan the Control Plane Endpoint](../how-to/control-plane-endpoint.mdx). |
 | `<control-plane-vip>` / `<control-plane-port>` | Operator-supplied stable endpoint. For `Internal`, use an unused IPv4 VIP in the control-plane Layer-2 domain. For `External`, use the load balancer frontend address. | n/a |
@@ -136,7 +143,7 @@ The example manifests below use `<placeholder>` syntax for environment-specific 
 
 Create a `MachineRegistration` that describes the registration URL and first-install cloud-config, and a `SeedImage` that points `elemental-operator` at the matching ISO base image.
 
-`SeedImage.spec.baseImage` is derived from the image catalog entry for the target Kubernetes version: take the catalog repository, append `-iso`, and keep the same tag or digest. For example, if `elemental-image-catalog` resolves `v1.33.7-2` to `<registry-address>/tkestack/baremetal-base-image:v0.0.0-beta-1.33.7-2`, then `SeedImage.spec.baseImage` is `<registry-address>/tkestack/baremetal-base-image-iso:v0.0.0-beta-1.33.7-2`.
+Set `SeedImage.spec.baseImage` to the exact `base-image-iso` reference supplied by Alauda technical support for the target release. It must be paired with the `base-image` used by the image catalog for later reprovisioning; do not construct the ISO reference by changing the repository name or tag yourself.
 
 ```yaml title="01-machineregistration-seedimage.yaml"
 apiVersion: elemental.cattle.io/v1beta1
@@ -181,7 +188,7 @@ metadata:
     app.kubernetes.io/part-of: cluster-api-provider-baremetal
 spec:
   type: iso
-  baseImage: <base-image-iso>          # See the table above for derivation.
+  baseImage: <base-image-iso>          # Obtain the exact reference from Alauda technical support.
   registrationRef:
     apiVersion: elemental.cattle.io/v1beta1
     kind: MachineRegistration
@@ -225,8 +232,22 @@ Every inventory you intend to use must:
 - Show `Ready=True`.
 - Have a non-empty `status.plan.secretRef.name`.
 - Have a `spec.observedNetwork` that matches the host's expected NIC (only required when you want the install-time IP to survive across reprovisions).
+- When managed data disks are required, run an observer-capable OS image, report a fresh `status.observedStorage`, and reach `status.storage.phase=Prepared` before pool allocation.
 
 Record the exact `MachineInventory` names — they are referenced by name in the next step.
+
+### Optional: Prepare Managed Data Disks \{#optional-prepare-managed-storage}
+
+Managed storage belongs to the long-lived `MachineInventory`, not to a CAPI `Machine` or `BaremetalMachineTemplate`. Configure it while the inventory is unallocated and before adding that inventory to a production pool.
+
+Follow [Manage Data Disks on Bare-Metal Hosts](../how-to/manage-bare-metal-storage.mdx) to:
+
+1. Verify `elemental-storage-observer.service` and inspect `status.observedStorage`.
+2. Select each device by a stable ID and choose `Adopt` or `InitializeIfBlank`.
+3. Use the matching `storagectl` binary to validate and atomically patch the declaration and, when required, its initialization approval.
+4. Wait for `StoragePrepared=True/AllRequiredVolumesPrepared` and `status.storage.phase=Prepared`.
+
+If no disks should be managed, leave `spec.storage` absent or set `volumes: []`. The storage controller converges that inventory to `Unmanaged` with `StoragePrepared=True/NoManagedVolumes` and performs no disk operation.
 
 ### Step 2: Create `MachineInventoryPool` Resources \{#step-2-pools}
 
@@ -277,7 +298,7 @@ kubectl apply -f 02-machineinventorypool.yaml
 kubectl -n cpaas-system get machineinventorypools.infrastructure.cluster.x-k8s.io
 ```
 
-A healthy pool reports `Ready=True`, `total = len(spec.machineInventories)`, and `available = total - allocated - preparing - reprovisioning - unavailable`. Inventories listed in `spec.machineInventories` that fail validation (missing, plan secret missing, Ready=False) raise the pool's `unavailable` counter and surface in the `MembersValid` condition.
+A healthy pool reports `Ready=True`, `total = len(spec.machineInventories)`, and `available = total - allocated - preparing - reprovisioning - unavailable`. Inventories listed in `spec.machineInventories` that fail validation (missing, plan secret missing, Ready=False, or storage not prepared) raise the pool's `unavailable` counter and surface in the `MembersValid` condition. A non-empty storage declaration is an allocation gate: the inventory is not `Available` to CAPI until Prepare succeeds against a fresh observation.
 
 Size the control-plane pool to at least `KubeadmControlPlane.spec.replicas`. Size the worker pool to at least `MachineDeployment.spec.replicas`. For rolling upgrades the pool must hold the entire replica count — the provider uses delete-then-add semantics from the same pool, never both at once.
 
@@ -476,6 +497,10 @@ kubectl -n cpaas-system get baremetalmachines.infrastructure.cluster.x-k8s.io
 # Pool counters
 kubectl -n cpaas-system get machineinventorypools.infrastructure.cluster.x-k8s.io
 
+# Storage lifecycle for inventories that declare managed volumes
+kubectl -n cpaas-system get machineinventories.elemental.cattle.io \
+  -o custom-columns='NAME:.metadata.name,PHASE:.status.storage.phase,PREPARED:.status.storage.conditions[?(@.type=="StoragePrepared")].status,ACTIVE:.status.storage.conditions[?(@.type=="StorageActive")].status'
+
 # Workload cluster Nodes (use the workload kubeconfig)
 kubectl get nodes -o wide
 ```
@@ -512,6 +537,7 @@ A successfully created cluster shows:
 - `KubeadmControlPlane` replicas all `Ready`.
 - Every `BaremetalMachine.status.phase=Running` and `status.ready=true`.
 - Every used `MachineInventory.status.plan.state=Applied` with `baremetal.alauda.io/plan.type=reprovision` on its plan secret.
+- Every used inventory with non-empty `spec.storage.volumes[]` reports `status.storage.phase=Active`, `StoragePrepared=True`, and `StorageActive=True`; the corresponding `BaremetalMachine` reports `StorageReady=True/AllVolumesReady`.
 - `MachineInventoryPool.status` satisfies `available + allocated + preparing + reprovisioning + unavailable = total`.
 - Kubernetes Nodes Ready.
 - For `Internal`, Alive Pods are Ready and the API is reachable through the Self-built VIP.
@@ -528,6 +554,8 @@ A successfully created cluster shows:
 | `BaremetalMachine` stuck after allocation, `BootstrapReady=False / Reason=BootstrapWaiting` | KubeadmConfig has not produced a bootstrap data secret yet. | `Machine.spec.bootstrap.dataSecretName`. |
 | `BaremetalMachine` in `Failed`, `ImageResolved=False / Reason=ImageCatalogMiss` | The target `Machine.spec.version` is not a key in `elemental-image-catalog`. | `kubectl -n cpaas-system get cm elemental-image-catalog -o yaml`. |
 | `ImageResolved=False / Reason=ImageRegistryMissing` | Neither the optional `cpaas.io/registry-address` annotation nor the platform registry-credential Secret resolves a registry address. | Cluster annotations; platform registry-credential Secret. |
+| Inventory is registered but not counted as `Available` | Its managed storage declaration has not reached `StoragePrepared=True`, or the host storage observation is missing or stale. | `MachineInventory.status.storage`, `status.observedStorage`, `elemental-storage-observer.service`, and the `storage-prepare` plan output. |
+| `BaremetalMachine` waits with `StorageReady=False` | A required managed volume did not activate or no fresh post-reboot observation confirms its mount. | `BaremetalMachine.status.conditions[StorageReady]`, `MachineInventory.status.storage`, and host mount units. |
 | Reprovision never completes; `MachineInventory.status.plan.state=Failed` | `elemental upgrade` failed (registry unreachable, TLS, disk full). | Plan secret `failed-output` field; host serial console. |
 | `BaremetalCluster` uses `Internal`, but the VIP is not reachable | `vrid` collides with another cluster; VIP is not in the control-plane L2 domain; VRRP or gratuitous ARP is blocked; IPVS or required sysctls are unavailable. | Alive Pods, `ip addr show`, `ipvsadm -Ln`, and the two required sysctl keys on a control-plane host. |
 | `BaremetalCluster` uses `External`, but the endpoint is not reachable | Listener, backend membership, TLS passthrough, health check, route, DNS, or certificate SAN is incorrect. | Load balancer configuration, HTTPS `/healthz` per backend, and ACP workload-cluster port requirements. |
@@ -541,6 +569,7 @@ For the full operator-side state machine reference (every condition reason and r
 After creating a cluster:
 
 - [Manage Nodes](../manage-nodes/bare-metal.mdx)
+- [Manage Data Disks](../how-to/manage-bare-metal-storage.mdx)
 - [Upgrade Cluster](../upgrade-cluster/bare-metal.mdx)
 
 ---

--- a/docs/en/how-to/manage-bare-metal-storage.mdx
+++ b/docs/en/how-to/manage-bare-metal-storage.mdx
@@ -1,0 +1,351 @@
+---
+weight: 27
+title: Manage Data Disks on Bare-Metal Hosts
+author: gangwang@alauda.io
+category: howto
+queries:
+  - manage bare metal data disks
+  - machineinventory storage
+  - initialize blank disk bare metal
+  - adopt existing filesystem bare metal
+  - persistent data disk bare metal
+---
+
+# Manage Data Disks on Bare-Metal Hosts
+
+Use `MachineInventory.spec.storage` to manage data disks that are already attached to a bare-metal host. The storage declaration belongs to the long-lived `MachineInventory`, not to a temporary Cluster API `Machine`, so the provider can retain the filesystem and data when a node is removed and later reuse the same inventory.
+
+This feature does not create, attach, detach, migrate, back up, or replicate physical disks or SAN LUNs. It manages only the devices explicitly listed in `spec.storage.volumes[]`. Every unlisted device remains observed but unmanaged.
+
+:::danger
+**`InitializeIfBlank` can format a disk**
+
+Use `InitializeIfBlank` only after you have verified the exact stable device ID on the target inventory, confirmed that the device is a disposable blank data disk, and backed up any important data independently. Never copy a device ID from another host and never use `/dev/sdX`, `/dev/vdX`, `/dev/nvmeXnY`, or `/dev/mapper/mpathX` as persistent identities.
+:::
+
+## Availability and Upgrade Boundary
+
+Managed storage requires all three components from a compatible Bare Metal Storage release:
+
+- The Bare Metal provider, including its storage controller and fail-closed `MachineInventory` admission webhooks.
+- The matching `elemental-operator` CRD and observer API.
+- A host OS image that installs and enables `elemental-storage-observer.service` and the early-boot storage integration.
+
+:::warning
+Obtain the matching `base-image` and `base-image-iso` from Alauda technical support before enabling managed storage. Use `base-image` for host reprovisioning and `base-image-iso` for `SeedImage` / live installation. These images are a supported pair for the target release; do not derive one image reference from the other or substitute an independently built image.
+:::
+
+Upgrading only the provider and `elemental-operator` on the `global` cluster does not install the observer service on hosts that were created from an older OS image.
+
+- An existing cluster can remain on unmanaged storage after the management-side upgrade when `spec.storage` stays absent or has `volumes: []`. This path does not create storage plans or modify disks.
+- To enable managed storage on an older host, first reinstall, reset, or replace that host with an approved observer-capable image. Confirm the observer service and a fresh `status.observedStorage` report before adding any non-empty storage declaration.
+- Do not add `spec.storage.volumes[]` to a running or allocated inventory. Storage declarations can change only while the inventory is unallocated and all managed volumes are inactive.
+
+## Storage Lifecycle
+
+| Stage | Trigger | Expected state | Host behavior |
+|---|---|---|---|
+| Observe | The host registers and the observer reports devices. | `Unmanaged` or `Observed` | Read-only discovery; no device is selected automatically. |
+| Prepare | An operator saves a non-empty storage declaration on an available inventory. | `Prepared`, `StoragePrepared=True` | Adopt an existing filesystem or initialize an explicitly authorized blank device. Business paths remain unmounted. |
+| Activate | Cluster API allocates the prepared inventory to a `BaremetalMachine`. | `Active`, `StorageActive=True` | The reprovision plan installs activation state; required mount units start before kubelet. |
+| Deactivate | The owning Cluster API `Machine` is deleted. | `Prepared`, `StorageActive=False` | The clean plan unmounts managed volumes. Filesystems, storage ownership, and data remain. |
+| Release | Volumes are removed from `spec.storage` while the inventory is available and inactive. | `Unmanaged`, `StoragePrepared=True/NoManagedVolumes` | Storage ownership and activation metadata are removed without wiping the filesystem or data. |
+
+Deleting a Machine performs **Deactivate**, not Release. A normal scale-down therefore preserves the inventory's storage declaration and data for later reuse.
+
+## Prerequisites
+
+1. Install a Bare Metal provider release that includes Storage support and wait for its manager deployment and admission webhooks to become Ready.
+2. Obtain the matching observer-capable `base-image` and `base-image-iso` from Alauda technical support. Use the ISO image to install the host and configure the paired base image for later reprovisioning.
+3. Keep the target `MachineInventory` outside production pools until Prepare succeeds. It must be `Ready=True`, unallocated, and have a default plan Secret.
+4. Back up existing data independently. Storage retention is not an application-consistent backup.
+5. Obtain the `storagectl` binary built from the exact same provider revision. `storagectl` reuses the provider's normalization, validation, and hash code; do not calculate the initialization approval hash by hand or use a binary from another release.
+6. The identity that submits `InitializeIfBlank` must be authorized for `update` on the virtual `machineinventories/storageinitialize` subresource. Pure `Adopt` declarations do not require this additional permission.
+
+Set operation-specific variables:
+
+```bash
+export BM_NS=cpaas-system
+export BM_INVENTORY='<machineinventory-name>'
+export BM_STORAGECTL='<path-to-matching-storagectl>'
+export BM_STORAGE_FILE=/tmp/baremetal-storage.yaml
+export BM_INVENTORY_FILE=/tmp/baremetal-machineinventory.json
+export BM_PATCH_FILE=/tmp/baremetal-storage.patch.json
+```
+
+Verify the management components and authorization:
+
+```bash
+kubectl -n "$BM_NS" rollout status \
+  deployment/cluster-api-provider-baremetal-manager --timeout=5m
+kubectl get mutatingwebhookconfiguration \
+  cluster-api-provider-baremetal-mutating-webhook-configuration
+kubectl get validatingwebhookconfiguration \
+  cluster-api-provider-baremetal-validating-webhook-configuration
+kubectl auth can-i update machineinventories.elemental.cattle.io \
+  --subresource=storageinitialize -n "$BM_NS"
+```
+
+The final command must return `yes` before the identity can submit or change an initialization approval. Grant this permission only to the specific administrative user or ServiceAccount that is authorized to format disks.
+
+## Step 1: Verify the Inventory and Observer
+
+Confirm that the inventory is available and has no current owner:
+
+```bash
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" \
+  -o jsonpath='uid={.metadata.uid}{"\n"}allocation={.metadata.annotations.baremetal\.alauda\.io/allocation-state}{"\n"}baremetalMachine={.metadata.annotations.baremetal\.alauda\.io/owner-baremetalmachine}{"\n"}machine={.metadata.annotations.baremetal\.alauda\.io/owner-machine}{"\n"}cluster={.metadata.annotations.baremetal\.alauda\.io/owner-cluster}{"\n"}plan={.status.plan.secretRef.name}{"\n"}'
+```
+
+The allocation value must be empty or `Available`; all owner values must be empty. If the inventory is allocated, delete the owning CAPI Machine and wait for the normal clean and Deactivate flow. Do not remove owner annotations or finalizers manually.
+
+On the host, verify the observer:
+
+```bash
+sudo systemctl is-enabled elemental-storage-observer.service
+sudo systemctl is-active elemental-storage-observer.service
+sudo systemctl cat elemental-storage-observer.service
+```
+
+Both state commands must succeed. On the `global` cluster, inspect the observation watermark and device facts:
+
+```bash
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" \
+  -o jsonpath='{.status.observedStorage.observedAt}{" epoch="}{.status.observedStorage.reportEpoch}{" sequence="}{.status.observedStorage.sequence}{" bootID="}{.status.observedStorage.bootID}{"\n"}'
+
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" -o json \
+  | jq -r '.status.observedStorage.devices[] |
+      [.id,.kind,.systemRole,(.sizeBytes|tostring),(.filesystem.type//"-"),
+       (.filesystem.uuid//"-"),([.mounts[].path]|join(",")),
+       ((.health.activePaths//0)|tostring),((.health.totalPaths//0)|tostring)] | @tsv'
+```
+
+Use only a device whose report is fresh and whose `systemRole` is `Data`.
+
+| Device kind | Stable ID | Supported policy |
+|---|---|---|
+| Direct disk | `wwn:`, `nvme-eui:`, `nvme-nguid:`, or an observer-approved `serial:` ID | `Adopt` or `InitializeIfBlank` |
+| Existing partition | `partuuid:` | `Adopt` only |
+| Multipath aggregate map | `wwid:` | `Adopt`, or `InitializeIfBlank` when the whole map is blank |
+
+Do not select a system or `Unknown` device, a multipath member, a read-only or removable device, or a device with an unexpected partition table, filesystem, LVM, RAID, LUKS, swap, consumer, or mount. Do not select both a whole disk and one of its partitions.
+
+## Step 2: Define the Managed Volumes
+
+Create a storage declaration. The example intentionally uses placeholders; replace every device ID, UUID, capacity, and mount path with facts from the same target inventory. Remove any volume that does not apply to the host.
+
+```yaml title="baremetal-storage.yaml"
+storage:
+  retryNonce: 0
+  volumes:
+    - name: cpaas-data
+      source:
+        deviceID: <blank-direct-disk-id>
+        minimumSize: 100Gi
+      filesystem:
+        policy: InitializeIfBlank
+        type: xfs
+      mount:
+        path: /var/cpaas
+        required: true
+        options:
+          - noatime
+
+    - name: application-data
+      source:
+        deviceID: <existing-partition-id>
+        minimumSize: 100Gi
+      filesystem:
+        policy: Adopt
+        type: ext4
+        expectedUUID: <existing-filesystem-uuid>
+      mount:
+        path: /data/application
+        required: true
+
+    - name: registry-data
+      source:
+        deviceID: <multipath-map-id>
+        multipath:
+          minimumActivePaths: 2
+      filesystem:
+        policy: Adopt
+        type: xfs
+        expectedUUID: <existing-filesystem-uuid>
+      mount:
+        path: /srv/registry
+        required: true
+        options:
+          - noatime
+```
+
+Storage v2 supports at most 32 volumes per inventory. The first version supports whole-device XFS or ext4, existing XFS/ext4 partitions through `Adopt`, and whole multipath maps. It does not create partitions or manage LVM, mdraid, LUKS, swap, shared-cluster filesystems, or multi-host read/write access.
+
+`required` defaults to `true`. An optional volume is still prepared and activated; only its failure-to-Ready behavior changes. `/var/cpaas` must always be required. The provider adds `nodev,nosuid` to managed mounts and validates every extra mount option against an allowlist.
+
+Validate the declaration locally:
+
+```bash
+"$BM_STORAGECTL" hash --storage "$BM_STORAGE_FILE"
+```
+
+## Step 3: Render and Apply an Atomic Patch
+
+Always start from a current live object so the patch contains the latest UID and `resourceVersion`:
+
+```bash
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" -o json \
+  >"$BM_INVENTORY_FILE"
+```
+
+For a declaration that contains `InitializeIfBlank`, choose a positive counter strictly greater than `status.storage.lastConsumedInitializationApprovalCounter` and render the patch:
+
+```bash
+jq '.status.storage.lastConsumedInitializationApprovalCounter // 0' \
+  "$BM_INVENTORY_FILE"
+
+"$BM_STORAGECTL" render-patch \
+  --inventory "$BM_INVENTORY_FILE" \
+  --storage "$BM_STORAGE_FILE" \
+  --counter <next-initialization-counter> \
+  >"$BM_PATCH_FILE"
+```
+
+The generated merge patch binds the approval to the current Inventory UID, normalized storage hash, counter, and `resourceVersion`. For an `Adopt`-only declaration, omit `--counter`.
+
+Run a server-side dry-run, inspect the resulting `spec.storage`, device IDs, paths, and approval one more time, and only then apply it:
+
+```bash
+kubectl -n "$BM_NS" patch machineinventory.elemental.cattle.io "$BM_INVENTORY" \
+  --type=merge --patch-file="$BM_PATCH_FILE" --dry-run=server -o yaml
+
+kubectl -n "$BM_NS" patch machineinventory.elemental.cattle.io "$BM_INVENTORY" \
+  --type=merge --patch-file="$BM_PATCH_FILE"
+```
+
+If the API reports a `resourceVersion` conflict, fetch the inventory again, regenerate the patch, repeat the server dry-run, and then apply. Never remove `resourceVersion` from the generated patch.
+
+## Step 4: Wait for Prepare
+
+Watch the storage state:
+
+```bash
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" -w
+
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" -o json \
+  | jq '.status.storage | {
+      phase,appliedSpecHash,pendingSpecHash,
+      lastConsumedInitializationApprovalCounter,conditions,appliedVolumes,operation}'
+```
+
+Before the inventory can be allocated, the expected result is:
+
+```text
+phase=Prepared
+StoragePrepared=True/AllRequiredVolumesPrepared
+StorageActive=False/Inactive
+operation=null
+```
+
+At this stage, initialized volumes have filesystem UUIDs and adopted volumes retain their original UUIDs, but the business mount paths are not active. Do not add the inventory to a production `MachineInventoryPool` until Prepare has completed.
+
+## Step 5: Allocate and Verify Activation
+
+Add the prepared inventory to the intended `MachineInventoryPool`, then create or scale the CAPI machine group as described in [Creating Clusters on Bare Metal](../create-cluster/bare-metal.mdx) and [Managing Nodes on Bare Metal](../manage-nodes/bare-metal.mdx).
+
+After reprovisioning completes, verify both the machine and storage state:
+
+```bash
+kubectl -n "$BM_NS" get baremetalmachines.infrastructure.cluster.x-k8s.io -o json \
+  | jq -r --arg inventory "$BM_INVENTORY" \
+      '.items[] | select(.status.machineInventoryRef.name==$inventory) |
+       [.metadata.name,.status.phase,.status.ready,
+        ([.status.conditions[]|select(.type=="StorageReady")|(.status+"/"+.reason)]|join(","))] | @tsv'
+
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" -o json \
+  | jq '.status.storage | {phase,conditions,appliedVolumes,operation}'
+```
+
+The expected result is `BaremetalMachine.status.phase=Running`, `StorageReady=True/AllVolumesReady`, `MachineInventory.status.storage.phase=Active`, and `StorageActive=True/AllRequiredVolumesActive`.
+
+On the host, confirm each source UUID, filesystem type, mount path, and mount options. Required mount units must enter active state before kubelet:
+
+```bash
+sudo findmnt --mountpoint /var/cpaas
+sudo systemctl is-active "$(systemd-escape --path --suffix=mount /var/cpaas)"
+sudo systemctl show "$(systemd-escape --path --suffix=mount /var/cpaas)" \
+  -p ActiveEnterTimestamp
+sudo systemctl show kubelet.service -p ActiveEnterTimestamp
+```
+
+## Step 6: Scale Down and Reuse the Inventory
+
+Delete the owning CAPI `Machine` through the normal scale-down or replacement workflow. Do not delete the `MachineInventory` and do not remove its storage finalizer.
+
+After drain, clean, and Deactivate complete, expect:
+
+```text
+allocation-state=Available
+status.storage.phase=Prepared
+StoragePrepared=True
+StorageActive=False/Inactive
+business mount paths are inactive
+filesystem UUIDs and data are retained
+```
+
+When the same inventory is allocated again, Activate reuses the existing ownership record and filesystem UUID; it does not format the device again. Generic pool allocation does not guarantee that a replacement Machine receives the same inventory. If an application must return to host-local data on a specific inventory, place that inventory first in a controlled ordered pool or use a dedicated pool and verify the selected `BaremetalMachine.status.machineInventoryRef` before relying on the data.
+
+## Step 7: Release Storage Ownership
+
+Release a volume only while the inventory is unallocated and inactive. Removing a volume is non-destructive: it removes Storage v2 ownership and activation metadata but preserves the filesystem UUID and data.
+
+To release all volumes, create an explicit empty declaration:
+
+```yaml title="baremetal-storage-empty.yaml"
+storage:
+  volumes: []
+```
+
+Fetch the live inventory and render, dry-run, and apply a patch without an initialization counter:
+
+```bash
+kubectl -n "$BM_NS" get machineinventory.elemental.cattle.io "$BM_INVENTORY" -o json \
+  >"$BM_INVENTORY_FILE"
+
+"$BM_STORAGECTL" render-patch \
+  --inventory "$BM_INVENTORY_FILE" \
+  --storage /tmp/baremetal-storage-empty.yaml \
+  >"$BM_PATCH_FILE"
+
+kubectl -n "$BM_NS" patch machineinventory.elemental.cattle.io "$BM_INVENTORY" \
+  --type=merge --patch-file="$BM_PATCH_FILE" --dry-run=server -o yaml
+kubectl -n "$BM_NS" patch machineinventory.elemental.cattle.io "$BM_INVENTORY" \
+  --type=merge --patch-file="$BM_PATCH_FILE"
+```
+
+Wait for `phase=Unmanaged`, `StoragePrepared=True/NoManagedVolumes`, an empty `appliedVolumes[]`, and `operation=null`. Verify retained data with a read-only mount when required. A storage finalizer may remain on the live inventory so a later object deletion still follows the correct cleanup order; do not remove it manually.
+
+## Failed Operations and Retry
+
+Storage operations fail closed. A required device that is missing, stale, busy, too small, degraded, mounted from an unknown source, or no longer matches its declared UUID prevents allocation or Machine readiness. The controller never selects a replacement disk automatically.
+
+After correcting the external cause of an operation whose `status.storage.operation.phase` is `Failed`, increment `spec.storage.retryNonce` while keeping `volumes[]` unchanged and render a new patch with `storagectl`. `retryNonce` creates another execution attempt for the same logical operation. It does not authorize a first format, bypass preflight, or permit a different storage declaration.
+
+Do not use retry as a recovery mechanism for an unknown or partially mutated declaration. When `pendingSpecHash` is non-empty or the failed operation reports `mutationState=DurableStateChanged` or `Unknown`, keep the original declaration and allow the same operation journal to converge. Contact technical support before considering any break-glass finalizer or ownership action.
+
+## Restrictions
+
+- `volumes[]` cannot change while the inventory is allocated or any managed volume is active.
+- A prepared volume's `deviceID`, filesystem policy/type, or name cannot be changed in place. Release the old volume first, wait for completion, and then add the replacement declaration.
+- Storage v2 does not move data between inventories. Inventory-owned data stays with the physical host or LUN identified by that inventory.
+- Multipath support manages the aggregate `wwid:` map only. It does not configure multipath, SAN zoning, LUN masking, fencing, or multi-host read/write filesystems.
+- `/var/lib/kubelet`, `/var/lib/containerd`, `/var/lib/etcd`, `/etc`, `/usr`, `/boot`, and other system paths are protected. Use business paths such as `/var/cpaas`, `/data/*`, `/srv/*`, or `/mnt/*` that do not overlap protected paths.
+- Do not manage the same device or path through both `MachineInventory.spec.storage` and kubeadm/cloud-init `disk_setup`, `fs_setup`, `mounts`, custom systemd units, or host scripts.
+
+## Related Documentation
+
+- [Bare Metal Provider](../overview/providers/bare-metal.mdx)
+- [Creating Clusters on Bare Metal](../create-cluster/bare-metal.mdx)
+- [Managing Nodes on Bare Metal](../manage-nodes/bare-metal.mdx)
+- [Upgrading Clusters on Bare Metal](../upgrade-cluster/bare-metal.mdx)
+- [MachineInventory API](../apis/providers/bare-metal/machineinventory.mdx)

--- a/docs/en/manage-nodes/bare-metal.mdx
+++ b/docs/en/manage-nodes/bare-metal.mdx
@@ -22,6 +22,7 @@ This document explains how to deploy worker nodes, scale them up and down, repla
 - The control plane must already be running. See [Create Cluster](../create-cluster/bare-metal.mdx).
 - The worker `MachineInventoryPool` must contain at least as many `Available` inventories as the target replica count, plus the headroom required by the rollout strategy.
 - The target `Machine.spec.version` must be a key in the `elemental-image-catalog` ConfigMap.
+- Any inventory with non-empty `spec.storage.volumes[]` must already report `status.storage.phase=Prepared` and `StoragePrepared=True` before it can count as `Available`. Follow [Manage Data Disks on Bare-Metal Hosts](../how-to/manage-bare-metal-storage.mdx) before adding a newly registered storage-managed inventory to the worker pool.
 :::
 
 :::info
@@ -43,6 +44,8 @@ The four resources that compose a worker node group:
 3. **`KubeadmConfigTemplate`** (`<cluster-name>-worker-bootstrap`) — cloud-init `user-data` for `kubeadm join`. The bare-metal provider normalizes this user-data at reprovision time (hostname, `provider-id`, `criSocket`); operators should not pre-fill those fields.
 4. **`MachineDeployment`** — controls replica count, version, rollout strategy.
 
+Managed data disks are not part of `BaremetalMachineTemplate`. Their declaration and retained data belong to each long-lived `MachineInventory`, so two members of the same worker pool may expose different host-local datasets unless operators standardize and verify their storage declarations.
+
 The Cluster API contract for templates: the running `Machine` set keeps an in-memory snapshot of the previous template, so editing a template in place does **not** trigger a rollout. Worker upgrades create a new `BaremetalMachineTemplate` and patch `MachineDeployment.spec.template.spec.infrastructureRef.name` to point at it.
 
 ## Worker Node Deployment \{#worker-node-deployment}
@@ -53,7 +56,7 @@ The Cluster API contract for templates: the running `Machine` set keeps an in-me
 kubectl -n cpaas-system get machineinventorypools.infrastructure.cluster.x-k8s.io <cluster-name>-worker-pool
 ```
 
-`status.available` must be at least the target replica count. If you need additional capacity, register more hosts (boot the `SeedImage` ISO on them — see [Create Cluster → Step 1](../create-cluster/bare-metal.mdx#step-1-machineregistration-seedimage)) and add their `MachineInventory` names to `spec.machineInventories`.
+`status.available` must be at least the target replica count. If you need additional capacity, register more hosts (boot the `SeedImage` ISO on them — see [Create Cluster → Step 1](../create-cluster/bare-metal.mdx#step-1-machineregistration-seedimage)), prepare any managed storage while each inventory is still unallocated, and then add their names to `spec.machineInventories`.
 
 ### Step 2: Configure the Worker `BaremetalMachineTemplate`
 
@@ -198,7 +201,7 @@ kubectl get nodes -o wide                     # workload cluster
 
 **Prerequisites**:
 
-- The worker pool has enough `Available` inventories. If not, register the additional hosts (boot the SeedImage ISO and confirm the new `MachineInventory` objects) and append them to `MachineInventoryPool.spec.machineInventories[]`.
+- The worker pool has enough `Available` inventories. If not, register the additional hosts (boot the SeedImage ISO and confirm the new `MachineInventory` objects), prepare any managed storage, and append them to `MachineInventoryPool.spec.machineInventories[]`.
 
 **Procedure**:
 
@@ -219,7 +222,7 @@ kubectl get nodes -o wide                     # workload cluster
    kubectl -n cpaas-system edit machineinventorypool <cluster-name>-worker-pool
    ```
 
-   Append the new `MachineInventory` names — they must already be registered and Ready. Save and exit; the pool reconciler picks up the change and increases `status.total` and `status.available`.
+   Append the new `MachineInventory` names — they must already be registered and Ready. Inventories with managed volumes must also be Prepared; otherwise they increase `status.total` but remain unavailable for allocation. Save and exit, then confirm the expected increase in `status.available`.
 
 3. **Scale up the `MachineDeployment`**
 
@@ -249,7 +252,7 @@ Two strategies are supported, identical in shape to the upstream Cluster API con
 :::info
 **Inventory recycling**
 
-A `clean` plan stops kubelet, clears CRI workload, and stops containerd. It does **not** wipe Kubernetes persistent directories or reset the OS — that work happens later, when the same or a different inventory is picked for a new `BaremetalMachine` and runs the `reprovision` plan. Until then, the inventory returns to `Available` and may be allocated to another cluster.
+A `clean` plan stops kubelet, deactivates declared storage mounts, clears CRI workload, and stops containerd. It does **not** wipe managed filesystems, Kubernetes persistent directories, or reset the OS — OS cleanup happens later, when the same or a different inventory is picked for a new `BaremetalMachine` and runs the `reprovision` plan. Until then, the inventory returns to `Available` and may be allocated again. Deleting a Machine performs **Deactivate**, not storage Release, so the storage declaration, filesystem UUIDs, and data remain on that inventory.
 :::
 
 ##### Random Removal
@@ -295,11 +298,11 @@ CAPI selects machines for deletion in its standard order. Each selected `Baremet
    kubectl -n cpaas-system get machineinventories.elemental.cattle.io <inventory-name> -o yaml
    ```
 
-   The released inventory must show `baremetal.alauda.io/allocation-state=Available`, the `baremetal.alauda.io/owner-*` annotations must be cleared, and the pool annotation must remain. `MachineInventory` itself is **not** deleted.
+   The released inventory must show `baremetal.alauda.io/allocation-state=Available`, the `baremetal.alauda.io/owner-*` annotations must be cleared, and the pool annotation must remain. `MachineInventory` itself is **not** deleted. If it declares managed volumes, it must return to `status.storage.phase=Prepared` with `StorageActive=False/Inactive`; its business mount paths must be inactive while filesystem UUIDs and data remain unchanged.
 
 ### Replacing a Single Failed Node \{#replacing-a-node}
 
-If a `BaremetalMachine` lands in `Failed`, the safest recovery is to delete the failed `Machine`. CAPI immediately creates a replacement `Machine` (because `replicas` did not change), and the bare-metal provider picks an `Available` inventory from the same pool. Most often the replacement is a different `MachineInventory`; the provider does not guarantee that the freshly released inventory will be re-picked.
+If a `BaremetalMachine` lands in `Failed`, the safest recovery is to delete the failed `Machine`. CAPI immediately creates a replacement `Machine` (because `replicas` did not change), and the bare-metal provider picks an `Available` inventory from the same pool. Most often the replacement is a different `MachineInventory`; the provider does not guarantee that the freshly released inventory will be re-picked. Host-local managed data does not follow the replacement Machine. If the application must reuse a specific inventory's data, use a dedicated or deliberately ordered pool and verify `BaremetalMachine.status.machineInventoryRef` before relying on that data.
 
 ```bash
 kubectl -n cpaas-system delete machine <machine-name>
@@ -310,7 +313,7 @@ Investigate the original failure separately: read `BaremetalMachine.status.condi
 
 ### Upgrading Machine Infrastructure
 
-`BaremetalMachineTemplate` carries only the pool reference and allocation policy — there is no CPU / memory / disk spec to revisit. Infrastructure-side changes that require a template swap are limited to:
+`BaremetalMachineTemplate` carries only the pool reference and allocation policy — there is no CPU, memory, or disk declaration on the template. Managed storage is changed separately on an unallocated, inactive `MachineInventory`; see [Manage Data Disks on Bare-Metal Hosts](../how-to/manage-bare-metal-storage.mdx). Infrastructure-side changes that require a template swap are limited to:
 
 - Moving a `MachineDeployment` to a different pool.
 - Adjusting allocation policy (when more policies are added).
@@ -377,7 +380,7 @@ The annotations the provider maintains on each `MachineInventory` are the author
 | `baremetal.alauda.io/owner-machine` | `Machine` name | Owning Cluster API `Machine`. |
 | `baremetal.alauda.io/owner-baremetalmachine` | `BaremetalMachine` name | Owning provider machine. |
 
-Each `BaremetalMachine.status.planSecretRef` plan secret also carries `baremetal.alauda.io/plan.type=clean|reprovision` so you can distinguish which plan is currently being driven.
+Each inventory's default plan secret also carries `baremetal.alauda.io/plan.type`. Normal node lifecycle uses `clean` or `reprovision`; inventory storage reconciliation additionally uses `storage-prepare` and `storage-release`. Inspect `MachineInventory.status.storage.conditions` and `.operation` together with the plan type when diagnosing storage.
 
 ---
 
@@ -390,11 +393,13 @@ Each `BaremetalMachine.status.planSecretRef` plan secret also carries `baremetal
 | Member missing | `MachineInventoryPool.MembersValid=False / Ready=False` | Pool's `status.unavailable`, message on the failing condition |
 | Inventory not Ready | Counted toward `status.unavailable` | `MachineInventory.status.conditions[Ready]`, plan secret existence |
 | Plan secret missing | Inventory ineligible for allocation | `MachineInventory.status.plan.secretRef`, presence of the referenced Secret |
+| Storage not prepared | Inventory does not count as `Available`; `StoragePrepared=False` | `MachineInventory.status.storage`, freshness and contents of `status.observedStorage`, and `storage-prepare` plan output |
 | Bootstrap secret missing | `BootstrapReady=False / Reason=BootstrapWaiting` | `Machine.spec.bootstrap.dataSecretName` |
 | Catalog miss | `BaremetalMachine` `Failed`, `ImageResolved=False / Reason=ImageCatalogMiss`, no plan written | `elemental-image-catalog` keys |
 | Registry annotation missing | `ImageResolved=False / Reason=ImageRegistryMissing` | `Cluster.metadata.annotations["cpaas.io/registry-address"]` |
 | Reprovision plan failed | `BaremetalMachine` `Failed`, inventory marked `Unavailable` | Plan secret `failed-output`; host serial console; reachable platform registry |
-| Clean plan failed | Deletion blocked by finalizer; inventory marked `Unavailable` | Same as above, focused on `clean` plan output |
+| Managed volume activation failed | `BaremetalMachine` `StorageReady=False`; node readiness is blocked for a required volume | Stable device identity, filesystem UUID, mount unit, fresh post-reboot observation, and plan `failed-output` |
+| Clean or Deactivate failed | Deletion blocked by finalizer; inventory marked `Unavailable` | `clean` plan output, host mounts, and `MachineInventory.status.storage.operation` |
 
 For the full operator-side state machine reference, see [Provider Overview → BaremetalMachine](../overview/providers/bare-metal.mdx#baremetalmachine).
 
@@ -403,4 +408,5 @@ For the full operator-side state machine reference, see [Provider Overview → B
 ## Next Steps
 
 - [Create Clusters](../create-cluster/bare-metal.mdx)
+- [Manage Data Disks](../how-to/manage-bare-metal-storage.mdx)
 - [Upgrade Clusters](../upgrade-cluster/bare-metal.mdx)

--- a/docs/en/overview/providers/bare-metal.mdx
+++ b/docs/en/overview/providers/bare-metal.mdx
@@ -33,6 +33,7 @@ The provider currently follows a YAML-only workflow. There is no Fleet Essential
 - **Image-catalog driven Kubernetes versions** — the provider keeps a cluster-scoped `elemental-image-catalog` ConfigMap that maps `Machine.spec.version` to an `elemental upgrade` image. Upgrades become "patch the version, controller resolves the matching image, reprovisions the node."
 - **Two control-plane endpoint modes** — `BaremetalCluster.spec.controlPlaneLoadBalancer.type: Internal` deploys Alive (keepalived + IPVS + `kube-lock` Lease arbitration) and reconciles the Self-built VIP. `External` skips Alive and uses a pre-provisioned Layer 4 TCP LoadBalancer whose backends are maintained outside the cluster. See [Plan the Control Plane Endpoint](../../how-to/control-plane-endpoint.mdx).
 - **Network identity preservation** — `elemental-register` reports the live-ISO observed network as `MachineInventory.spec.observedNetwork`. The first `elemental install` and every later `reprovision` plan replay that snapshot as cloud-init `network-config v2`, so a host keeps its address, default route, and DNS across the entire lifecycle.
+- **Inventory-owned managed data disks** — an operator can declare up to 32 XFS or ext4 data volumes in `MachineInventory.spec.storage`. The provider prepares them before allocation, activates their mount units before kubelet during reprovision, deactivates them during node removal, and preserves their filesystems and data for reuse of the same inventory. See [Manage Data Disks on Bare-Metal Hosts](../../how-to/manage-bare-metal-storage.mdx).
 
 ## Differences from VM-Based Providers
 
@@ -41,7 +42,7 @@ The provider currently follows a YAML-only workflow. There is no Fleet Essential
 | Node creation | Clone a VM template from a credential-scoped platform | Reprovision an already-installed physical host via `elemental upgrade` |
 | Node deletion | Power-off and delete the VM | Run `clean` plan; host stays in inventory and returns to pool |
 | Pool model | IP pool / hostname pool sized per replica | `MachineInventoryPool` listing concrete `MachineInventory` names |
-| Data on the node | System and template disks recreated on every replacement; declared persistent disks survive (DCS) | `elemental upgrade` snapshot model — `initramfs` clears Kubernetes persistent state; pool-managed persistent disks are not part of this provider |
+| Data on the node | System and template disks recreated on every replacement; declared persistent disks survive (DCS) | `initramfs` clears Kubernetes-managed system state on every reprovision. Data volumes explicitly declared on the long-lived `MachineInventory` can retain their filesystems and data, but the data stays with that inventory and does not follow a replacement `Machine` automatically. |
 | Recovery time | Minutes per replacement | Minutes per `elemental upgrade` + reboot |
 | First install path | One-off VM template upload by the platform admin | Live ISO built by `SeedImage`, booted on the host, `elemental install` to disk |
 | Control-plane LB | External LB supplied by operator | Internal LB managed by `alive` static pods on the control-plane nodes (External LB supported through `type: External`) |
@@ -71,12 +72,15 @@ Triggers `elemental-operator` to build a bootable ISO that contains the registra
 
 #### `MachineInventory` \{#machineinventory}
 
-The long-lived host identity object. The provider only relies on the following parts of its contract:
+The long-lived host identity object. The provider relies on the following parts of its contract:
 
 - `status.plan.secretRef` — the single default plan secret owned by `elemental-operator`.
 - `status.plan.state` — `Applied` / `Failed` transitions used to drive the `BaremetalMachine` state machine.
 - `status.conditions` — host-side readiness signals.
 - `spec.observedNetwork` — fork-only field populated by `elemental-register` from the live-ISO NICs; replayed during install and during every `reprovision` plan.
+- `spec.storage` — optional operator-authored declaration of inventory-owned data volumes.
+- `status.observedStorage` — objective device, filesystem, mount, and multipath facts reported by `elemental-storage-observer.service` on the host.
+- `status.storage` — provider-owned Prepare / Activate / Deactivate / Release state, operation journal, conditions, and applied-volume identities.
 
 The provider never deletes a `MachineInventory`, never uses `MachineInventorySelector`, and does not run a separate `MachineInventoryLifecycleController` — that lifecycle remains with `elemental-operator`.
 
@@ -116,16 +120,18 @@ Phase transitions: `Pending → Allocated → Reprovisioning → Running`; delet
 
 A cluster-scoped `ConfigMap` (default name `elemental-image-catalog` in `cpaas-system`) that maps `Machine.spec.version` to an `elemental upgrade` image. The bare-metal provider chart renders this ConfigMap from `provider.imageCatalog.images` (`global.registry.address` is prepended to each repository) and from `provider.imageCatalog.data` (for fully-qualified overrides such as digest-pinned images). The reconciler hot-reloads the ConfigMap; a missing key is a terminal `Failed` state, not a fallback to a default image.
 
-The image catalog also drives `SeedImage.spec.baseImage`: the ISO variant is the same repository with `-iso` appended and the same tag/digest as the catalog entry.
+Obtain the matching `base-image` and `base-image-iso` references from Alauda technical support. The image catalog uses `base-image` for reprovisioning, while `SeedImage.spec.baseImage` uses `base-image-iso` for live installation. Do not derive one reference from the other or substitute an independently built image.
 
-#### `clean` and `reprovision` plans \{#clean-reprovision}
+#### Host lifecycle plans \{#clean-reprovision}
 
-The only two plan types the provider writes into `MachineInventory.spec.plan` (annotated with `baremetal.alauda.io/plan.type=clean|reprovision`):
+The provider serializes all host work through the inventory's single default plan secret. The secret's `baremetal.alauda.io/plan.type` annotation identifies the current lifecycle plan:
 
-- **`reprovision`** — runs on node attach. Writes NoCloud `user-data` / `meta-data` (and, when `MachineInventory.spec.observedNetwork` is non-empty, `network-config` v2), writes a cleanup marker, runs `cloud-init clean --logs --seed`, runs `elemental upgrade --reboot=false --system <image>`, and triggers a delayed reboot. After reboot, `initramfs` clears `/var/lib/kubelet`, `/var/lib/containerd`, `/var/lib/etcd`, `/etc/kubernetes`; cloud-init re-runs and performs `kubeadm init` / `kubeadm join`.
-- **`clean`** — runs on node detach. Stops `kubelet`, clears CRI workload, stops `containerd`. It explicitly **does not** run `kubeadm reset`, `cloud-init clean`, or `elemental upgrade`, and it does not reboot. Real cleanup is deferred to the `reprovision` plan that runs when the host is re-allocated.
+- **`storage-prepare`** — runs while an inventory is available and before allocation. It preflights every declared volume, then adopts an existing matching filesystem or initializes an explicitly authorized blank device. It does not mount business paths.
+- **`reprovision`** — runs on node attach. It embeds managed-volume activation, writes NoCloud `user-data` / `meta-data` (and, when `MachineInventory.spec.observedNetwork` is non-empty, `network-config` v2), writes a cleanup marker, runs `cloud-init clean --logs --seed`, runs `elemental upgrade --reboot=false --system <image>`, and triggers a delayed reboot. After reboot, `initramfs` clears `/var/lib/kubelet`, `/var/lib/containerd`, `/var/lib/etcd`, and `/etc/kubernetes`; managed mount units start before kubelet, and cloud-init performs `kubeadm init` / `kubeadm join`.
+- **`clean`** — runs on node detach. It stops kubelet, deactivates managed mounts, clears CRI workload, and stops containerd. It explicitly **does not** wipe managed filesystems, run `kubeadm reset`, run `cloud-init clean`, run `elemental upgrade`, or reboot. OS cleanup is deferred to the next `reprovision` plan.
+- **`storage-release`** — runs only while an inventory is available and all managed volumes are inactive. It removes provider ownership and activation metadata for volumes removed from `spec.storage` without wiping their filesystems or data.
 
-The provider applies the plans through the upstream "single default plan secret" semantics; it does not use `MachineInventorySelector` or `FleetBundle`.
+The provider does not use `MachineInventorySelector` or `FleetBundle`. Storage lifecycle details, safety gates, and examples are documented in [Manage Data Disks on Bare-Metal Hosts](../../how-to/manage-bare-metal-storage.mdx).
 
 #### `alive` (control-plane HA) \{#alive}
 
@@ -164,6 +170,7 @@ The bare-metal provider enforces that support decision through `elemental-image-
 - A control-plane VIP, free port (typically `6443`), and a `vrid` unique within the control-plane Layer-2 broadcast domain.
 - One `MachineInventoryPool` per role (control plane, worker) sized to at least the target replica count plus headroom for upgrades.
 - A host with a real hardware TPM (`/dev/tpm0`) can register with `emulate-tpm: false`. Any host without a hardware TPM — virtual machines and physical servers that ship without a TPM module alike — must set `MachineRegistration.spec.config.elemental.registration.emulate-tpm: true`; the physical-versus-virtual distinction does not apply.
+- Managed data disks additionally require an observer-capable host OS image with `elemental-storage-observer.service` enabled. Upgrading only the management-side provider and `elemental-operator` does not add this service to hosts installed from an older image.
 
 ## Documentation
 
@@ -172,5 +179,6 @@ For detailed instructions on using the bare-metal provider, see:
 - [Installation](../../install/bare-metal.mdx)
 - [Creating Clusters](../../create-cluster/bare-metal.mdx)
 - [Managing Nodes](../../manage-nodes/bare-metal.mdx)
+- [Managing Data Disks](../../how-to/manage-bare-metal-storage.mdx)
 - [Upgrading Clusters](../../upgrade-cluster/bare-metal.mdx)
 - [API Reference](../../apis/providers/bare-metal/)

--- a/docs/en/upgrade-cluster/bare-metal.mdx
+++ b/docs/en/upgrade-cluster/bare-metal.mdx
@@ -33,15 +33,16 @@ Bare-metal upgrades replace every node — they do not run `kubeadm upgrade` on 
 
 1. CAPI deletes one `Machine` according to the rollout strategy.
 2. The provider writes a `clean` plan to the inventory's plan secret.
-3. The host stops kubelet + CRI workload + containerd, then returns to `Available` in the same pool.
+3. The host stops kubelet, deactivates any managed data mounts, clears CRI workload, stops containerd, then returns to `Available` in the same pool.
 4. CAPI creates a replacement `Machine`.
 5. The provider picks an `Available` inventory from the same pool, resolves the new Kubernetes version against `elemental-image-catalog`, and writes a `reprovision` plan.
-6. The host runs `cloud-init clean` → `elemental upgrade --system <new-image>` → reboot. `initramfs` clears Kubernetes persistent state; cloud-init re-executes and runs `kubeadm init` / `kubeadm join` against the new control plane.
+6. The host stages managed-volume activation, runs `cloud-init clean` → `elemental upgrade --system <new-image>` → reboot. `initramfs` clears Kubernetes persistent state; managed mount units start before kubelet, and cloud-init re-executes and runs `kubeadm init` / `kubeadm join` against the new control plane.
 
 Two structural consequences operators must internalize before starting:
 
-- **Bare-metal does not preserve Kubernetes-managed disk state.** `/var/lib/kubelet`, `/var/lib/containerd`, `/var/lib/etcd`, `/etc/kubernetes` are cleared by the initramfs cleanup step of every reprovision. There is no equivalent of the DCS provider's pool-managed persistent disks today.
-- **The same `MachineInventory` may not be re-picked.** The provider does not guarantee that the inventory released by a `clean` plan is the same one re-allocated to the replacement `Machine`. Replacements are performed as delete-then-add when `maxSurge=0` (no overlap between old and new node), so pool capacity sizing need only accommodate the desired replica count — old and new nodes do not coexist during the rollout.
+- **Kubernetes-managed system state is not preserved.** `/var/lib/kubelet`, `/var/lib/containerd`, `/var/lib/etcd`, and `/etc/kubernetes` are cleared by the initramfs cleanup step of every reprovision. Storage v2 does not permit these protected paths as managed data mounts.
+- **Declared data volumes can remain on an inventory.** The clean plan deactivates them without wiping their filesystems, and reprovision activates the selected inventory's prepared volumes before kubelet. This is host-local retention, not a backup or data-migration mechanism.
+- **The same `MachineInventory` may not be re-picked.** The provider does not guarantee that the inventory released by a `clean` plan is the same one re-allocated to the replacement `Machine`; data does not follow the replacement automatically. Replacements are performed as delete-then-add when `maxSurge=0` (no overlap between old and new node), so pool capacity sizing need only accommodate the desired replica count — old and new nodes do not coexist during the rollout.
 
 ## Upgrade Sequence
 
@@ -60,6 +61,18 @@ Cluster API orchestrates the rolling replacement.
 Skipping step 1 risks two failure modes: the old provider silently ignores new schema fields; or a controller image swap mid-rollout interrupts the plan secret state machine. Always settle the management-side upgrade before touching workload rollout.
 :::
 
+## Storage Compatibility Across Provider Upgrades
+
+An existing cluster created before managed storage was introduced remains compatible when `MachineInventory.spec.storage` stays absent or has `volumes: []`. In this unmanaged mode, the storage controller performs no disk operation and does not rewrite the running Machine's plan merely because the management-side provider was upgraded.
+
+This compatibility does **not** mean that managed storage can be enabled in place on every old host:
+
+- Upgrading only the provider and `elemental-operator` on the `global` cluster does not install `elemental-storage-observer.service` or early-boot storage integration into an older host OS.
+- Keep `spec.storage` empty on such hosts. To enable managed storage later, reinstall, reset, or replace the host with an approved observer-capable image, then verify the observer service and a fresh `status.observedStorage` report while the inventory is unallocated.
+- Configure and Prepare managed volumes only after those host-image prerequisites are satisfied. Do not add a non-empty storage declaration to a running or allocated inventory.
+
+For the preparation and validation procedure, see [Manage Data Disks on Bare-Metal Hosts](../how-to/manage-bare-metal-storage.mdx).
+
 ## Prerequisites
 
 Before you start, ensure all of the following prerequisites are met:
@@ -75,6 +88,7 @@ Before you start, ensure all of the following prerequisites are met:
 - The platform registry is reachable from every host in the cluster.
 - Both `KubeadmControlPlane.spec.rolloutStrategy.rollingUpdate.maxSurge = 0` and `MachineDeployment.spec.strategy.rollingUpdate.maxSurge = 0` are set — bare-metal does not over-provision physical hosts.
 - The relevant pools have enough capacity to replace one node at a time without falling below the desired replica count.
+- Every inventory with a non-empty storage declaration reports `StoragePrepared=True`, and every currently allocated inventory reports `StorageActive=True`. Record each `BaremetalMachine.status.machineInventoryRef` and the managed filesystem UUIDs before the rollout so that you can detect selection of a different inventory instead of assuming data moved with the Machine.
 
 :::info
 The default local archive under `/var/cpaas/backup` can be used for recovery; S3-compatible storage is not required. However, bare-metal replacement can make the original node-local copy unavailable, and the replacement `Machine` is not guaranteed to use the same `MachineInventory`. If your recovery design cannot guarantee access to the local archive after node replacement or failure, keep an off-node copy in S3-compatible storage or another secure location outside the node before starting Phase 2.
@@ -117,7 +131,7 @@ kubectl -n cpaas-system get configmap elemental-image-catalog -o yaml
 
 The key must include the leading `v` (for example `v1.34.5`). If the key is missing when CAPI creates the replacement `Machine`, the resulting `BaremetalMachine` enters `Failed` with `ImageResolved=False / Reason=ImageCatalogMiss` and no `reprovision` plan is written — adding the key later restarts the reconciliation automatically.
 
-When the new version corresponds to a new Alauda OS / base-image release, the ISO variant for that release should also be available before the upgrade. The bare-metal provider does not rebuild SeedImages automatically, but you may want to refresh `MachineRegistration` / `SeedImage` for **future** host onboarding so the new hosts come up on the new release. The ISO repository is the same as the base-image repository with `-iso` appended.
+When the new version corresponds to a new Alauda OS release, obtain the matching `base-image` and `base-image-iso` references from Alauda technical support. The bare-metal provider uses `base-image` for reprovisioning and does not rebuild SeedImages automatically. Before future host onboarding, refresh `MachineRegistration` / `SeedImage` with the supported `base-image-iso` reference. Do not derive one image reference from the other or substitute an independently built image.
 
 ## Upgrade Kube-OVN Before the Control Plane \{#upgrade-kube-ovn-before-the-control-plane}
 
@@ -154,10 +168,10 @@ kubectl get nodes -o wide                                                    # w
 The expected sequence on each node:
 
 1. CAPI marks one old `Machine` for deletion; corresponding `BaremetalMachine` moves to `Preparing`.
-2. The provider writes a `clean` plan; the inventory ends up `Available` with cleared owner annotations.
+2. The provider writes a `clean` plan; managed volumes are deactivated without being wiped, and the inventory ends up `Available` with cleared owner annotations and storage returned to `Prepared`.
 3. CAPI creates a new `Machine` (with the target version); a new `BaremetalMachine` is created.
 4. The provider allocates an `Available` inventory from the control-plane pool, resolves the new image, and writes a `reprovision` plan.
-5. The host runs `elemental upgrade --system <new-image>`, reboots, and `kubeadm join`s the surviving control plane. `BaremetalMachine.status.phase` becomes `Running`.
+5. The host stages activation for that selected inventory's prepared volumes, runs `elemental upgrade --system <new-image>`, reboots, starts required mount units before kubelet, and `kubeadm join`s the surviving control plane. `BaremetalMachine.status.phase` becomes `Running` only after required storage is active.
 
 Repeat steps 1–5 until every control-plane node has been replaced.
 
@@ -231,12 +245,14 @@ For each current `BaremetalMachine`, use the `INVENTORY` and `PLAN_SECRET` colum
 
 ```bash
 kubectl -n cpaas-system get machineinventories.elemental.cattle.io <inventory-name> \
-  -o jsonpath='{.status.plan.state}{"\n"}'
+  -o jsonpath='{.status.plan.state}{" storage="}{.status.storage.phase}{"\n"}'
 kubectl -n cpaas-system get secret <plan-secret-name> \
   -o jsonpath='{.metadata.annotations.baremetal\.alauda\.io/plan\.type}{"\n"}'
 ```
 
 Each referenced `MachineInventory` should report `Applied`, and each referenced plan Secret should report `reprovision`. Apply this check only to inventories referenced by the current `BaremetalMachine` objects. A spare inventory that did not participate in the rollout may have no `reprovision` plan. An inventory that completed a `clean` plan but was not selected for a replacement Machine may still report `clean`; neither case means that the rollout is incomplete.
+
+For an inventory with managed volumes, also verify `status.storage.phase=Active`, `StoragePrepared=True`, `StorageActive=True`, and `BaremetalMachine.status.conditions[StorageReady]=True/AllVolumesReady`. Compare its current filesystem UUIDs with the pre-upgrade record. A different UUID usually means a different inventory was selected; it must not be interpreted as the original data having migrated.
 
 `MachineInventoryPool.status` should satisfy `available + allocated + preparing + reprovisioning + unavailable = total` with `preparing = reprovisioning = 0`. `available` may remain greater than zero when the pool contains spare inventories; those inventories are outside the plan verification above.
 
@@ -246,6 +262,8 @@ Each referenced `MachineInventory` should report `Applied`, and each referenced 
 |---|---|
 | The Kube-OVN annotation changed but the chart name, target revision, or installed revision did not converge | Confirm that the installed Bare Metal provider is `v0.0.1` or later, then inspect the `AppRelease` conditions and provider logs. Follow the shared [Kube-OVN verification](./index.mdx#verify-the-kube-ovn-apprelease); do not patch the source manually. |
 | Rollout stuck on the first new node | `BaremetalMachine.status.conditions[ImageResolved]` — confirm the new key is in `elemental-image-catalog` and that the `Cluster` carries `cpaas.io/registry-address`. |
+| Inventory does not become allocatable after clean | Check `MachineInventory.status.storage` and `status.observedStorage`. Managed volumes must be confirmed inactive and Prepared from a fresh host observation before the inventory can return to the allocation set. |
+| Replacement Machine waits on `StorageReady` | Verify that the selected inventory is the intended one, required device IDs and filesystem UUIDs still match, required mount units are active, and the host produced a fresh post-reboot observation. |
 | Host reboots into a state that never joins the cluster | `MachineInventory.status.plan.state` (`Failed` is terminal); inspect the host's serial console for `elemental upgrade` errors. Verify the platform registry is reachable from the host. |
 | New control-plane node fails `kubeadm join` | Confirm the VIP is still reachable; `alive` may have lost the lock. Check `kubectl -n kube-system get lease`, `ipvsadm -Ln`, `keepalived` logs from the static pod. |
 | Worker rollout stalls with `MachineDeployment.spec.strategy.rollingUpdate.maxSurge > 0` set | Bare-metal pools cannot honour over-provisioning. Set `maxSurge=0` and bump `maxUnavailable` to budget more parallel replacements within the pool. |

--- a/docs/shared/crds/providers/bare-metal/elemental.cattle.io_machineinventories.yaml
+++ b/docs/shared/crds/providers/bare-metal/elemental.cattle.io_machineinventories.yaml
@@ -109,7 +109,7 @@ spec:
                   - name
                   type: object
                   x-kubernetes-map-type: atomic
-                description: IPAddressPools is a map of IPAddressPool objects associated
+                description: IPAddressPools is a list of IPAddressPool associated
                   to this machine.
                 type: object
               machineHash:
@@ -212,10 +212,138 @@ spec:
                       type: string
                     type: array
                 type: object
+              storage:
+                description: |-
+                  Storage is the explicit desired state for Inventory-owned data volumes.
+                  Devices omitted from this list remain unmanaged.
+                properties:
+                  retryNonce:
+                    default: 0
+                    description: |-
+                      RetryNonce is a monotonic operator-controlled retry counter. It is not
+                      part of the normalized storage content hash.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  volumes:
+                    description: Volumes are the only block devices the platform may
+                      manage.
+                    items:
+                      description: |-
+                        MachineInventoryStorageVolume declares one filesystem and its business
+                        mount point on this Inventory.
+                      properties:
+                        filesystem:
+                          description: StorageVolumeFilesystem declares filesystem
+                            adoption/initialization intent.
+                          properties:
+                            expectedUUID:
+                              description: |-
+                                ExpectedUUID is mandatory for Adopt and forbidden for a new blank
+                                initialization.
+                              maxLength: 128
+                              type: string
+                            policy:
+                              description: |-
+                                StorageFilesystemPolicy declares whether an existing filesystem is adopted
+                                or an entirely blank logical device may be initialized.
+                              enum:
+                              - Adopt
+                              - InitializeIfBlank
+                              type: string
+                            type:
+                              description: StorageFilesystemType is a supported ordinary
+                                single-host filesystem.
+                              enum:
+                              - xfs
+                              - ext4
+                              type: string
+                          required:
+                          - policy
+                          - type
+                          type: object
+                        mount:
+                          description: StorageVolumeMount declares the business mount
+                            path and readiness policy.
+                          properties:
+                            options:
+                              description: Options contains individual, admission-whitelisted
+                                mount options.
+                              items:
+                                type: string
+                              maxItems: 16
+                              type: array
+                            path:
+                              description: Path is a normalized absolute path accepted
+                                by provider admission.
+                              maxLength: 255
+                              minLength: 2
+                              type: string
+                            required:
+                              default: true
+                              description: |-
+                                Required defaults to true. Optional volumes are still prepared and
+                                activated; only Machine readiness is relaxed.
+                              type: boolean
+                          required:
+                          - path
+                          type: object
+                        name:
+                          description: Name is the stable logical identity inside
+                            this Inventory.
+                          maxLength: 63
+                          minLength: 1
+                          type: string
+                        source:
+                          description: StorageVolumeSource selects one observer-reported
+                            logical block device.
+                          properties:
+                            deviceID:
+                              description: |-
+                                DeviceID must exactly reference status.observedStorage.devices[].id.
+                                Dynamic kernel paths such as /dev/sdb are not accepted.
+                              maxLength: 512
+                              minLength: 5
+                              type: string
+                            minimumSize:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: MinimumSize is a non-destructive capacity
+                                assertion.
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            multipath:
+                              description: 'Multipath is valid only for a wwid: aggregate
+                                map.'
+                              properties:
+                                minimumActivePaths:
+                                  default: 1
+                                  description: MinimumActivePaths defaults to one.
+                                  format: int32
+                                  maximum: 1024
+                                  minimum: 1
+                                  type: integer
+                              type: object
+                          required:
+                          - deviceID
+                          type: object
+                      required:
+                      - filesystem
+                      - mount
+                      - name
+                      - source
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                type: object
               tpmHash:
                 description: |-
                   TPMHash the hash of the TPM EK public key. This is used if you are
-                  using TPM2 to identify nodes.  You can obtain the TPM by
+                  using TPM2 to identifiy nodes.  You can obtain the TPM by
                   running `rancherd get-tpm-hash` on the node. Or nodes can
                   report their TPM hash by using the MachineRegister.
                 type: string
@@ -280,6 +408,226 @@ spec:
                   - type
                   type: object
                 type: array
+              observedStorage:
+                description: |-
+                  ObservedStorage is objective host state written only by the authenticated
+                  periodic observer channel.
+                properties:
+                  bootID:
+                    description: BootID is the host's current Linux boot ID.
+                    maxLength: 128
+                    type: string
+                  devices:
+                    description: Devices contains facts for all discovered logical
+                      block devices.
+                    items:
+                      description: ObservedStorageDevice describes one logical block
+                        device and its topology.
+                      properties:
+                        consumers:
+                          description: |-
+                            Consumers contains descendant block devices layered on this logical
+                            device (for example partitions, dm-crypt, LVM or RAID). These are
+                            objective topology facts; provider policy decides whether they make the
+                            device ineligible for management.
+                          items:
+                            description: |-
+                              ObservedStorageConsumer describes one descendant block consumer. Path is
+                              diagnostic only; Type and FilesystemType are the kernel/util-linux facts.
+                            properties:
+                              filesystemType:
+                                maxLength: 64
+                                type: string
+                              mounts:
+                                items:
+                                  type: string
+                                maxItems: 64
+                                type: array
+                              path:
+                                maxLength: 512
+                                type: string
+                              type:
+                                maxLength: 64
+                                type: string
+                            required:
+                            - path
+                            - type
+                            type: object
+                          maxItems: 256
+                          type: array
+                        filesystem:
+                          description: ObservedStorageFilesystem describes an existing
+                            filesystem.
+                          properties:
+                            type:
+                              maxLength: 64
+                              type: string
+                            uuid:
+                              maxLength: 128
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        health:
+                          description: ObservedStorageMultipathHealth reports aggregate
+                            path health.
+                          properties:
+                            activePaths:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                            totalPaths:
+                              format: int32
+                              minimum: 0
+                              type: integer
+                          type: object
+                        id:
+                          description: |-
+                            ID is the canonical management identity (wwn:, nvme-eui:,
+                            nvme-nguid:, serial:, partuuid:, or wwid:).
+                          maxLength: 512
+                          minLength: 5
+                          type: string
+                        kind:
+                          description: |-
+                            ObservedStorageDeviceKind identifies the logical object represented by a
+                            report record.
+                          enum:
+                          - DirectDisk
+                          - Partition
+                          - Multipath
+                          type: string
+                        memberIDs:
+                          description: |-
+                            MemberIDs lists Multipath member-path diagnostic identities. Members are
+                            never valid desired device IDs.
+                          items:
+                            type: string
+                          maxItems: 256
+                          type: array
+                        model:
+                          maxLength: 256
+                          type: string
+                        mounts:
+                          items:
+                            description: ObservedStorageMount describes a current
+                              mount of this exact logical device.
+                            properties:
+                              options:
+                                items:
+                                  type: string
+                                maxItems: 128
+                                type: array
+                              path:
+                                maxLength: 512
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          maxItems: 64
+                          type: array
+                        parentID:
+                          description: ParentID links a partition to its direct parent
+                            disk.
+                          maxLength: 512
+                          type: string
+                        partitionTableType:
+                          maxLength: 32
+                          type: string
+                        path:
+                          description: Path is diagnostic only and must never be persisted
+                            as desired identity.
+                          maxLength: 512
+                          type: string
+                        readOnly:
+                          type: boolean
+                        removable:
+                          type: boolean
+                        rotational:
+                          type: boolean
+                        serial:
+                          maxLength: 256
+                          type: string
+                        signatures:
+                          items:
+                            description: ObservedStorageSignature is one wipefs/lsblk
+                              signature fact.
+                            properties:
+                              type:
+                                maxLength: 64
+                                type: string
+                              value:
+                                maxLength: 256
+                                type: string
+                            required:
+                            - type
+                            - value
+                            type: object
+                          maxItems: 64
+                          type: array
+                        sizeBytes:
+                          format: int64
+                          type: integer
+                        stablePaths:
+                          description: StablePaths are current udev aliases for diagnostics/resolution.
+                          items:
+                            type: string
+                          maxItems: 32
+                          type: array
+                        startBytes:
+                          description: StartBytes is populated for partitions.
+                          format: int64
+                          type: integer
+                        systemEvidence:
+                          items:
+                            type: string
+                          maxItems: 32
+                          type: array
+                        systemRole:
+                          description: |-
+                            ObservedStorageSystemRole is an objective system-disk classification.
+                            Unknown is intentionally fail-closed in provider policy.
+                          enum:
+                          - System
+                          - Data
+                          - Unknown
+                          type: string
+                        transport:
+                          description: |-
+                            Transport and identity evidence are informational and support safe
+                            serial fallback classification.
+                          maxLength: 64
+                          type: string
+                        wwn:
+                          maxLength: 256
+                          type: string
+                      required:
+                      - id
+                      - kind
+                      - systemRole
+                      type: object
+                    maxItems: 1024
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - id
+                    x-kubernetes-list-type: map
+                  observedAt:
+                    description: ObservedAt is set by the operator when it accepts
+                      the report.
+                    format: date-time
+                    type: string
+                  reportEpoch:
+                    description: ReportEpoch is allocated by the operator for an observer
+                      session.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  sequence:
+                    description: Sequence strictly increases within ReportEpoch.
+                    format: int64
+                    minimum: 0
+                    type: integer
+                type: object
               plan:
                 description: PlanStatus reflect the status of the plan owned by the
                   machine inventory object.
@@ -335,6 +683,351 @@ spec:
                       machine inventory.
                     enum:
                     - Applied
+                    - Failed
+                    type: string
+                type: object
+              storage:
+                description: |-
+                  Storage is desired-state convergence written only by the baremetal
+                  provider Inventory Storage Reconciler.
+                properties:
+                  appliedSpecHash:
+                    type: string
+                  appliedVolumes:
+                    items:
+                      description: |-
+                        ManagedStorageVolumeStatus is a complete cleanup-capable snapshot of one
+                        managed volume, not merely a diagnostic summary.
+                      properties:
+                        active:
+                          type: boolean
+                        deviceID:
+                          type: string
+                        effectiveRequired:
+                          type: boolean
+                        expectedFilesystemUUID:
+                          type: string
+                        filesystemPolicy:
+                          description: |-
+                            StorageFilesystemPolicy declares whether an existing filesystem is adopted
+                            or an entirely blank logical device may be initialized.
+                          enum:
+                          - Adopt
+                          - InitializeIfBlank
+                          type: string
+                        filesystemType:
+                          description: StorageFilesystemType is a supported ordinary
+                            single-host filesystem.
+                          enum:
+                          - xfs
+                          - ext4
+                          type: string
+                        filesystemUUID:
+                          type: string
+                        lastOperationID:
+                          type: string
+                        lastTransitionTime:
+                          format: date-time
+                          type: string
+                        message:
+                          type: string
+                        minimumActivePaths:
+                          format: int32
+                          type: integer
+                        minimumSizeBytes:
+                          format: int64
+                          type: integer
+                        mountOptions:
+                          items:
+                            type: string
+                          type: array
+                        mountPath:
+                          type: string
+                        mutationState:
+                          description: StorageMutationState records whether durable
+                            host state may have changed.
+                          enum:
+                          - None
+                          - DurableStateChanged
+                          - Unknown
+                          type: string
+                        name:
+                          type: string
+                        phase:
+                          type: string
+                        reason:
+                          type: string
+                        required:
+                          type: boolean
+                        resolvedPath:
+                          type: string
+                      required:
+                      - deviceID
+                      - effectiveRequired
+                      - filesystemPolicy
+                      - filesystemType
+                      - mountPath
+                      - name
+                      - required
+                      type: object
+                    maxItems: 32
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  conditions:
+                    items:
+                      description: Condition contains details for one aspect of the
+                        current state of this API Resource.
+                      properties:
+                        lastTransitionTime:
+                          description: |-
+                            lastTransitionTime is the last time the condition transitioned from one status to another.
+                            This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                          format: date-time
+                          type: string
+                        message:
+                          description: |-
+                            message is a human readable message indicating details about the transition.
+                            This may be an empty string.
+                          maxLength: 32768
+                          type: string
+                        observedGeneration:
+                          description: |-
+                            observedGeneration represents the .metadata.generation that the condition was set based upon.
+                            For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                            with respect to the current state of the instance.
+                          format: int64
+                          minimum: 0
+                          type: integer
+                        reason:
+                          description: |-
+                            reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                            Producers of specific condition types may define expected values and meanings for this field,
+                            and whether the values are considered a guaranteed API.
+                            The value should be a CamelCase string.
+                            This field may not be empty.
+                          maxLength: 1024
+                          minLength: 1
+                          pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                          type: string
+                        status:
+                          description: status of the condition, one of True, False,
+                            Unknown.
+                          enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                          type: string
+                        type:
+                          description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                          maxLength: 316
+                          pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                          type: string
+                      required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  hashVersion:
+                    type: string
+                  lastConsumedInitializationApprovalCounter:
+                    format: int64
+                    type: integer
+                  lastConsumedInitializationApprovalHash:
+                    type: string
+                  lastConsumedRetryNonce:
+                    format: int64
+                    type: integer
+                  operation:
+                    description: |-
+                      StorageOperationStatus is the durable controller journal projection for a
+                      logical operation and its current execution attempt.
+                    properties:
+                      attemptID:
+                        type: string
+                      initializationApprovalCounter:
+                        format: int64
+                        type: integer
+                      initializationApprovalHash:
+                        type: string
+                      mutationState:
+                        description: StorageMutationState records whether durable
+                          host state may have changed.
+                        enum:
+                        - None
+                        - DurableStateChanged
+                        - Unknown
+                        type: string
+                      observationBootID:
+                        description: |-
+                          ObservationBootID is the host boot ID captured before a Machine-owned
+                          lifecycle operation. Activate uses it to prove that reprovision crossed a
+                          boot before accepting a later mounted observation. It is a fact, not an
+                          ordering key.
+                        maxLength: 128
+                        type: string
+                      observationReportEpoch:
+                        description: |-
+                          ObservationReportEpoch and ObservationSequence capture the host report
+                          seen when the operation was claimed. The controller waits for a strictly
+                          newer accepted report before writing a host plan.
+                        format: int64
+                        type: integer
+                      observationSequence:
+                        format: int64
+                        type: integer
+                      operationID:
+                        type: string
+                      phase:
+                        description: StorageOperationPhase is the controller-side
+                          state of an operation.
+                        enum:
+                        - Pending
+                        - Running
+                        - Applied
+                        - Failed
+                        type: string
+                      planChecksum:
+                        type: string
+                      planOwnerKind:
+                        type: string
+                      planOwnerUID:
+                        type: string
+                      retryNonce:
+                        format: int64
+                        type: integer
+                      startedAt:
+                        format: date-time
+                        type: string
+                      targetSpecHash:
+                        type: string
+                      type:
+                        description: StorageOperationType identifies one logical convergence
+                          operation.
+                        enum:
+                        - Prepare
+                        - Release
+                        - Activate
+                        - Deactivate
+                        type: string
+                      updatedAt:
+                        format: date-time
+                        type: string
+                      volumes:
+                        items:
+                          description: |-
+                            ManagedStorageVolumeStatus is a complete cleanup-capable snapshot of one
+                            managed volume, not merely a diagnostic summary.
+                          properties:
+                            active:
+                              type: boolean
+                            deviceID:
+                              type: string
+                            effectiveRequired:
+                              type: boolean
+                            expectedFilesystemUUID:
+                              type: string
+                            filesystemPolicy:
+                              description: |-
+                                StorageFilesystemPolicy declares whether an existing filesystem is adopted
+                                or an entirely blank logical device may be initialized.
+                              enum:
+                              - Adopt
+                              - InitializeIfBlank
+                              type: string
+                            filesystemType:
+                              description: StorageFilesystemType is a supported ordinary
+                                single-host filesystem.
+                              enum:
+                              - xfs
+                              - ext4
+                              type: string
+                            filesystemUUID:
+                              type: string
+                            lastOperationID:
+                              type: string
+                            lastTransitionTime:
+                              format: date-time
+                              type: string
+                            message:
+                              type: string
+                            minimumActivePaths:
+                              format: int32
+                              type: integer
+                            minimumSizeBytes:
+                              format: int64
+                              type: integer
+                            mountOptions:
+                              items:
+                                type: string
+                              type: array
+                            mountPath:
+                              type: string
+                            mutationState:
+                              description: StorageMutationState records whether durable
+                                host state may have changed.
+                              enum:
+                              - None
+                              - DurableStateChanged
+                              - Unknown
+                              type: string
+                            name:
+                              type: string
+                            phase:
+                              type: string
+                            reason:
+                              type: string
+                            required:
+                              type: boolean
+                            resolvedPath:
+                              type: string
+                          required:
+                          - deviceID
+                          - effectiveRequired
+                          - filesystemPolicy
+                          - filesystemType
+                          - mountPath
+                          - name
+                          - required
+                          type: object
+                        maxItems: 32
+                        type: array
+                        x-kubernetes-list-map-keys:
+                        - name
+                        x-kubernetes-list-type: map
+                    required:
+                    - attemptID
+                    - mutationState
+                    - operationID
+                    - phase
+                    - planOwnerKind
+                    - planOwnerUID
+                    - retryNonce
+                    - startedAt
+                    - targetSpecHash
+                    - type
+                    - updatedAt
+                    type: object
+                  pendingSpecHash:
+                    type: string
+                  phase:
+                    description: StorageLifecyclePhase is the Inventory-wide managed-storage
+                      phase.
+                    enum:
+                    - Unmanaged
+                    - Observed
+                    - Validating
+                    - Preparing
+                    - Prepared
+                    - Activating
+                    - Active
+                    - Deactivating
+                    - Releasing
+                    - Degraded
                     - Failed
                     type: string
                 type: object


### PR DESCRIPTION
## Summary

- add an operator guide for inventory-scoped managed data disks, including Prepare, Activate, Deactivate, Release, `Adopt`, and approved `InitializeIfBlank` workflows
- integrate the Storage v2 lifecycle and compatibility boundaries into the bare-metal create, manage, upgrade, overview, and API documentation
- state that the matching `base-image` and `base-image-iso` must be obtained from Alauda technical support, with `base-image` used for reprovisioning and `base-image-iso` used for `SeedImage` / live installation
- synchronize the generated `MachineInventory` CRD reference with the Storage v2 API

## Validation

- `git diff --check origin/master...HEAD`
- `yarn lint`
- `yarn build`
